### PR TITLE
github-ci: add simple CI based on GitHub actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,75 @@
+name: testing
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    # We want to run on external PRs, but not on our own internal
+    # PRs as they'll be run by the push to the branch.
+    #
+    # The main trick is described here:
+    # https://github.com/Dart-Code/Dart-Code/pull/2375
+    if: github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tarantool:
+          - '1.10'
+          - '2.8'
+          - '2.9'
+
+    steps:
+      - name: Clone the connector
+        uses: actions/checkout@v2
+
+      - name: Setup tarantool ${{ matrix.tarantool }}
+        uses: tarantool/setup-tarantool@v1
+        with:
+          tarantool-version: ${{ matrix.tarantool }}
+
+      - name: Setup golang for the connector and tests
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+
+      - name: Run base tests
+        run: |
+          mkdir snap xlog
+          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
+          go clean -testcache && go test -v
+          kill $TNT_PID
+
+# TODO(ylobankov): Uncomment this when tarantool/go-tarantool#115 is resolved.
+#      - name: Run queue tests
+#        working-directory: ./queue
+#        run: |
+#          mkdir snap xlog
+#          tarantoolctl rocks install queue 1.1.0
+#          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
+#          go clean -testcache && go test -v
+#          kill $TNT_PID
+
+      - name: Run uuid tests
+        working-directory: ./uuid
+        run: |
+          mkdir snap xlog
+          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
+          go clean -testcache && go test -v
+          kill $TNT_PID
+        if: ${{ matrix.tarantool != 1.10 }}
+
+      - name: Run multi tests
+        working-directory: ./multi
+        run: |
+          mkdir -p m1/{snap,xlog} m2/{snap,xlog}
+          TNT_PID_1=$(tarantool ./config_m1.lua > tarantool_m1.log 2>&1 & echo $!)
+          TNT_PID_2=$(tarantool ./config_m2.lua > tarantool_m2.log 2>&1 & echo $!)
+          go clean -testcache && go test -v
+          kill $TNT_PID_1 $TNT_PID_2


### PR DESCRIPTION
In the provided workflow we install tarantool (1.10, 2.8, 2.9)
and just run tests from the module against it.

Closes #114