### PR TITLE
Queue "Exists" method evals wrong query

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -146,7 +146,7 @@ func (q *queue) Create(cfg Cfg) error {
 
 // Exists checks existance of a tube
 func (q *queue) Exists() (bool, error) {
-	cmd := "local name = ... ; return queue.tube[name] ~= null"
+	cmd := "local name = ... ; return queue.tube[name] ~= nil"
 	resp, err := q.conn.Eval(cmd, []string{q.name})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
There is invalid query in [queue/queue.go:149](https://github.com/tarantool/go-tarantool/blob/master/queue/queue.go#L148), `null` is used instead of `nil`:
```go
cmd := "local name = ... ; return queue.tube[name] ~= null"
resp, err := q.conn.Eval(cmd, []string{q.name})
```

When queue.Exists() is called, it throws an error:
```
eval:1: variable 'null' is not declared
```

This pr fixes that.