### PR TITLE
Set up test tarantool work directories in script

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Run base tests
         run: |
-          mkdir snap xlog
           TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
           go clean -testcache && go test -v
           kill $TNT_PID
@@ -49,7 +48,6 @@ jobs:
 #      - name: Run queue tests
 #        working-directory: ./queue
 #        run: |
-#          mkdir snap xlog
 #          tarantoolctl rocks install queue 1.1.0
 #          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
 #          go clean -testcache && go test -v
@@ -58,7 +56,6 @@ jobs:
       - name: Run uuid tests
         working-directory: ./uuid
         run: |
-          mkdir snap xlog
           TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
           go clean -testcache && go test -v
           kill $TNT_PID
@@ -67,7 +64,6 @@ jobs:
       - name: Run multi tests
         working-directory: ./multi
         run: |
-          mkdir -p m1/{snap,xlog} m2/{snap,xlog}
           TNT_PID_1=$(tarantool ./config_m1.lua > tarantool_m1.log 2>&1 & echo $!)
           TNT_PID_2=$(tarantool ./config_m2.lua > tarantool_m2.log 2>&1 & echo $!)
           go clean -testcache && go test -v

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: Run base tests
         run: |
-          mkdir snap xlog
           TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
           go clean -testcache && go test -v
           kill $TNT_PID
@@ -50,7 +49,6 @@ jobs:
 #      - name: Run queue tests
 #        working-directory: ./queue
 #        run: |
-#          mkdir snap xlog
 #          tarantoolctl rocks install queue 1.1.0
 #          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
 #          go clean -testcache && go test -v
@@ -59,7 +57,6 @@ jobs:
       - name: Run uuid tests
         working-directory: ./uuid
         run: |
-          mkdir snap xlog
           TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
           go clean -testcache && go test -v
           kill $TNT_PID
@@ -68,7 +65,6 @@ jobs:
       - name: Run multi tests
         working-directory: ./multi
         run: |
-          mkdir -p m1/{snap,xlog} m2/{snap,xlog}
           TNT_PID_1=$(tarantool ./config_m1.lua > tarantool_m1.log 2>&1 & echo $!)
           TNT_PID_2=$(tarantool ./config_m2.lua > tarantool_m2.log 2>&1 & echo $!)
           go clean -testcache && go test -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.DS_Store
 *.swp
 .idea/
-snap
-xlog
+work_dir*
+.rocks

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,13 @@
+local fio = require("fio")
+
+local work_dir = 'work_dir'
+
+fio.rmtree(work_dir)
+fio.mktree(work_dir)
+
 box.cfg{
     listen = 3013,
-    wal_dir='xlog',
-    snap_dir='snap',
+    work_dir = work_dir,
 }
 
 box.once("init", function()

--- a/multi/config_m1.lua
+++ b/multi/config_m1.lua
@@ -1,9 +1,14 @@
+local fio = require('fio')
 local nodes_load = require("config_load_nodes")
+
+local work_dir = 'work_dir_1'
+
+fio.rmtree(work_dir)
+fio.mktree(work_dir)
 
 box.cfg {
     listen = 3013,
-    wal_dir = 'm1/xlog',
-    snap_dir = 'm1/snap',
+    work_dir = work_dir,
 }
 
 get_cluster_nodes = nodes_load.get_cluster_nodes

--- a/multi/config_m2.lua
+++ b/multi/config_m2.lua
@@ -1,9 +1,14 @@
+local fio = require('fio')
 local nodes_load = require("config_load_nodes")
+
+local work_dir = 'work_dir_2'
+
+fio.rmtree(work_dir)
+fio.mktree(work_dir)
 
 box.cfg {
     listen = 3014,
-    wal_dir = 'm2/xlog',
-    snap_dir = 'm2/snap',
+    work_dir = work_dir,
 }
 
 get_cluster_nodes = nodes_load.get_cluster_nodes

--- a/queue/config.lua
+++ b/queue/config.lua
@@ -1,9 +1,14 @@
-queue = require 'queue'
+local fio = require('fio')
+queue = require('queue')
+
+local work_dir = 'work_dir'
+
+fio.rmtree(work_dir)
+fio.mktree(work_dir)
 
 box.cfg{
     listen = 3013,
-    wal_dir='xlog',
-    snap_dir='snap',
+    work_dir = work_dir,
 }
 
 box.once("init", function()

--- a/uuid/config.lua
+++ b/uuid/config.lua
@@ -1,10 +1,15 @@
+local fio = require('fio')
 local uuid = require('uuid')
 local msgpack = require('msgpack')
 
+local work_dir = 'work_dir'
+
+fio.rmtree(work_dir)
+fio.mktree(work_dir)
+
 box.cfg{
     listen = 3013,
-    wal_dir = 'xlog',
-    snap_dir = 'snap',
+    work_dir = work_dir,
 }
 
 box.schema.user.create('test', { password = 'test' , if_not_exists = true })


### PR DESCRIPTION
Before this patch, user needed to create snap and xlog directories
for test tarantools before starting them up. Now `config.lua` create
this directories before `box.cfg` (and removes existing data if there
are any).

Update .gitignore to ignore all test tarantool files.

Closes #107