### PR TITLE
Make possible to pass Space and Index objects into Select etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ func main() {
     fmt.Printf("Space %d %d\n", space1.FieldsCount, space1.Temporary)
 
     // access index information by name or id
-    index1 := schema.Indexes["some_index"]
-    index2 := schema.IndexesById[2] // it's a map
+    index1 := space1.Indexes["some_index"]
+    index2 := space1.IndexesById[2] // it's a map
     fmt.Printf("Index %d %s\n", index1.Id, index1.Name)
 
     // access index fields information by index

--- a/schema.go
+++ b/schema.go
@@ -196,6 +196,10 @@ func (schema *Schema) resolveSpaceIndex(s interface{}, i interface{}) (spaceNo, 
 		spaceNo = uint32(s)
 	case int8:
 		spaceNo = uint32(s)
+	case Space:
+		spaceNo = s.Id
+	case *Space:
+		spaceNo = s.Id
 	default:
 		panic("unexpected type of space param")
 	}
@@ -234,6 +238,10 @@ func (schema *Schema) resolveSpaceIndex(s interface{}, i interface{}) (spaceNo, 
 			indexNo = uint32(i)
 		case int8:
 			indexNo = uint32(i)
+		case Index:
+			indexNo = i.Id
+		case *Index:
+			indexNo = i.Id
 		default:
 			panic("unexpected type of index param")
 		}


### PR DESCRIPTION
Convenience:

In addition to this:

```go
    space_devs := schema.Spaces["devs"]
    index_devs_primary := space_devs.Indexes["primary"]

    var res_devs []DevEnt
    err := client.SelectTyped(space_devs.Id, index_devs_primary.Id, 0, 10, tarantool.IterAll, []interface{}{}, &res_devs)
```

it's now possible to do this, seems more intuitive:

```go
    space_devs := schema.Spaces["devs"]
    index_devs_primary := space_devs.Indexes["primary"]

    var res_devs []DevEnt
    err := client.SelectTyped(space_devs, index_devs_primary, 0, 10, tarantool.IterAll, []interface{}{}, &res_devs)
```

Note that ".Id" can be omitted on both Space and Index.