### PR TITLE
Support IPROTO_PUSH messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - SSL support (#155)
+- IPROTO_PUSH messages support (#67)
 
 ### Changed
 

--- a/config.lua
+++ b/config.lua
@@ -110,6 +110,14 @@ local function simple_incr(a)
 end
 rawset(_G, 'simple_incr', simple_incr)
 
+local function push_func(cnt)
+    for i = 1, cnt do
+        box.session.push(i)
+    end
+    return cnt
+end
+rawset(_G, 'push_func', push_func)
+
 box.space.test:truncate()
 
 --box.schema.user.revoke('guest', 'read,write,execute', 'universe')

--- a/const.go
+++ b/const.go
@@ -61,6 +61,7 @@ const (
 	RLimitWait = 2
 
 	OkCode            = uint32(0)
+	PushCode          = uint32(0x80)
 	ErrorCodeBit      = 0x8000
 	PacketLengthBytes = 5
 	ErSpaceExistsCode = 0xa

--- a/future.go
+++ b/future.go
@@ -1,0 +1,131 @@
+package tarantool
+
+import (
+	"time"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+// Future is a handle for asynchronous request.
+type Future struct {
+	requestId   uint32
+	requestCode int32
+	timeout     time.Duration
+	resp        *Response
+	err         error
+	ready       chan struct{}
+	next        *Future
+}
+
+// NewErrorFuture returns new set empty Future with filled error field.
+func NewErrorFuture(err error) *Future {
+	return &Future{err: err}
+}
+
+// Get waits for Future to be filled and returns Response and error.
+//
+// Response will contain deserialized result in Data field.
+// It will be []interface{}, so if you want more performace, use GetTyped method.
+//
+// Note: Response could be equal to nil if ClientError is returned in error.
+//
+// "error" could be Error, if it is error returned by Tarantool,
+// or ClientError, if something bad happens in a client process.
+func (fut *Future) Get() (*Response, error) {
+	fut.wait()
+	if fut.err != nil {
+		return fut.resp, fut.err
+	}
+	fut.err = fut.resp.decodeBody()
+	return fut.resp, fut.err
+}
+
+// GetTyped waits for Future and calls msgpack.Decoder.Decode(result) if no error happens.
+// It is could be much faster than Get() function.
+//
+// Note: Tarantool usually returns array of tuples (except for Eval and Call17 actions).
+func (fut *Future) GetTyped(result interface{}) error {
+	fut.wait()
+	if fut.err != nil {
+		return fut.err
+	}
+	fut.err = fut.resp.decodeBodyTyped(result)
+	return fut.err
+}
+
+var closedChan = make(chan struct{})
+
+func init() {
+	close(closedChan)
+}
+
+// WaitChan returns channel which becomes closed when response arrived or error occured.
+func (fut *Future) WaitChan() <-chan struct{} {
+	if fut.ready == nil {
+		return closedChan
+	}
+	return fut.ready
+}
+
+// Err returns error set on Future.
+// It waits for future to be set.
+// Note: it doesn't decode body, therefore decoding error are not set here.
+func (fut *Future) Err() error {
+	fut.wait()
+	return fut.err
+}
+
+func (fut *Future) pack(h *smallWBuf, enc *msgpack.Encoder, body func(*msgpack.Encoder) error) (err error) {
+	rid := fut.requestId
+	hl := h.Len()
+	h.Write([]byte{
+		0xce, 0, 0, 0, 0, // Length.
+		0x82,                           // 2 element map.
+		KeyCode, byte(fut.requestCode), // Request code.
+		KeySync, 0xce,
+		byte(rid >> 24), byte(rid >> 16),
+		byte(rid >> 8), byte(rid),
+	})
+
+	if err = body(enc); err != nil {
+		return
+	}
+
+	l := uint32(h.Len() - 5 - hl)
+	h.b[hl+1] = byte(l >> 24)
+	h.b[hl+2] = byte(l >> 16)
+	h.b[hl+3] = byte(l >> 8)
+	h.b[hl+4] = byte(l)
+
+	return
+}
+
+func (fut *Future) send(conn *Connection, body func(*msgpack.Encoder) error) *Future {
+	if fut.ready == nil {
+		return fut
+	}
+	conn.putFuture(fut, body)
+	return fut
+}
+
+func (fut *Future) markReady(conn *Connection) {
+	close(fut.ready)
+	if conn.rlimit != nil {
+		<-conn.rlimit
+	}
+}
+
+func (fut *Future) fail(conn *Connection, err error) *Future {
+	if f := conn.fetchFuture(fut.requestId); f == fut {
+		f.err = err
+		fut.markReady(conn)
+	}
+	return fut
+}
+
+func (fut *Future) wait() {
+	if fut.ready == nil {
+		return
+	}
+	<-fut.ready
+}

--- a/future_test.go
+++ b/future_test.go
@@ -1,0 +1,235 @@
+package tarantool_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/tarantool/go-tarantool"
+)
+
+func assertResponseIteratorValue(t testing.TB, it ResponseIterator,
+	code uint32, resp *Response) {
+	t.Helper()
+
+	if it.Err() != nil {
+		t.Errorf("An unexpected iteration error: %q", it.Err().Error())
+	}
+
+	if it.Value() == nil {
+		t.Errorf("An unexpected nil value")
+	} else if it.Value().Code != code {
+		t.Errorf("An unexpected response code %d, expected %d", it.Value().Code, code)
+	}
+
+	if it.Value() != resp {
+		t.Errorf("An unexpected response %v, expected %v", it.Value(), resp)
+	}
+}
+
+func assertResponseIteratorFinished(t testing.TB, it ResponseIterator) {
+	t.Helper()
+
+	if it.Err() != nil {
+		t.Errorf("An unexpected iteration error: %q", it.Err().Error())
+	}
+	if it.Value() != nil {
+		t.Errorf("An unexpected value %v", it.Value())
+	}
+}
+
+func TestFutureGetIteratorNoItems(t *testing.T) {
+	fut := NewFuture()
+
+	it := fut.GetIterator()
+	if it.Next() {
+		t.Errorf("An unexpected next value.")
+	} else {
+		assertResponseIteratorFinished(t, it)
+	}
+}
+
+func TestFutureGetIteratorNoResponse(t *testing.T) {
+	push := &Response{}
+	fut := NewFuture()
+	fut.AppendPush(push)
+
+	if it := fut.GetIterator(); it.Next() {
+		assertResponseIteratorValue(t, it, PushCode, push)
+		if it.Next() == true {
+			t.Errorf("An unexpected next value.")
+		}
+		assertResponseIteratorFinished(t, it)
+	} else {
+		t.Errorf("A push message expected.")
+	}
+}
+
+func TestFutureGetIteratorNoResponseTimeout(t *testing.T) {
+	push := &Response{}
+	fut := NewFuture()
+	fut.AppendPush(push)
+
+	if it := fut.GetIterator().WithTimeout(1 * time.Nanosecond); it.Next() {
+		assertResponseIteratorValue(t, it, PushCode, push)
+		if it.Next() == true {
+			t.Errorf("An unexpected next value.")
+		}
+		assertResponseIteratorFinished(t, it)
+	} else {
+		t.Errorf("A push message expected.")
+	}
+}
+
+func TestFutureGetIteratorResponseOnTimeout(t *testing.T) {
+	push := &Response{}
+	resp := &Response{}
+	fut := NewFuture()
+	fut.AppendPush(push)
+
+	var done sync.WaitGroup
+	var wait sync.WaitGroup
+	wait.Add(1)
+	done.Add(1)
+
+	go func() {
+		defer done.Done()
+
+		var it ResponseIterator
+		var cnt = 0
+		for it = fut.GetIterator().WithTimeout(5 * time.Second); it.Next(); {
+			code := PushCode
+			r := push
+			if cnt == 1 {
+				code = OkCode
+				r = resp
+			}
+			assertResponseIteratorValue(t, it, code, r)
+			cnt += 1
+			if cnt == 1 {
+				wait.Done()
+			}
+		}
+		assertResponseIteratorFinished(t, it)
+
+		if cnt != 2 {
+			t.Errorf("An unexpected count of responses %d != %d", cnt, 2)
+		}
+	}()
+
+	wait.Wait()
+	fut.SetResponse(resp)
+	done.Wait()
+}
+
+func TestFutureGetIteratorFirstResponse(t *testing.T) {
+	resp1 := &Response{}
+	resp2 := &Response{}
+	fut := NewFuture()
+	fut.SetResponse(resp1)
+	fut.SetResponse(resp2)
+
+	if it := fut.GetIterator(); it.Next() {
+		assertResponseIteratorValue(t, it, OkCode, resp1)
+		if it.Next() == true {
+			t.Errorf("An unexpected next value.")
+		}
+		assertResponseIteratorFinished(t, it)
+	} else {
+		t.Errorf("A response expected.")
+	}
+}
+
+func TestFutureGetIteratorFirstError(t *testing.T) {
+	const errMsg1 = "error1"
+	const errMsg2 = "error2"
+
+	fut := NewFuture()
+	fut.SetError(errors.New(errMsg1))
+	fut.SetError(errors.New(errMsg2))
+
+	it := fut.GetIterator()
+	if it.Next() {
+		t.Errorf("An unexpected value.")
+	} else if it.Err() == nil {
+		t.Errorf("An error expected.")
+	} else if it.Err().Error() != errMsg1 {
+		t.Errorf("An unexpected error %q, expected %q", it.Err().Error(), errMsg1)
+	}
+}
+
+func TestFutureGetIteratorResponse(t *testing.T) {
+	responses := []*Response{
+		{},
+		{},
+		{Code: OkCode},
+	}
+	fut := NewFuture()
+	for i, resp := range responses {
+		if i == len(responses)-1 {
+			fut.SetResponse(resp)
+		} else {
+			fut.AppendPush(resp)
+		}
+	}
+
+	var its = []ResponseIterator{
+		fut.GetIterator(),
+		fut.GetIterator().WithTimeout(5 * time.Second),
+	}
+	for _, it := range its {
+		var cnt = 0
+		for it.Next() {
+			code := PushCode
+			if cnt == len(responses)-1 {
+				code = OkCode
+			}
+			assertResponseIteratorValue(t, it, code, responses[cnt])
+			cnt += 1
+		}
+		assertResponseIteratorFinished(t, it)
+
+		if cnt != len(responses) {
+			t.Errorf("An unexpected count of responses %d != %d", cnt, len(responses))
+		}
+	}
+}
+
+func TestFutureGetIteratorError(t *testing.T) {
+	const errMsg = "error message"
+	responses := []*Response{
+		{},
+		{},
+	}
+	err := errors.New(errMsg)
+	fut := NewFuture()
+	for _, resp := range responses {
+		fut.AppendPush(resp)
+	}
+	fut.SetError(err)
+
+	var its = []ResponseIterator{
+		fut.GetIterator(),
+		fut.GetIterator().WithTimeout(5 * time.Second),
+	}
+	for _, it := range its {
+		var cnt = 0
+		for it.Next() {
+			code := PushCode
+			assertResponseIteratorValue(t, it, code, responses[cnt])
+			cnt += 1
+		}
+		if err = it.Err(); err != nil {
+			if err.Error() != errMsg {
+				t.Errorf("An unexpected error %q, expected %q", err.Error(), errMsg)
+			}
+		} else {
+			t.Errorf("An error expected.")
+		}
+
+		if cnt != len(responses) {
+			t.Errorf("An unexpected count of responses %d != %d", cnt, len(responses))
+		}
+	}
+}

--- a/response.go
+++ b/response.go
@@ -184,7 +184,7 @@ func (resp *Response) decodeBody() (err error) {
 				}
 			}
 		}
-		if resp.Code != OkCode {
+		if resp.Code != OkCode && resp.Code != PushCode {
 			resp.Code &^= ErrorCodeBit
 			err = Error{resp.Code, resp.Error}
 		}
@@ -227,7 +227,7 @@ func (resp *Response) decodeBodyTyped(res interface{}) (err error) {
 				}
 			}
 		}
