### PR TITLE
readme: update URL of connectors comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,4 +708,4 @@ There are two more connectors from the open-source community available:
 * [viciious/go-tarantool](https://github.com/viciious/go-tarantool),
 * [FZambia/tarantool](https://github.com/FZambia/tarantool).
 
-See feature comparison in [documentation](https://www.tarantool.io/en/doc/latest/book/connectors/#feature-comparison).
+See feature comparison in [documentation](https://www.tarantool.io/en/doc/latest/book/connectors/#go-feature-comparison).


### PR DESCRIPTION
The new link is more persistent: should not become broken in a future.

See https://github.com/tarantool/doc/pull/2694.

Follows up #138