### PR TITLE
Add context support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support decimal type in msgpack (#96)
 - Support datetime type in msgpack (#118)
 - Prepared SQL statements (#117)
+- Context support for request objects (#48)
 
 ### Changed
 

--- a/connection.go
+++ b/connection.go
@@ -197,7 +197,6 @@ type connShard struct {
 	bufmut          sync.Mutex
 	buf             smallWBuf
 	enc             *msgpack.Encoder
-	_pad            [16]uint64 //nolint: unused,structcheck
 }
 
 // Greeting is a message sent by Tarantool on connect.

--- a/prepared.go
+++ b/prepared.go
@@ -1,6 +1,7 @@
 package tarantool
 
 import (
+	"context"
 	"fmt"
 
 	"gopkg.in/vmihailenco/msgpack.v2"
@@ -58,6 +59,17 @@ func (req *PrepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error 
 	return fillPrepare(enc, req.expr)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *PrepareRequest) Context(ctx context.Context) *PrepareRequest {
+	req.ctx = ctx
+	return req
+}
+
 // UnprepareRequest helps you to create an unprepare request object for
 // execution by a Connection.
 type UnprepareRequest struct {
@@ -81,6 +93,17 @@ func (req *UnprepareRequest) Conn() *Connection {
 // Body fills an encoder with the execute request body.
 func (req *UnprepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillUnprepare(enc, *req.stmt)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *UnprepareRequest) Context(ctx context.Context) *UnprepareRequest {
+	req.ctx = ctx
+	return req
 }
 
 // ExecutePreparedRequest helps you to create an execute prepared request
@@ -115,6 +138,17 @@ func (req *ExecutePreparedRequest) Args(args interface{}) *ExecutePreparedReques
 // Body fills an encoder with the execute request body.
 func (req *ExecutePreparedRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillExecutePrepared(enc, *req.stmt, req.args)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *ExecutePreparedRequest) Context(ctx context.Context) *ExecutePreparedRequest {
+	req.ctx = ctx
+	return req
 }
 
 func fillPrepare(enc *msgpack.Encoder, expr string) error {

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package tarantool
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -537,6 +538,8 @@ type Request interface {
 	Code() int32
 	// Body fills an encoder with a request body.
 	Body(resolver SchemaResolver, enc *msgpack.Encoder) error
+	// Ctx returns a context of the request.
+	Ctx() context.Context
 }
 
 // ConnectedRequest is an interface that provides the info about a Connection
@@ -549,11 +552,17 @@ type ConnectedRequest interface {
 
 type baseRequest struct {
 	requestCode int32
+	ctx         context.Context
 }
 
 // Code returns a IPROTO code for the request.
 func (req *baseRequest) Code() int32 {
 	return req.requestCode
+}
+
+// Ctx returns a context of the request.
+func (req *baseRequest) Ctx() context.Context {
+	return req.ctx
 }
 
 type spaceRequest struct {
@@ -611,6 +620,17 @@ func NewPingRequest() *PingRequest {
 // Body fills an encoder with the ping request body.
 func (req *PingRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillPing(enc)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *PingRequest) Context(ctx context.Context) *PingRequest {
+	req.ctx = ctx
+	return req
 }
 
 // SelectRequest allows you to create a select request object for execution
@@ -683,6 +703,17 @@ func (req *SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillSelect(enc, spaceNo, indexNo, req.offset, req.limit, req.iterator, req.key)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *SelectRequest) Context(ctx context.Context) *SelectRequest {
+	req.ctx = ctx
+	return req
+}
+
 // InsertRequest helps you to create an insert request object for execution
 // by a Connection.
 type InsertRequest struct {
@@ -716,6 +747,17 @@ func (req *InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillInsert(enc, spaceNo, req.tuple)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *InsertRequest) Context(ctx context.Context) *InsertRequest {
+	req.ctx = ctx
+	return req
+}
+
 // ReplaceRequest helps you to create a replace request object for execution
 // by a Connection.
 type ReplaceRequest struct {
@@ -747,6 +789,17 @@ func (req *ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error 
 	}
 
 	return fillInsert(enc, spaceNo, req.tuple)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *ReplaceRequest) Context(ctx context.Context) *ReplaceRequest {
+	req.ctx = ctx
+	return req
 }
 
 // DeleteRequest helps you to create a delete request object for execution
@@ -787,6 +840,17 @@ func (req *DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	}
 
 	return fillDelete(enc, spaceNo, indexNo, req.key)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *DeleteRequest) Context(ctx context.Context) *DeleteRequest {
+	req.ctx = ctx
+	return req
 }
 
 // UpdateRequest helps you to create an update request object for execution
@@ -840,6 +904,17 @@ func (req *UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillUpdate(enc, spaceNo, indexNo, req.key, req.ops)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *UpdateRequest) Context(ctx context.Context) *UpdateRequest {
+	req.ctx = ctx
+	return req
+}
+
 // UpsertRequest helps you to create an upsert request object for execution
 // by a Connection.
 type UpsertRequest struct {
@@ -884,6 +959,17 @@ func (req *UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillUpsert(enc, spaceNo, req.tuple, req.ops)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *UpsertRequest) Context(ctx context.Context) *UpsertRequest {
+	req.ctx = ctx
+	return req
+}
+
 // CallRequest helps you to create a call request object for execution
 // by a Connection.
 type CallRequest struct {
@@ -913,6 +999,17 @@ func (req *CallRequest) Args(args interface{}) *CallRequest {
 // Body fills an encoder with the call request body.
 func (req *CallRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillCall(enc, req.function, req.args)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *CallRequest) Context(ctx context.Context) *CallRequest {
+	req.ctx = ctx
+	return req
 }
 
 // NewCall16Request returns a new empty Call16Request. It uses request code for
@@ -961,6 +1058,17 @@ func (req *EvalRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillEval(enc, req.expr, req.args)
 }
 
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *EvalRequest) Context(ctx context.Context) *EvalRequest {
+	req.ctx = ctx
+	return req
+}
+
 // ExecuteRequest helps you to create an execute request object for execution
 // by a Connection.
 type ExecuteRequest struct {
@@ -988,4 +1096,15 @@ func (req *ExecuteRequest) Args(args interface{}) *ExecuteRequest {
 // Body fills an encoder with the execute request body.
 func (req *ExecuteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return fillExecute(enc, req.expr, req.args)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *ExecuteRequest) Context(ctx context.Context) *ExecuteRequest {
+	req.ctx = ctx
+	return req
 }

--- a/test_helpers/request_mock.go
+++ b/test_helpers/request_mock.go
@@ -1,6 +1,8 @@
 package test_helpers
 
 import (
+	"context"
+
 	"github.com/tarantool/go-tarantool"
 	"gopkg.in/vmihailenco/msgpack.v2"
 )
@@ -22,4 +24,8 @@ func (sr *StrangerRequest) Body(resolver tarantool.SchemaResolver, enc *msgpack.
 
 func (sr *StrangerRequest) Conn() *tarantool.Connection {
 	return &tarantool.Connection{}
+}
+
+func (sr *StrangerRequest) Ctx() context.Context {
+	return nil
 }


### PR DESCRIPTION
### What has been done? Why? What problem is being solved?

This patch adds the support of using context in API. The API is based
on using request objects. Added tests that cover almost all cases of
using the context in a query. Added benchamrk tests are equivalent to
other, that use the same query but without any context.

Closes #48

### I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:
#48

## Context support

Context support supposes a mechanism of canceling requests to instance.
The canceling happens when the timeout/deadline is over or the cancel function is called.
Also contexts may keep key-value inside.

## API
There are two ways of representing context in API.

Standard `http` package supports it inside the Request object.

```go
func NewRequestWithContext(ctx context.Context, method, url string, body io.Reader) (*Request, error)

func (r *Request) Context() context.Context
```
For outgoing client requests, the context controls cancellation.

For incoming server requests, the context is canceled when the client's connection closes, 
the request is canceled (with HTTP/2), or when the ServeHTTP method returns.

The second approach.

The interface package `database/sql` supposes the next way of passing contexts.

```go
func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (Result, error)

func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*Rows, error)
```


### The proposal for API:
It is decided to use request objects due to their flexibility and comfortability.
There is also no need to add similar methods to the common API with only difference, that
the first argument is a context.

Example:
```go
    conn, err = Connect(server, opts)
	
    ctx, cancel := context.WithCancel(context.Background())
    defer cancel()
    
    req := NewSelectRequest(spaceNo).
        Index(indexNo).
        Limit(1).
        Iterator(IterEq).
        Key([]interface{}{uint(1010)}).
        WithContext(ctx)
	
    resp, err := conn.Do(req).Get()
```

## Implementation
Let's consider the next points before discussing the implementation of adding context support.

- The request that is already passed to a Tarantool instance cannot be canceled.
- When the context is passed to a synchronous call, it must not be returned until the response
is come or the context is done.
- One of the main purposes to use contexts is the ability to keep the internal resources free.
- There is no way to say to an instance that we don't wait the response to the canceled request anymore.
- There is already a mechanism of canceling requests with the common timeout.

### The architecture of the internal queue
<img width="594" alt="image" src="https://user-images.githubusercontent.com/55545103/178977043-e093510a-9ee5-4877-a8b0-226a49612d4c.png">

### Proposal

We will keep a context inside the `Future` object, so it is associated with the request lifetime.

We add a goroutine that scans all the queues of `Future` objects and removes each Future that has an expired
context.

We keep two queues for Futures with context not nil and other Futures. So each goroutine has the responsibility
over it's own type of Futures. (Consider side effects later)

When we have already removed the Future due to it's cancelled context, we can get a response from the instance
for that Future, then we log a message that have received an unexpected response from the instance. We assume that
it is expected behavior.

We also check if the context is cancelled:
- before put the Future to the queue
- when we call `.Get()` (sync call) for the Future.
- when the response comes from Tarantool instance and we search the future with it's request id.

This approach let us almost the full control over the Future lifetime.

### Problems

1. The period of `contexts`-goroutine work.
2. If there is a need to combine the behavior of timeouts and contexts.
3. Mutexes.
4. Do we need the context support in general?

### Premature optimization.
One of the reasons to leave the context inside the Future object, was to avoid 
the need to check context only with this goroutine every nanosecond(or some other time). 
I would like to have this goroutine as a garbage collector just for cleaning up the queue when it is needed. 
I also had an idea to have an internal atomic counter of a Futures count inside and run this goroutine when 
this count is critical (we could configure this critical number and have a dependency from GOMAXPROC by default).

### Benchmarks

Environment:

```
goos: darwin
goarch: amd64
pkg: github.com/tarantool/go-tarantool
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
Tarantool 2.11.0
go version go1.16.12 darwin/amd64
```

Setup:
- One tarantool instance is up
- N testing goroutines working parallel (50, 100, 500 and 1000)
- One pre-inserted tuple in test space
- Operation Get (Select with limit=1)
- Limit on used CPU: (1,2,4)

Comparing between two queries:
```go
req := NewSelectRequest(spaceNo).
    Index(indexNo).
    Limit(1).
    Iterator(IterEq).
    Key([]interface{}{uint(1010)}).
    WithContext(ctx)
```

and 

```go
req := NewSelectRequest(spaceNo).
    Index(indexNo).
    Limit(1).
    Iterator(IterEq).
    Key([]interface{}{uint(1010)})
```


### 50 testing goroutines
```
> $ benchstat b50g.txt a50g_alter.txt                                                                                                                               [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      4.24µs ± 0%    4.31µs ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    2.30µs ± 1%    2.48µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.80µs ± 1%    2.74µs ±57%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-2      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-4      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
```

### 100 testing goroutines

```
> $ benchstat b100g.txt a100g_alter.txt                                                                                                                             [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      3.56µs ± 0%    3.75µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    2.07µs ± 1%    2.18µs ± 2%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.71µs ± 2%    1.82µs ± 0%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-2      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-4      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
```

### 500 testing goroutines

```
> $ benchstat b500g.txt a500g_alter.txt                                                                                                                             [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      3.20µs ± 2%    3.35µs ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    1.68µs ± 1%    1.97µs ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.38µs ± 1%    1.52µs ± 3%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      849B ± 0%      885B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      803B ± 0%      843B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-2      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-4      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
```

### 1000 testing goroutines

```
> $ benchstat b1000g.txt a1000g_alter.txt                                                                                                                           [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      2.88µs ± 1%    3.34µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    1.49µs ± 1%    1.85µs ± 2%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.41µs ± 2%    1.49µs ± 1%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        794B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      853B ± 0%      882B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      809B ± 0%      858B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-2      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
ClientParallelRequestObject-4      16.0 ± 0%      16.0 ± 0%   ~     (all equal)
```

## Alternative way
Let us keep the context only inside the request object and check if the context or the future is "done"
in a separated goroutine.

The API is the same one:

```go
    conn, err = Connect(server, opts)
	
    ctx, cancel := context.WithCancel(context.Background())
    defer cancel()
    
    req := NewSelectRequest(spaceNo).
        Index(indexNo).
        Limit(1).
        Iterator(IterEq).
        Key([]interface{}{uint(1010)}).
        WithContext(ctx)
	
    resp, err := conn.Do(req).Get()
```

The goroutine that scans ready channels:

```go
if req.Context() != nil {
		go func() {
			select {
			case <-fut.done:
			default:
				select {
				case <-req.Context().Done():
				default:
					select {
					case <-fut.done:
					case <-req.Context().Done():
					}
				}
			}
		}()
}
```

### Benchmarks

Environment:

```
goos: darwin
goarch: amd64
pkg: github.com/tarantool/go-tarantool
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
Tarantool 2.11.0
go version go1.16.12 darwin/amd64
```

Setup:
- One tarantool instance is up
- N testing goroutines working parallel (50, 100, 500 and 1000)
- One pre-inserted tuple in test space
- Operation Get (Select with limit=1)
- Limit on used CPU: (1,2,4)

Comparing between two queries:
```go
req := NewSelectRequest(spaceNo).
    Index(indexNo).
    Limit(1).
    Iterator(IterEq).
    Key([]interface{}{uint(1010)}).
    WithContext(ctx)
```

and 

```go
req := NewSelectRequest(spaceNo).
    Index(indexNo).
    Limit(1).
    Iterator(IterEq).
    Key([]interface{}{uint(1010)})
```

### 50 testing goroutines:

```
> $ benchstat b50g.txt a50g.txt                                                                                                                                     [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      4.24µs ± 0%    4.93µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    2.30µs ± 1%    2.66µs ± 3%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.80µs ± 1%    2.19µs ± 4%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
```

### 100 testing goroutines:

```
> $ benchstat b100g.txt a100g.txt                                                                                                                                   [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      3.56µs ± 0%    4.25µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    2.07µs ± 1%    2.66µs ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.71µs ± 2%    2.24µs ± 0%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
```

### 500 testing goroutines:

```
> $ benchstat b1000g.txt a1000g.txt                                                                                                                                 [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      2.88µs ± 1%    4.03µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    1.49µs ± 1%    2.12µs ± 1%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.41µs ± 2%    1.63µs ± 1%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        794B ± 0%      828B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      853B ± 0%      846B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      809B ± 0%      859B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
```

### 1000 testing goroutines:

```
> $ benchstat b500g.txt a500g.txt                                                                                                                                   [±vr009/gh-48-add-context-support ●●▴▾]
name                           old time/op    new time/op    delta
ClientParallelRequestObject      3.20µs ± 2%    3.99µs ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2    1.68µs ± 1%    2.36µs ± 2%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4    1.38µs ± 1%    1.64µs ± 2%   ~     (p=0.100 n=3+3)

name                           old alloc/op   new alloc/op   delta
ClientParallelRequestObject        792B ± 0%      824B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      849B ± 0%      843B ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      803B ± 0%      844B ± 0%   ~     (p=0.100 n=3+3)

name                           old allocs/op  new allocs/op  delta
ClientParallelRequestObject        16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-2      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
ClientParallelRequestObject-4      16.0 ± 0%      17.0 ± 0%   ~     (p=0.100 n=3+3)
```