### PR TITLE
tests: queue tests fail

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -45,15 +45,14 @@ jobs:
           go clean -testcache && go test -v
           kill $TNT_PID
 
-# TODO(ylobankov): Uncomment this when tarantool/go-tarantool#115 is resolved.
-#      - name: Run queue tests
-#        working-directory: ./queue
-#        run: |
-#          mkdir snap xlog
-#          tarantoolctl rocks install queue 1.1.0
-#          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
-#          go clean -testcache && go test -v
-#          kill $TNT_PID
+      - name: Run queue tests
+        working-directory: ./queue
+        run: |
+          mkdir snap xlog
+          tarantoolctl rocks install queue 1.1.0
+          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
+          go clean -testcache && go test -v
+          kill $TNT_PID
 
       - name: Run uuid tests
         working-directory: ./uuid

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,15 +46,16 @@ jobs:
           go clean -testcache && go test -v
           kill $TNT_PID
 
-# TODO(ylobankov): Uncomment this when tarantool/go-tarantool#115 is resolved.
-#      - name: Run queue tests
-#        working-directory: ./queue
-#        run: |
-#          mkdir snap xlog
-#          tarantoolctl rocks install queue 1.1.0
-#          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
-#          go clean -testcache && go test -v
-#          kill $TNT_PID
+      - name: Run queue tests
+        working-directory: ./queue
+        run: |
+          rm -rf snap
+          rm -rf xlog
+          mkdir snap xlog
+          tarantoolctl rocks install queue 1.1.0
+          TNT_PID=$(tarantool ./config.lua > tarantool.log 2>&1 & echo $!)
+          go clean -testcache && go test -v
+          kill $TNT_PID
 
       - name: Run uuid tests
         working-directory: ./uuid

--- a/queue/config.lua
+++ b/queue/config.lua
@@ -18,6 +18,12 @@ box.schema.func.create('queue.tube.test_queue:delete')
 box.schema.func.create('queue.tube.test_queue:release')
 box.schema.func.create('queue.tube.test_queue:bury')
 box.schema.func.create('queue.statistics')
+box.schema.user.grant('test', 'create', 'space')
+box.schema.user.grant('test', 'write', 'space', '_schema')
+box.schema.user.grant('test', 'write', 'space', '_space')
+box.schema.user.grant('test', 'read,write', 'space', '_space_sequence')
+box.schema.user.grant('test', 'write', 'space', '_index')
+box.schema.user.grant('test', 'read, write', 'space', '_queue_session_ids')
 box.schema.user.grant('test', 'execute', 'universe')
 box.schema.user.grant('test', 'read,write', 'space', '_queue')
 box.schema.user.grant('test', 'read,write', 'space', '_schema')
@@ -25,5 +31,17 @@ box.schema.user.grant('test', 'read,write', 'space', '_space')
 box.schema.user.grant('test', 'read,write', 'space', '_index')
 box.schema.user.grant('test', 'read,write', 'space', '_queue_consumers')
 box.schema.user.grant('test', 'read,write', 'space', '_priv')
-box.schema.user.grant('test', 'read,write', 'space', '_queue_taken')
+box.schema.user.grant('test', 'read,write', 'space', '_queue_taken_2')
+if box.space._trigger ~= nil then
+    box.schema.user.grant('test', 'read', 'space', '_trigger')
+end
+if box.space._fk_constraint ~= nil then
+    box.schema.user.grant('test', 'read', 'space', '_fk_constraint')
+end
+if box.space._ck_constraint ~= nil then
+    box.schema.user.grant('test', 'read', 'space', '_ck_constraint')
+end
+if box.space._func_index ~= nil then
+    box.schema.user.grant('test', 'read', 'space', '_func_index')
+end
 end)

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -13,7 +13,7 @@ import (
 
 var server = "127.0.0.1:3013"
 var opts = Opts{
-	Timeout: 500 * time.Millisecond,
+	Timeout: 2500 * time.Millisecond,
 	User:    "test",
 	Pass:    "test",
 	//Concurrency: 32,


### PR DESCRIPTION
tests: queue tests fix 

Before this patch, queue tests failed due to impossibility to use _queue_taken,
which was deprecated in tarantool/queue [1]. Switch to _queue_taken_2 fixed it. 

Create access and some other actions were denied for test user. 
Additional grants fixed this problem.

The test `TestUtube_Put` was affected by replacing timeout in the call 
of `TakeTimeout()` with timeout of connection structure. For clarification 
of this effect see annotation for function `TakeTimeout()` [2]. That was 
fixed by making connection timeout longer than the timeout in the function call.

The step in testing.yml was uncommented for enabling queue tests in CI.

1. [queue/_queue_taken_2](https://github.com/tarantool/queue/tree/7d05b6db5b0d596db4281d53b57811e156234a0d#fields-of-the-_queue_consumers-space)
2. https://github.com/tarantool/go-tarantool/blob/master/queue/queue.go#L35

Fixes #115