### PR TITLE
SetSchema method for the connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -863,3 +863,12 @@ func (conn *Connection) nextRequestId() (requestId uint32) {
 func (conn *Connection) ConfiguredTimeout() time.Duration {
 	return conn.opts.Timeout
 }
+
+// OverrideSchema sets Schema for the connection
+func (conn *Connection) OverrideSchema(s *Schema) {
+	if s != nil {
+		conn.mutex.Lock()
+		defer conn.mutex.Unlock()
+		conn.Schema = s
+	}
+}


### PR DESCRIPTION
Is more suitable for mocking than setup Schema due to an exported variable.