### PR TITLE
add runtime.Gosched() for decreasing writer.flush

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -250,8 +251,11 @@ func (conn *Connection) writer() {
 		case packet = <-conn.packets:
 		default:
 			if w = conn.w; w != nil {
-				if err := w.Flush(); err != nil {
-					conn.closeConnection(err)
+				runtime.Gosched()
+				if len(conn.packets) == 0 {
+					if err := w.Flush(); err != nil {
+						conn.closeConnection(err)
+					}
 				}
 			}
 			select {


### PR DESCRIPTION
add runtime.Gosched() for decreasing writer.flush
bencmarks:
![tnt-bench](https://cloud.githubusercontent.com/assets/5286115/18049889/c6906bb2-6df3-11e6-8530-a994e6f86d86.png)

profiling:
[tarantool-cpu.prof.zip](https://github.com/tarantool/go-tarantool/files/442293/tarantool-cpu.prof.zip)

see flush and syscall diff