### PR TITLE
Fix duplicate key test case

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -119,7 +119,7 @@ func Example() {
 	fmt.Println("Insert Data", resp.Data)
 
 	// insert new tuple { 11, 1 }
-	resp, err = client.Insert("test", &Tuple{Id: 10, Msg: "test", Name: "one"})
+	resp, err = client.Insert("test", &Tuple{Id: 11, Msg: "test", Name: "one"})
 	fmt.Println("Insert Error", err)
 	fmt.Println("Insert Code", resp.Code)
 	fmt.Println("Insert Data", resp.Data)
@@ -194,9 +194,9 @@ func Example() {
 	// Insert Error <nil>
 	// Insert Code 0
 	// Insert Data [[10 test one]]
-	// Insert Error Duplicate key exists in unique index 'primary' in space 'test' (0x3)
-	// Insert Code 3
-	// Insert Data []
+	// Insert Error <nil>
+	// Insert Code 0
+	// Insert Data [[11 test one]]
 	// Delete Error <nil>
 	// Delete Code 0
 	// Delete Data [[10 test one]]

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -439,7 +439,7 @@ func TestClient(t *testing.T) {
 		t.Errorf("Expected ErrTupleFound but got: %v", err)
 	}
 	if len(resp.Data) != 0 {
-		t.Errorf("Response Body len != 1")
+		t.Errorf("Response Body len != 0")
 	}
 
 	// Delete


### PR DESCRIPTION
Issue is described in #105. After further investigation, it was found that it was meant to be "insert structure using space name" test case that must process with success instead of "duplicate key error". Test case and corresponding output was changed to be consistent in first commit.
Before patch test case:
https://github.com/tarantool/go-tarantool/blob/61f3a41907b6bcb060e9fa07069cde5b33ba9764/example_test.go#L121-L125

Since there is a duplicate key error test case in another file, coverage has not decreased. 
https://github.com/tarantool/go-tarantool/blob/61f3a41907b6bcb060e9fa07069cde5b33ba9764/tarantool_test.go#L437-L443

Closes #105