### PR TITLE
readme: update "Alternative connectors" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,5 +675,8 @@ Additional options (configurable via `ConnectWithOpts`):
 
 ## Alternative connectors
 
-- https://github.com/viciious/go-tarantool
-  Has tools to emulate tarantool, and to being replica for tarantool.
+There are two more connectors from the open-source community available:
+* [viciious/go-tarantool](https://github.com/viciious/go-tarantool),
+* [FZambia/tarantool](https://github.com/FZambia/tarantool).
+
+See feature comparison in [documentation](https://www.tarantool.io/en/doc/latest/book/connectors/#feature-comparison).


### PR DESCRIPTION
Add [FZambia/tarantool](https://github.com/FZambia/tarantool) connector to README "Alternative connectors" section. Add a link to feature comparison table in documentation.

Closes #138