### PR TITLE
Fix lint warnings

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -39,4 +39,12 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          args: --issues-exit-code=0 -E gofmt
+          # The suppression of the rule `errcheck` may be removed after adding
+          # errors check in all methods calling EncodeXxx inside.
+          # For now those methods are not even able to return any error
+          # cause of internal implementation of writer interface (see smallbuf.go).
+          #
+          # The `//nolint` workaround was not the acceptable way of warnings suppression,
+          # cause those comments get rendered in documentation by godoc.
+          # See https://github.com/tarantool/go-tarantool/pull/160#discussion_r858608221
+          args: -E gofmt -D errcheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,13 @@ For example, for running tests in `multi`, `uuid` and `main` packages, call
 make test-multi test-uuid test-main
 ```
 
+To check if the current changes will pass the linter in CI, install
+golnagci-lint from [sources](https://golangci-lint.run/usage/install/) 
+and run it with next flags:
+```bash
+golangci-lint run -E gofmt -D errcheck
+```
+
 ## Code review checklist
 
 - Public API contains functions, variables, constants that are needed from

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -65,9 +65,9 @@ func TestConnSuccessfully(t *testing.T) {
 	defer connPool.Close()
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
 			server: true,
@@ -90,9 +90,9 @@ func TestReconnect(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(instances[0])
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
 			server: false,
@@ -106,9 +106,9 @@ func TestReconnect(t *testing.T) {
 	require.Nilf(t, err, "failed to restart tarantool")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
 			server: true,
@@ -133,9 +133,9 @@ func TestDisconnectAll(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(instances[1])
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server1, server2},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
 			server1: false,
@@ -153,9 +153,9 @@ func TestDisconnectAll(t *testing.T) {
 	require.Nilf(t, err, "failed to restart tarantool")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server1, server2},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
 			server1: true,
@@ -176,9 +176,9 @@ func TestClose(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server1, server2},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
 			server1: true,
@@ -192,9 +192,9 @@ func TestClose(t *testing.T) {
 	connPool.Close()
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
-		Servers: []string{server1, server2},
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
 			server1: false,
@@ -353,8 +353,8 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
+		ConnPool:      connPool,
+		Mode:          connection_pool.ANY,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -364,8 +364,8 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -375,8 +375,8 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -386,8 +386,8 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -397,8 +397,8 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -435,8 +435,8 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
+		ConnPool:      connPool,
+		Mode:          connection_pool.ANY,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -446,8 +446,8 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -457,8 +457,8 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -468,8 +468,8 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -506,8 +506,8 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
+		ConnPool:      connPool,
+		Mode:          connection_pool.ANY,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -517,8 +517,8 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -528,8 +528,8 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -539,8 +539,8 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -584,8 +584,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
+		ConnPool:      connPool,
+		Mode:          connection_pool.ANY,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -595,8 +595,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -606,8 +606,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -617,8 +617,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -628,8 +628,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -655,8 +655,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.ANY,
+		ConnPool:      connPool,
+		Mode:          connection_pool.ANY,
 	}
 
 	err = test_helpers.Retry(test_helpers.ProcessListenOnInstance, args, defaultCountRetry, defaultTimeoutRetry)
@@ -666,8 +666,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RW,
 	}
 
 	err = test_helpers.Retry(test_helpers.ProcessListenOnInstance, args, defaultCountRetry, defaultTimeoutRetry)
@@ -677,8 +677,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.RO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.RO,
 	}
 
 	err = test_helpers.Retry(test_helpers.ProcessListenOnInstance, args, defaultCountRetry, defaultTimeoutRetry)
@@ -688,8 +688,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRW,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRW,
 	}
 
 	err = test_helpers.Retry(test_helpers.ProcessListenOnInstance, args, defaultCountRetry, defaultTimeoutRetry)
@@ -699,8 +699,8 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool: connPool,
-		Mode: connection_pool.PreferRO,
+		ConnPool:      connPool,
+		Mode:          connection_pool.PreferRO,
 	}
 
 	err = test_helpers.Retry(test_helpers.ProcessListenOnInstance, args, defaultCountRetry, defaultTimeoutRetry)

--- a/connection_pool/const.go
+++ b/connection_pool/const.go
@@ -29,7 +29,7 @@ Mode parameter:
  | upsert  | RW          |
  | select  | ANY         |
  | get     | ANY         |
- */
+*/
 const (
 	ANY = iota
 	RW

--- a/connection_pool/example_test.go
+++ b/connection_pool/example_test.go
@@ -53,7 +53,7 @@ func ExampleConnectionPool_Select() {
 		return
 	}
 	// Insert a new tuple {"key2", "value2"}.
-	_, err = conn.Insert(spaceName,  &Tuple{Key: "key2", Value: "value2"})
+	_, err = conn.Insert(spaceName, &Tuple{Key: "key2", Value: "value2"})
 	if err != nil {
 		fmt.Printf("Failed to insert: %s", err.Error())
 		return
@@ -114,7 +114,7 @@ func ExampleConnectionPool_SelectTyped() {
 		return
 	}
 	// Insert a new tuple {"key2", "value2"}.
-	_, err = conn.Insert(spaceName,  &Tuple{Key: "key2", Value: "value2"})
+	_, err = conn.Insert(spaceName, &Tuple{Key: "key2", Value: "value2"})
 	if err != nil {
 		fmt.Printf("Failed to insert: %s", err.Error())
 		return
@@ -176,7 +176,7 @@ func ExampleConnectionPool_SelectAsync() {
 		return
 	}
 	// Insert a new tuple {"key2", "value2"}.
-	_, err = conn.Insert(spaceName,  &Tuple{Key: "key2", Value: "value2"})
+	_, err = conn.Insert(spaceName, &Tuple{Key: "key2", Value: "value2"})
 	if err != nil {
 		fmt.Printf("Failed to insert: %s", err.Error())
 		return
@@ -196,7 +196,7 @@ func ExampleConnectionPool_SelectAsync() {
 		spaceName, indexName, 0, 1, tarantool.IterEq,
 		[]interface{}{"key2"}, connection_pool.RW)
 	futs[2] = pool.SelectAsync(
-		spaceName, indexName, 0, 1,tarantool.IterEq,
+		spaceName, indexName, 0, 1, tarantool.IterEq,
 		[]interface{}{"key3"}, connection_pool.RW)
 	var t []Tuple
 	err = futs[0].GetTyped(&t)

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -16,7 +16,7 @@ type Tuple2 struct {
 
 // Same effect in a "magic" way, but slower.
 type Tuple3 struct {
-	_msgpack struct{} `msgpack:",asArray"`
+	_msgpack struct{} `msgpack:",asArray"` //nolint: structcheck,unused
 
 	Cid     uint
 	Orig    string

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,7 @@ import (
 type Tuple struct {
 	// Instruct msgpack to pack this struct as array, so no custom packer
 	// is needed.
-	_msgpack struct{} `msgpack:",asArray"`
+	_msgpack struct{} `msgpack:",asArray"` //nolint: structcheck,unused
 	Id       uint
 	Msg      string
 	Name     string

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -27,10 +27,10 @@ var connOptsMulti = OptsMulti{
 func TestConnError_IncorrectParams(t *testing.T) {
 	multiConn, err := Connect([]string{}, tarantool.Opts{})
 	if err == nil {
-		t.Errorf("err is nil with incorrect params")
+		t.Fatalf("err is nil with incorrect params")
 	}
 	if multiConn != nil {
-		t.Errorf("conn is not nill with incorrect params")
+		t.Fatalf("conn is not nill with incorrect params")
 	}
 	if err.Error() != "addrs should not be empty" {
 		t.Errorf("incorrect error: %s", err.Error())
@@ -38,10 +38,10 @@ func TestConnError_IncorrectParams(t *testing.T) {
 
 	multiConn, err = ConnectWithOpts([]string{server1}, tarantool.Opts{}, OptsMulti{})
 	if err == nil {
-		t.Errorf("err is nil with incorrect params")
+		t.Fatal("err is nil with incorrect params")
 	}
 	if multiConn != nil {
-		t.Errorf("conn is not nill with incorrect params")
+		t.Fatal("conn is not nill with incorrect params")
 	}
 	if err.Error() != "wrong check timeout, must be greater than 0" {
 		t.Errorf("incorrect error: %s", err.Error())

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -114,9 +114,15 @@ func Example_simpleQueueCustomMsgPack() {
 	fmt.Println("Data is ", task.Data())
 
 	task, err = que.Put([]int{1, 2, 3})
+	if err != nil {
+		log.Fatalf("Put failed: %s", err)
+	}
 	task.Bury()
 
 	task, err = que.TakeTimeout(2 * time.Second)
+	if err != nil {
+		log.Fatalf("Take with timeout failed: %s", err)
+	}
 	if task == nil {
 		fmt.Println("Task is nil")
 	}

--- a/queue/example_test.go
+++ b/queue/example_test.go
@@ -74,6 +74,9 @@ func Example_simpleQueue() {
 	}
 
 	task, err = q.TakeTimeout(2 * time.Second)
+	if err != nil {
+		fmt.Printf("error in take with timeout")
+	}
 	if task != nil {
 		fmt.Printf("Task should be nil, but %d", task.Id())
 		return

--- a/response.go
+++ b/response.go
@@ -15,10 +15,6 @@ type Response struct {
 	buf  smallBuf
 }
 
-func (resp *Response) fill(b []byte) {
-	resp.buf.b = b
-}
-
 func (resp *Response) smallInt(d *msgpack.Decoder) (i int, err error) {
 	b, err := resp.buf.ReadByte()
 	if err != nil {

--- a/schema.go
+++ b/schema.go
@@ -50,6 +50,7 @@ type IndexField struct {
 	Type string
 }
 
+//nolint: varcheck,deadcode
 const (
 	maxSchemas = 10000
 	spaceSpId  = 280

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -101,7 +101,7 @@ func BenchmarkClientSerialTyped(b *testing.B) {
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
-		b.Errorf("No connection available")
+		b.Fatal("No connection available")
 	}
 
 	var r []Tuple
@@ -224,7 +224,7 @@ func BenchmarkClientFutureParallelTyped(b *testing.B) {
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
-		b.Errorf("No connection available")
+		b.Fatal("No connection available")
 	}
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -263,7 +263,7 @@ func BenchmarkClientParallel(b *testing.B) {
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
-		b.Errorf("No connection available")
+		b.Fatal("No connection available")
 	}
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -287,7 +287,7 @@ func BenchmarkClientParallelMassive(b *testing.B) {
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
-		b.Errorf("No connection available")
+		b.Fatal("No connection available")
 	}
 
 	var wg sync.WaitGroup
@@ -361,31 +361,29 @@ func TestClient(t *testing.T) {
 
 	conn, err = Connect(server, opts)
 	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
+		t.Fatalf("Failed to connect: %s", err.Error())
 	}
 	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
+		t.Fatalf("conn is nil after Connect")
 	}
 	defer conn.Close()
 
 	// Ping
 	resp, err = conn.Ping()
 	if err != nil {
-		t.Errorf("Failed to Ping: %s", err.Error())
+		t.Fatalf("Failed to Ping: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Ping")
+		t.Fatalf("Response is nil after Ping")
 	}
 
 	// Insert
 	resp, err = conn.Insert(spaceNo, []interface{}{uint(1), "hello", "world"})
 	if err != nil {
-		t.Errorf("Failed to Insert: %s", err.Error())
+		t.Fatalf("Failed to Insert: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Insert")
+		t.Fatalf("Response is nil after Insert")
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("Response Body len != 1")
@@ -415,10 +413,10 @@ func TestClient(t *testing.T) {
 	// Delete
 	resp, err = conn.Delete(spaceNo, indexNo, []interface{}{uint(1)})
 	if err != nil {
-		t.Errorf("Failed to Delete: %s", err.Error())
+		t.Fatalf("Failed to Delete: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Delete")
+		t.Fatalf("Response is nil after Delete")
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("Response Body len != 1")
@@ -438,10 +436,10 @@ func TestClient(t *testing.T) {
 	}
 	resp, err = conn.Delete(spaceNo, indexNo, []interface{}{uint(101)})
 	if err != nil {
-		t.Errorf("Failed to Delete: %s", err.Error())
+		t.Fatalf("Failed to Delete: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Delete")
+		t.Fatalf("Response is nil after Delete")
 	}
 	if len(resp.Data) != 0 {
 		t.Errorf("Response Data len != 0")
@@ -450,17 +448,17 @@ func TestClient(t *testing.T) {
 	// Replace
 	resp, err = conn.Replace(spaceNo, []interface{}{uint(2), "hello", "world"})
 	if err != nil {
-		t.Errorf("Failed to Replace: %s", err.Error())
+		t.Fatalf("Failed to Replace: %s", err.Error())
 	}
 	if resp == nil {
 		t.Errorf("Response is nil after Replace")
 	}
 	resp, err = conn.Replace(spaceNo, []interface{}{uint(2), "hi", "planet"})
 	if err != nil {
-		t.Errorf("Failed to Replace (duplicate): %s", err.Error())
+		t.Fatalf("Failed to Replace (duplicate): %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Replace (duplicate)")
+		t.Fatalf("Response is nil after Replace (duplicate)")
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("Response Data len != 1")
@@ -482,10 +480,10 @@ func TestClient(t *testing.T) {
 	// Update
 	resp, err = conn.Update(spaceNo, indexNo, []interface{}{uint(2)}, []interface{}{[]interface{}{"=", 1, "bye"}, []interface{}{"#", 2, 1}})
 	if err != nil {
-		t.Errorf("Failed to Update: %s", err.Error())
+		t.Fatalf("Failed to Update: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Update")
+		t.Fatalf("Response is nil after Update")
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("Response Data len != 1")
@@ -508,14 +506,14 @@ func TestClient(t *testing.T) {
 	if strings.Compare(conn.Greeting.Version, "Tarantool 1.6.7") >= 0 {
 		resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
 		if err != nil {
-			t.Errorf("Failed to Upsert (insert): %s", err.Error())
+			t.Fatalf("Failed to Upsert (insert): %s", err.Error())
 		}
 		if resp == nil {
 			t.Errorf("Response is nil after Upsert (insert)")
 		}
 		resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
 		if err != nil {
-			t.Errorf("Failed to Upsert (update): %s", err.Error())
+			t.Fatalf("Failed to Upsert (update): %s", err.Error())
 		}
 		if resp == nil {
 			t.Errorf("Response is nil after Upsert (update)")
@@ -526,15 +524,18 @@ func TestClient(t *testing.T) {
 	for i := 10; i < 20; i++ {
 		resp, err = conn.Replace(spaceNo, []interface{}{uint(i), fmt.Sprintf("val %d", i), "bla"})
 		if err != nil {
-			t.Errorf("Failed to Replace: %s", err.Error())
+			t.Fatalf("Failed to Replace: %s", err.Error())
+		}
+		if resp.Code != 0 {
+			t.Errorf("Failed to replace")
 		}
 	}
 	resp, err = conn.Select(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(10)})
 	if err != nil {
-		t.Errorf("Failed to Select: %s", err.Error())
+		t.Fatalf("Failed to Select: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Select")
+		t.Fatalf("Response is nil after Select")
 	}
 	if len(resp.Data) != 1 {
 		t.Errorf("Response Data len != 1")
@@ -553,10 +554,10 @@ func TestClient(t *testing.T) {
 	// Select empty
 	resp, err = conn.Select(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(30)})
 	if err != nil {
-		t.Errorf("Failed to Select: %s", err.Error())
+		t.Fatalf("Failed to Select: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Select")
+		t.Fatalf("Response is nil after Select")
 	}
 	if len(resp.Data) != 0 {
 		t.Errorf("Response Data len != 0")
@@ -566,7 +567,7 @@ func TestClient(t *testing.T) {
 	var tpl []Tuple
 	err = conn.SelectTyped(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(10)}, &tpl)
 	if err != nil {
-		t.Errorf("Failed to SelectTyped: %s", err.Error())
+		t.Fatalf("Failed to SelectTyped: %s", err.Error())
 	}
 	if len(tpl) != 1 {
 		t.Errorf("Result len of SelectTyped != 1")
@@ -580,7 +581,7 @@ func TestClient(t *testing.T) {
 	var singleTpl = Tuple{}
 	err = conn.GetTyped(spaceNo, indexNo, []interface{}{uint(10)}, &singleTpl)
 	if err != nil {
-		t.Errorf("Failed to GetTyped: %s", err.Error())
+		t.Fatalf("Failed to GetTyped: %s", err.Error())
 	}
 	if singleTpl.Id != 10 {
 		t.Errorf("Bad value loaded from GetTyped")
@@ -590,7 +591,7 @@ func TestClient(t *testing.T) {
 	var tpl1 [1]Tuple
 	err = conn.SelectTyped(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(10)}, &tpl1)
 	if err != nil {
-		t.Errorf("Failed to SelectTyped: %s", err.Error())
+		t.Fatalf("Failed to SelectTyped: %s", err.Error())
 	}
 	if len(tpl) != 1 {
 		t.Errorf("Result len of SelectTyped != 1")
@@ -604,7 +605,7 @@ func TestClient(t *testing.T) {
 	var singleTpl2 Tuple
 	err = conn.GetTyped(spaceNo, indexNo, []interface{}{uint(30)}, &singleTpl2)
 	if err != nil {
-		t.Errorf("Failed to GetTyped: %s", err.Error())
+		t.Fatalf("Failed to GetTyped: %s", err.Error())
 	}
 	if singleTpl2.Id != 0 {
 		t.Errorf("Bad value loaded from GetTyped")
@@ -614,7 +615,7 @@ func TestClient(t *testing.T) {
 	var tpl2 []Tuple
 	err = conn.SelectTyped(spaceNo, indexNo, 0, 1, IterEq, []interface{}{uint(30)}, &tpl2)
 	if err != nil {
-		t.Errorf("Failed to SelectTyped: %s", err.Error())
+		t.Fatalf("Failed to SelectTyped: %s", err.Error())
 	}
 	if len(tpl2) != 0 {
 		t.Errorf("Result len of SelectTyped != 1")
@@ -623,10 +624,10 @@ func TestClient(t *testing.T) {
 	// Call
 	resp, err = conn.Call("box.info", []interface{}{"box.schema.SPACE_ID"})
 	if err != nil {
-		t.Errorf("Failed to Call: %s", err.Error())
+		t.Fatalf("Failed to Call: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Call")
+		t.Fatalf("Response is nil after Call")
 	}
 	if len(resp.Data) < 1 {
 		t.Errorf("Response.Data is empty after Eval")
@@ -634,11 +635,17 @@ func TestClient(t *testing.T) {
 
 	// Call vs Call17
 	resp, err = conn.Call("simple_incr", []interface{}{1})
+	if err != nil {
+		t.Errorf("Failed to use Call")
+	}
 	if resp.Data[0].([]interface{})[0].(uint64) != 2 {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
 
 	resp, err = conn.Call17("simple_incr", []interface{}{1})
+	if err != nil {
+		t.Errorf("Failed to use Call17")
+	}
 	if resp.Data[0].(uint64) != 2 {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
@@ -646,10 +653,10 @@ func TestClient(t *testing.T) {
 	// Eval
 	resp, err = conn.Eval("return 5 + 6", []interface{}{})
 	if err != nil {
-		t.Errorf("Failed to Eval: %s", err.Error())
+		t.Fatalf("Failed to Eval: %s", err.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Eval")
+		t.Fatalf("Response is nil after Eval")
 	}
 	if len(resp.Data) < 1 {
 		t.Errorf("Response.Data is empty after Eval")
@@ -666,12 +673,10 @@ func TestSchema(t *testing.T) {
 
 	conn, err = Connect(server, opts)
 	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
+		t.Fatalf("Failed to connect: %s", err.Error())
 	}
 	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
+		t.Fatalf("conn is nil after Connect")
 	}
 	defer conn.Close()
 
@@ -807,7 +812,7 @@ func TestSchema(t *testing.T) {
 	ifield1 := index3.Fields[0]
 	ifield2 := index3.Fields[1]
 	if ifield1 == nil || ifield2 == nil {
-		t.Errorf("index field is nil")
+		t.Fatalf("index field is nil")
 	}
 	if ifield1.Id != 1 || ifield2.Id != 2 {
 		t.Errorf("index field has incorrect Id")
@@ -821,7 +826,7 @@ func TestSchema(t *testing.T) {
 	if err != nil || rSpaceNo != 514 || rIndexNo != 3 {
 		t.Errorf("numeric space and index params not resolved as-is")
 	}
-	rSpaceNo, rIndexNo, err = schema.ResolveSpaceIndex(514, nil)
+	rSpaceNo, _, err = schema.ResolveSpaceIndex(514, nil)
 	if err != nil || rSpaceNo != 514 {
 		t.Errorf("numeric space param not resolved as-is")
 	}
@@ -829,15 +834,15 @@ func TestSchema(t *testing.T) {
 	if err != nil || rSpaceNo != 514 || rIndexNo != 3 {
 		t.Errorf("symbolic space and index params not resolved")
 	}
-	rSpaceNo, rIndexNo, err = schema.ResolveSpaceIndex("schematest", nil)
+	rSpaceNo, _, err = schema.ResolveSpaceIndex("schematest", nil)
 	if err != nil || rSpaceNo != 514 {
 		t.Errorf("symbolic space param not resolved")
 	}
-	rSpaceNo, rIndexNo, err = schema.ResolveSpaceIndex("schematest22", "secondary")
+	_, _, err = schema.ResolveSpaceIndex("schematest22", "secondary")
 	if err == nil {
 		t.Errorf("resolveSpaceIndex didn't returned error with not existing space name")
 	}
-	rSpaceNo, rIndexNo, err = schema.ResolveSpaceIndex("schematest", "secondary22")
+	_, _, err = schema.ResolveSpaceIndex("schematest", "secondary22")
 	if err == nil {
 		t.Errorf("resolveSpaceIndex didn't returned error with not existing index name")
 	}
@@ -850,25 +855,26 @@ func TestClientNamed(t *testing.T) {
 
 	conn, err = Connect(server, opts)
 	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
+		t.Fatalf("Failed to connect: %s", err.Error())
 	}
 	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
+		t.Fatalf("conn is nil after Connect")
 	}
 	defer conn.Close()
 
 	// Insert
 	resp, err = conn.Insert(spaceName, []interface{}{uint(1001), "hello2", "world2"})
 	if err != nil {
-		t.Errorf("Failed to Insert: %s", err.Error())
+		t.Fatalf("Failed to Insert: %s", err.Error())
+	}
+	if resp.Code != 0 {
+		t.Errorf("Failed to Insert: wrong code returned %d", resp.Code)
 	}
 
 	// Delete
 	resp, err = conn.Delete(spaceName, indexName, []interface{}{uint(1001)})
 	if err != nil {
-		t.Errorf("Failed to Delete: %s", err.Error())
+		t.Fatalf("Failed to Delete: %s", err.Error())
 	}
 	if resp == nil {
 		t.Errorf("Response is nil after Delete")
@@ -877,7 +883,7 @@ func TestClientNamed(t *testing.T) {
 	// Replace
 	resp, err = conn.Replace(spaceName, []interface{}{uint(1002), "hello", "world"})
 	if err != nil {
-		t.Errorf("Failed to Replace: %s", err.Error())
+		t.Fatalf("Failed to Replace: %s", err.Error())
 	}
 	if resp == nil {
 		t.Errorf("Response is nil after Replace")
@@ -886,7 +892,7 @@ func TestClientNamed(t *testing.T) {
 	// Update
 	resp, err = conn.Update(spaceName, indexName, []interface{}{uint(1002)}, []interface{}{[]interface{}{"=", 1, "bye"}, []interface{}{"#", 2, 1}})
 	if err != nil {
-		t.Errorf("Failed to Update: %s", err.Error())
+		t.Fatalf("Failed to Update: %s", err.Error())
 	}
 	if resp == nil {
 		t.Errorf("Response is nil after Update")
@@ -896,14 +902,14 @@ func TestClientNamed(t *testing.T) {
 	if strings.Compare(conn.Greeting.Version, "Tarantool 1.6.7") >= 0 {
 		resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
 		if err != nil {
-			t.Errorf("Failed to Upsert (insert): %s", err.Error())
+			t.Fatalf("Failed to Upsert (insert): %s", err.Error())
 		}
 		if resp == nil {
 			t.Errorf("Response is nil after Upsert (insert)")
 		}
 		resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
 		if err != nil {
-			t.Errorf("Failed to Upsert (update): %s", err.Error())
+			t.Fatalf("Failed to Upsert (update): %s", err.Error())
 		}
 		if resp == nil {
 			t.Errorf("Response is nil after Upsert (update)")
@@ -914,12 +920,15 @@ func TestClientNamed(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		resp, err = conn.Replace(spaceName, []interface{}{uint(i), fmt.Sprintf("val %d", i), "bla"})
 		if err != nil {
-			t.Errorf("Failed to Replace: %s", err.Error())
+			t.Fatalf("Failed to Replace: %s", err.Error())
+		}
+		if resp.Code != 0 {
+			t.Errorf("Failed to Replace: wrong code returned %d", resp.Code)
 		}
 	}
 	resp, err = conn.Select(spaceName, indexName, 0, 1, IterEq, []interface{}{uint(1010)})
 	if err != nil {
-		t.Errorf("Failed to Select: %s", err.Error())
+		t.Fatalf("Failed to Select: %s", err.Error())
 	}
 	if resp == nil {
 		t.Errorf("Response is nil after Select")
@@ -929,7 +938,7 @@ func TestClientNamed(t *testing.T) {
 	var tpl []Tuple
 	err = conn.SelectTyped(spaceName, indexName, 0, 1, IterEq, []interface{}{uint(1010)}, &tpl)
 	if err != nil {
-		t.Errorf("Failed to SelectTyped: %s", err.Error())
+		t.Fatalf("Failed to SelectTyped: %s", err.Error())
 	}
 	if len(tpl) != 1 {
 		t.Errorf("Result len of SelectTyped != 1")
@@ -942,27 +951,23 @@ func TestComplexStructs(t *testing.T) {
 
 	conn, err = Connect(server, opts)
 	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
+		t.Fatalf("Failed to connect: %s", err.Error())
 	}
 	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
+		t.Fatalf("conn is nil after Connect")
 	}
 	defer conn.Close()
 
 	tuple := Tuple2{Cid: 777, Orig: "orig", Members: []Member{{"lol", "", 1}, {"wut", "", 3}}}
 	_, err = conn.Replace(spaceNo, &tuple)
 	if err != nil {
-		t.Errorf("Failed to insert: %s", err.Error())
-		return
+		t.Fatalf("Failed to insert: %s", err.Error())
 	}
 
 	var tuples [1]Tuple2
 	err = conn.SelectTyped(spaceNo, indexNo, 0, 1, IterEq, []interface{}{777}, &tuples)
 	if err != nil {
-		t.Errorf("Failed to selectTyped: %s", err.Error())
-		return
+		t.Fatalf("Failed to selectTyped: %s", err.Error())
 	}
 
 	if len(tuples) != 1 {

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -144,8 +144,6 @@ func IsTarantoolVersionLess(majorMin uint64, minorMin uint64, patchMin uint64) (
 	} else {
 		return patch < patchMin, nil
 	}
-
-	return false, nil
 }
 
 // RestartTarantool restarts a tarantool instance for tests

--- a/test_helpers/pool_helper.go
+++ b/test_helpers/pool_helper.go
@@ -10,18 +10,18 @@ import (
 )
 
 type ListenOnInstanceArgs struct {
-	ConnPool *connection_pool.ConnectionPool
-	Mode connection_pool.Mode
+	ConnPool      *connection_pool.ConnectionPool
+	Mode          connection_pool.Mode
 	ServersNumber int
 	ExpectedPorts map[string]bool
 }
 
 type CheckStatusesArgs struct {
-	ConnPool *connection_pool.ConnectionPool
-	Servers []string
-	Mode connection_pool.Mode
+	ConnPool           *connection_pool.ConnectionPool
+	Servers            []string
+	Mode               connection_pool.Mode
 	ExpectedPoolStatus bool
-	ExpectedStatuses map[string]bool
+	ExpectedStatuses   map[string]bool
 }
 
 func compareTuples(expectedTpl []interface{}, actualTpl []interface{}) error {
@@ -168,7 +168,7 @@ func InsertOnInstance(server string, connOpts tarantool.Opts, space interface{},
 func InsertOnInstances(servers []string, connOpts tarantool.Opts, space interface{}, tuple interface{}) error {
 	serversNumber := len(servers)
 	roles := make([]bool, serversNumber)
-	for i:= 0; i < serversNumber; i++{
+	for i := 0; i < serversNumber; i++ {
 		roles[i] = false
 	}
 

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -53,7 +53,7 @@ func (t *TupleUUID) DecodeMsgpack(d *msgpack.Decoder) error {
 func connectWithValidation(t *testing.T) *Connection {
 	conn, err := Connect(server, opts)
 	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
+		t.Fatalf("Failed to connect: %s", err.Error())
 	}
 	if conn == nil {
 		t.Errorf("conn is nil after Connect")
@@ -63,7 +63,7 @@ func connectWithValidation(t *testing.T) *Connection {
 
 func tupleValueIsId(t *testing.T, tuples []interface{}, id uuid.UUID) {
 	if len(tuples) != 1 {
-		t.Errorf("Response Data len != 1")
+		t.Fatalf("Response Data len != 1")
 	}
 
 	if tpl, ok := tuples[0].([]interface{}); !ok {
@@ -88,22 +88,22 @@ func TestSelect(t *testing.T) {
 
 	id, uuidErr := uuid.Parse("c8f0fa1f-da29-438c-a040-393f1126ad39")
 	if uuidErr != nil {
-		t.Errorf("Failed to prepare test uuid: %s", uuidErr)
+		t.Fatalf("Failed to prepare test uuid: %s", uuidErr)
 	}
 
 	resp, errSel := conn.Select(space, index, 0, 1, IterEq, []interface{}{id})
 	if errSel != nil {
-		t.Errorf("UUID select failed: %s", errSel.Error())
+		t.Fatalf("UUID select failed: %s", errSel.Error())
 	}
 	if resp == nil {
-		t.Errorf("Response is nil after Select")
+		t.Fatalf("Response is nil after Select")
 	}
 	tupleValueIsId(t, resp.Data, id)
 
 	var tuples []TupleUUID
 	errTyp := conn.SelectTyped(space, index, 0, 1, IterEq, []interface{}{id}, &tuples)
 	if errTyp != nil {
-		t.Errorf("Failed to SelectTyped: %s", errTyp.Error())
+		t.Fatalf("Failed to SelectTyped: %s", errTyp.Error())
 	}
 	if len(tuples) != 1 {
 		t.Errorf("Result len of SelectTyped != 1")
@@ -131,7 +131,7 @@ func TestReplace(t *testing.T) {
 		t.Errorf("UUID replace failed: %s", errRep)
 	}
 	if respRep == nil {
-		t.Errorf("Response is nil after Replace")
+		t.Fatalf("Response is nil after Replace")
 	}
 	tupleValueIsId(t, respRep.Data, id)
 
@@ -140,7 +140,7 @@ func TestReplace(t *testing.T) {
 		t.Errorf("UUID select failed: %s", errSel)
 	}
 	if respSel == nil {
-		t.Errorf("Response is nil after Select")
+		t.Fatalf("Response is nil after Select")
 	}
 	tupleValueIsId(t, respSel.Data, id)
 }


### PR DESCRIPTION
code health: fix all places highlighted by linter

Changed the warning's suppression in check.yaml. The suppression of the rule
`errcheck` may be removed after adding errors check in all methods
with calling encodeXxx inside. See details below.

Suppressed the highlighting lacks of error's check in all methods,
having encodeXxx inside. For now those methods are not able to
return any error due to internal implementation of writer
interface (see smallbuf.go). For future, if the implementation of the writer
will be changed, and there will be a need to check errors, we must think
about how to say to compiler that the error check is 'unlikely' for keeping performance
(If there will be any affect on it).

Fixed the use of time package API in all places with calls of
time.Now().Sub(). Now time package propose the explicit time.Until() and time.Since().

Replaced all calls of Errorf() with Fatalf() in tests, where it is
needed. That change prevents nil dereferences below in the code and
stops the test execution, where it is expected in tests.

Suppressed the highlighting of all unused constants and functions with `//nolint` comment.

Fixed the calling of Fatalf() from non-testing goroutine in queue tests.
It is not a valid way to stop test from another goroutine.

Fixed the gofmt-highlighted places in test_helpers/pool_helper.go and
connection_pool/const.go.

Added instructions to CONTRIBUTING.md how to run CI-linter locally.

Closes https://github.com/tarantool/go-tarantool/issues/142
Closes https://github.com/tarantool/go-tarantool/issues/150