-		if resp.Code != OkCode {
+		if resp.Code != OkCode && resp.Code != PushCode {
 			resp.Code &^= ErrorCodeBit
 			err = Error{resp.Code, resp.Error}
 		}

--- a/response_it.go
+++ b/response_it.go
@@ -1,0 +1,26 @@
+package tarantool
+
+import (
+	"time"
+)
+
+// ResponseIterator is an interface for iteration over a set of responses.
+type ResponseIterator interface {
+	// Next tries to switch to a next Response and returns true if it exists.
+	Next() bool
+	// Value returns a current Response if it exists, nil otherwise.
+	Value() *Response
+	// Err returns error if it happens.
+	Err() error
+}
+
+// TimeoutResponseIterator is an interface that extends ResponseIterator
+// and adds the ability to change a timeout for the Next() call.
+type TimeoutResponseIterator interface {
+	ResponseIterator
+	// WithTimeout allows to set up a timeout for the Next() call.
+	// Note: in the current implementation, there is a timeout for each
+	// response (the timeout for the request is reset by each push message):
+	// Connection's Opts.Timeout. You need to increase the value if necessary.
+	WithTimeout(timeout time.Duration) TimeoutResponseIterator
+}


### PR DESCRIPTION
This patch adds support for receiving messages sent using box.session.push()
via an iterator in the manner of asynchronous case of a Lua implementation[1].

Now the calls Future.Get() and Future.GetTyped() ignore push messages, and
do not report an error.

1. https://www.tarantool.io/ru/doc/latest/reference/reference_lua/box_session/push/

Closes #67

I'm not particularly familiar with Go. So I most likely made mistakes in some basic and idiomatic things