### PR TITLE
Get feature

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,8 +1,9 @@
 package tarantool
 
 import (
-	"gopkg.in/vmihailenco/msgpack.v2"
 	"time"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // Future is a handle for asynchronous request

--- a/request.go
+++ b/request.go
@@ -49,6 +49,10 @@ func (req *Future) fillInsert(enc *msgpack.Encoder, spaceNo uint32, tuple interf
 	return enc.Encode(tuple)
 }
 
+// Get performs select to box space with offset = 0 and limit = 1.
+//
+// It is equal to conn.SelectAsync(space, index, 0, 1, IterEq, key).Get()
+// Note: it will be return slice with one tuple.
 func (conn *Connection) Get(space, index interface{}, key interface{}) (resp *Response, err error) {
 	return conn.GetAsync(space, index, key).Get()
 }
@@ -145,6 +149,10 @@ func (s *single) DecodeMsgpack(d *msgpack.Decoder) error {
 	return d.Decode(s.res)
 }
 
+// GetTyped performs select (with limit = 1 and offset = 0)
+// to box space and fills typed result.
+//
+// It is equal to conn.GetAsync(space, index, key).GetTyped(&result)
 func (conn *Connection) GetTyped(space, index interface{}, key interface{}, result interface{}) (err error) {
 	s := single{res: result}
 	err = conn.GetAsync(space, index, key).GetTyped(&s)
@@ -212,6 +220,10 @@ func (conn *Connection) EvalTyped(expr string, args interface{}, result interfac
 	return conn.EvalAsync(expr, args).GetTyped(result)
 }
 
+// GetAsync sends select request (with limit = 1 and offest = 0) to tarantool
+// and returns Future.
+//
+// It is equal to conn.SelectAsync(space, index, 0, 1, IterEq, key)
 func (conn *Connection) GetAsync(space, index interface{}, key interface{}) *Future {
 	return conn.SelectAsync(space, index, 0, 1, IterEq, key)
 }

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -605,6 +605,16 @@ func TestClient(t *testing.T) {
 		}
 	}
 
+	// Get Typed
+	var singleTpl = Tuple{}
+	err = conn.GetTyped(spaceNo, indexNo, []interface{}{uint(10)}, &singleTpl)
+	if err != nil {
+		t.Errorf("Failed to GetTyped: %s", err.Error())
+	}
+	if singleTpl.Id != 10 {
+		t.Errorf("Bad value loaded from GetTyped")
+	}
+
 	// Select Typed for one tuple
 	var tpl1 [1]Tuple
 	err = conn.SelectTyped(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(10)}, &tpl1)
@@ -617,6 +627,16 @@ func TestClient(t *testing.T) {
 		if tpl[0].Id != 10 {
 			t.Errorf("Bad value loaded from SelectTyped")
 		}
+	}
+
+	// Get Typed Empty
+	var singleTpl2 Tuple
+	err = conn.GetTyped(spaceNo, indexNo, []interface{}{uint(30)}, &singleTpl2)
+	if err != nil {
+		t.Errorf("Failed to GetTyped: %s", err.Error())
+	}
+	if singleTpl2.Id != 0 {
+		t.Errorf("Bad value loaded from GetTyped")
 	}
 
 	// Select Typed Empty


### PR DESCRIPTION
In many cases, we need write code like this:

```
var tuples []Tuple
Select(..., ..., 0, 1, IterEq, &tuples)
if len(tuples) != 1 {
  return 
}

result = tuples[0]
``` 

Tarantool cli has (binary protocol - no) `get` func for shorthand select()[1]. I suggest to add this feature.

Code worked and tested in my cases, but we need tests in this package. In this week i will done this todo:

- [x] doc coments
- [x] tests 

Now we can pass pointer one tuple:

```
var tuple Tuple
conn.GetTyped(space, key, &tuple)
```

What do you think about this?