### PR TITLE
Optional support of msgpack.v5

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,8 +71,14 @@ jobs:
       - name: Run regression tests
         run: make test
 
-      - name: Run tests with call_17
+      - name: Run regression tests with call_17
         run: make test TAGS="go_tarantool_call_17"
+
+      - name: Run regression tests with msgpack.v5
+        run: make test TAGS="go_tarantool_msgpack_v5"
+
+      - name: Run regression tests with msgpack.v5 and call_17
+        run: make test TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
 
       - name: Run fuzzing tests
         if: ${{ matrix.fuzzing }}
@@ -146,17 +152,31 @@ jobs:
           source tarantool-enterprise/env.sh
           make deps
 
-      - name: Run tests
+      - name: Run regression tests
         run: |
           source tarantool-enterprise/env.sh
           make test
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 
-      - name: Run tests with call_17
+      - name: Run regression tests with call_17
         run: |
           source tarantool-enterprise/env.sh
           make test TAGS="go_tarantool_call_17"
+        env:
+          TEST_TNT_SSL: ${{matrix.ssl}}
+
+      - name: Run regression tests with msgpack.v5
+        run: |
+          source tarantool-enterprise/env.sh
+          make test TAGS="go_tarantool_msgpack_v5"
+        env:
+          TEST_TNT_SSL: ${{matrix.ssl}}
+
+      - name: Run regression tests with msgpack.v5 and call_17
+        run: |
+          source tarantool-enterprise/env.sh
+          make test TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Optional msgpack.v5 usage (#124)
+
 ### Changed
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,11 @@ make test
 The tests set up all required `tarantool` processes before run and clean up
 afterwards.
 
+If you want to run the tests with specific build tags:
+```bash
+make test TAGS=go_tarantool_ssl_disable,go_tarantool_msgpack_v5
+```
+
 If you have Tarantool Enterprise Edition 2.10 or newer, you can run additional
 SSL tests. To do this, you need to set an environment variable 'TEST_TNT_SSL':
 

--- a/call_16_test.go
+++ b/call_16_test.go
@@ -18,11 +18,11 @@ func TestConnection_Call(t *testing.T) {
 	defer conn.Close()
 
 	// Call16
-	resp, err = conn.Call("simple_incr", []interface{}{1})
+	resp, err = conn.Call("simple_concat", []interface{}{"1"})
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}
-	if resp.Data[0].([]interface{})[0].(uint64) != 2 {
+	if val, ok := resp.Data[0].([]interface{})[0].(string); !ok || val != "11" {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
 }
@@ -34,18 +34,18 @@ func TestCallRequest(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
-	req := NewCallRequest("simple_incr").Args([]interface{}{1})
+	req := NewCallRequest("simple_concat").Args([]interface{}{"1"})
 	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}
-	if resp.Data[0].([]interface{})[0].(uint64) != 2 {
+	if val, ok := resp.Data[0].([]interface{})[0].(string); !ok || val != "11" {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
 }
 
 func TestCallRequestCode(t *testing.T) {
-	req := NewCallRequest("simple_incrt")
+	req := NewCallRequest("simple_concat")
 	code := req.Code()
 	expected := Call16RequestCode
 	if code != int32(expected) {

--- a/call_17_test.go
+++ b/call_17_test.go
@@ -18,11 +18,11 @@ func TestConnection_Call(t *testing.T) {
 	defer conn.Close()
 
 	// Call17
-	resp, err = conn.Call17("simple_incr", []interface{}{1})
+	resp, err = conn.Call17("simple_concat", []interface{}{"1"})
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}
-	if resp.Data[0].(uint64) != 2 {
+	if val, ok := resp.Data[0].(string); !ok || val != "11" {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
 }
@@ -34,18 +34,18 @@ func TestCallRequest(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
-	req := NewCallRequest("simple_incr").Args([]interface{}{1})
+	req := NewCallRequest("simple_concat").Args([]interface{}{"1"})
 	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}
-	if resp.Data[0].(uint64) != 2 {
+	if val, ok := resp.Data[0].(string); !ok || val != "11" {
 		t.Errorf("result is not {{1}} : %v", resp.Data)
 	}
 }
 
 func TestCallRequestCode(t *testing.T) {
-	req := NewCallRequest("simple_incrt")
+	req := NewCallRequest("simple_concat")
 	code := req.Code()
 	expected := Call17RequestCode
 	if code != int32(expected) {

--- a/client_tools.go
+++ b/client_tools.go
@@ -1,16 +1,12 @@
 package tarantool
 
-import (
-	"gopkg.in/vmihailenco/msgpack.v2"
-)
-
 // IntKey is utility type for passing integer key to Select*, Update* and Delete*.
 // It serializes to array with single integer element.
 type IntKey struct {
 	I int
 }
 
-func (k IntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (k IntKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(1)
 	enc.EncodeInt(k.I)
 	return nil
@@ -22,7 +18,7 @@ type UintKey struct {
 	I uint
 }
 
-func (k UintKey) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (k UintKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(1)
 	enc.EncodeUint(k.I)
 	return nil
@@ -34,7 +30,7 @@ type StringKey struct {
 	S string
 }
 
-func (k StringKey) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (k StringKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(1)
 	enc.EncodeString(k.S)
 	return nil
@@ -46,7 +42,7 @@ type IntIntKey struct {
 	I1, I2 int
 }
 
-func (k IntIntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (k IntIntKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(2)
 	enc.EncodeInt(k.I1)
 	enc.EncodeInt(k.I2)
@@ -60,7 +56,7 @@ type Op struct {
 	Arg   interface{}
 }
 
-func (o Op) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (o Op) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(3)
 	enc.EncodeString(o.Op)
 	enc.EncodeInt(o.Field)
@@ -148,7 +144,7 @@ type OpSplice struct {
 	Replace string
 }
 
-func (o OpSplice) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (o OpSplice) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(5)
 	enc.EncodeString(o.Op)
 	enc.EncodeInt(o.Field)

--- a/client_tools.go
+++ b/client_tools.go
@@ -8,7 +8,7 @@ type IntKey struct {
 
 func (k IntKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(1)
-	enc.EncodeInt(k.I)
+	encodeInt(enc, int64(k.I))
 	return nil
 }
 
@@ -20,7 +20,7 @@ type UintKey struct {
 
 func (k UintKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(1)
-	enc.EncodeUint(k.I)
+	encodeUint(enc, uint64(k.I))
 	return nil
 }
 
@@ -44,8 +44,8 @@ type IntIntKey struct {
 
 func (k IntIntKey) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(2)
-	enc.EncodeInt(k.I1)
-	enc.EncodeInt(k.I2)
+	encodeInt(enc, int64(k.I1))
+	encodeInt(enc, int64(k.I2))
 	return nil
 }
 
@@ -59,7 +59,7 @@ type Op struct {
 func (o Op) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(3)
 	enc.EncodeString(o.Op)
-	enc.EncodeInt(o.Field)
+	encodeInt(enc, int64(o.Field))
 	return enc.Encode(o.Arg)
 }
 
@@ -147,9 +147,9 @@ type OpSplice struct {
 func (o OpSplice) EncodeMsgpack(enc *encoder) error {
 	enc.EncodeArrayLen(5)
 	enc.EncodeString(o.Op)
-	enc.EncodeInt(o.Field)
-	enc.EncodeInt(o.Pos)
-	enc.EncodeInt(o.Len)
+	encodeInt(enc, int64(o.Field))
+	encodeInt(enc, int64(o.Pos))
+	encodeInt(enc, int64(o.Len))
 	enc.EncodeString(o.Replace)
 	return nil
 }

--- a/client_tools.go
+++ b/client_tools.go
@@ -11,7 +11,7 @@ type IntKey struct {
 }
 
 func (k IntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(1)
+	enc.EncodeArrayLen(1)
 	enc.EncodeInt(k.I)
 	return nil
 }
@@ -23,7 +23,7 @@ type UintKey struct {
 }
 
 func (k UintKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(1)
+	enc.EncodeArrayLen(1)
 	enc.EncodeUint(k.I)
 	return nil
 }
@@ -35,7 +35,7 @@ type StringKey struct {
 }
 
 func (k StringKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(1)
+	enc.EncodeArrayLen(1)
 	enc.EncodeString(k.S)
 	return nil
 }
@@ -47,7 +47,7 @@ type IntIntKey struct {
 }
 
 func (k IntIntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(2)
+	enc.EncodeArrayLen(2)
 	enc.EncodeInt(k.I1)
 	enc.EncodeInt(k.I2)
 	return nil
@@ -61,7 +61,7 @@ type Op struct {
 }
 
 func (o Op) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(3)
+	enc.EncodeArrayLen(3)
 	enc.EncodeString(o.Op)
 	enc.EncodeInt(o.Field)
 	return enc.Encode(o.Arg)
@@ -149,7 +149,7 @@ type OpSplice struct {
 }
 
 func (o OpSplice) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeSliceLen(5)
+	enc.EncodeArrayLen(5)
 	enc.EncodeString(o.Op)
 	enc.EncodeInt(o.Field)
 	enc.EncodeInt(o.Pos)

--- a/config.lua
+++ b/config.lua
@@ -80,7 +80,7 @@ box.once("init", function()
 
     --box.schema.user.grant('guest', 'read,write,execute', 'universe')
     box.schema.func.create('box.info')
-    box.schema.func.create('simple_incr')
+    box.schema.func.create('simple_concat')
 
     -- auth testing: access control
     box.schema.user.create('test', {password = 'test'})
@@ -106,10 +106,10 @@ local function func_name()
 end
 rawset(_G, 'func_name', func_name)
 
-local function simple_incr(a)
-    return a + 1
+local function simple_concat(a)
+    return a .. a
 end
-rawset(_G, 'simple_incr', simple_incr)
+rawset(_G, 'simple_concat', simple_concat)
 
 local function push_func(cnt)
     for i = 1, cnt do

--- a/datetime/datetime.go
+++ b/datetime/datetime.go
@@ -13,8 +13,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"time"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // Datetime MessagePack serialization schema is an MP_EXT extension, which
@@ -101,9 +99,6 @@ func (dtime *Datetime) ToTime() time.Time {
 	return dtime.time
 }
 
-var _ msgpack.Marshaler = (*Datetime)(nil)
-var _ msgpack.Unmarshaler = (*Datetime)(nil)
-
 func (dtime *Datetime) MarshalMsgpack() ([]byte, error) {
 	tm := dtime.ToTime()
 
@@ -151,8 +146,4 @@ func (tm *Datetime) UnmarshalMsgpack(b []byte) error {
 		*tm = *dtp
 	}
 	return err
-}
-
-func init() {
-	msgpack.RegisterExt(datetime_extId, &Datetime{})
 }

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/tarantool/go-tarantool"
 	. "github.com/tarantool/go-tarantool/datetime"
 	"github.com/tarantool/go-tarantool/test_helpers"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 var lesserBoundaryTimes = []time.Time{
@@ -270,7 +269,7 @@ type Tuple1 struct {
 	Datetime Datetime
 }
 
-func (t *Tuple1) EncodeMsgpack(e *msgpack.Encoder) error {
+func (t *Tuple1) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
@@ -280,7 +279,7 @@ func (t *Tuple1) EncodeMsgpack(e *msgpack.Encoder) error {
 	return nil
 }
 
-func (t *Tuple1) DecodeMsgpack(d *msgpack.Decoder) error {
+func (t *Tuple1) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {
@@ -296,7 +295,7 @@ func (t *Tuple1) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (ev *Event) EncodeMsgpack(e *msgpack.Encoder) error {
+func (ev *Event) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
@@ -309,7 +308,7 @@ func (ev *Event) EncodeMsgpack(e *msgpack.Encoder) error {
 	return nil
 }
 
-func (ev *Event) DecodeMsgpack(d *msgpack.Decoder) error {
+func (ev *Event) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {
@@ -329,7 +328,7 @@ func (ev *Event) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
+func (c *Tuple2) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
@@ -343,7 +342,7 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 	return nil
 }
 
-func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
+func (c *Tuple2) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {
@@ -525,7 +524,7 @@ func TestMPEncode(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unable to create Datetime from %s: %s", tm, err)
 			}
-			buf, err := msgpack.Marshal(dt)
+			buf, err := marshal(dt)
 			if err != nil {
 				t.Fatalf("Marshalling failed: %s", err.Error())
 			}
@@ -549,7 +548,7 @@ func TestMPDecode(t *testing.T) {
 			}
 			buf, _ := hex.DecodeString(testcase.mpBuf)
 			var v Datetime
-			err = msgpack.Unmarshal(buf, &v)
+			err = unmarshal(buf, &v)
 			if err != nil {
 				t.Fatalf("Unmarshalling failed: %s", err.Error())
 			}

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -332,7 +332,7 @@ func (c *Tuple2) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
-	if err := e.EncodeUint(c.Cid); err != nil {
+	if err := encodeUint(e, uint64(c.Cid)); err != nil {
 		return err
 	}
 	if err := e.EncodeString(c.Orig); err != nil {

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -271,7 +271,7 @@ type Tuple1 struct {
 }
 
 func (t *Tuple1) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(2); err != nil {
+	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
 	if err := e.Encode(&t.Datetime); err != nil {
@@ -283,7 +283,7 @@ func (t *Tuple1) EncodeMsgpack(e *msgpack.Encoder) error {
 func (t *Tuple1) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 1 {
@@ -297,7 +297,7 @@ func (t *Tuple1) DecodeMsgpack(d *msgpack.Decoder) error {
 }
 
 func (ev *Event) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(2); err != nil {
+	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
 	if err := e.EncodeString(ev.Location); err != nil {
@@ -312,7 +312,7 @@ func (ev *Event) EncodeMsgpack(e *msgpack.Encoder) error {
 func (ev *Event) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 2 {
@@ -330,7 +330,7 @@ func (ev *Event) DecodeMsgpack(d *msgpack.Decoder) error {
 }
 
 func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(3); err != nil {
+	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
 	if err := e.EncodeUint(c.Cid); err != nil {
@@ -346,7 +346,7 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 3 {
@@ -358,7 +358,7 @@ func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	if c.Orig, err = d.DecodeString(); err != nil {
 		return err
 	}
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	c.Events = make([]Event, l)

--- a/datetime/msgpack.go
+++ b/datetime/msgpack.go
@@ -1,0 +1,9 @@
+package datetime
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+func init() {
+	msgpack.RegisterExt(datetime_extId, &Datetime{})
+}

--- a/datetime/msgpack.go
+++ b/datetime/msgpack.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package datetime
 
 import (

--- a/datetime/msgpack_helper_test.go
+++ b/datetime/msgpack_helper_test.go
@@ -1,0 +1,16 @@
+package datetime_test
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder
+
+func marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}
+
+func unmarshal(data []byte, v interface{}) error {
+	return msgpack.Unmarshal(data, v)
+}

--- a/datetime/msgpack_helper_test.go
+++ b/datetime/msgpack_helper_test.go
@@ -7,6 +7,10 @@ import (
 type encoder = msgpack.Encoder
 type decoder = msgpack.Decoder
 
+func encodeUint(e *encoder, v uint64) error {
+	return e.EncodeUint(uint(v))
+}
+
 func marshal(v interface{}) ([]byte, error) {
 	return msgpack.Marshal(v)
 }

--- a/datetime/msgpack_v5.go
+++ b/datetime/msgpack_v5.go
@@ -1,0 +1,12 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package datetime
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func init() {
+	msgpack.RegisterExt(datetime_extId, (*Datetime)(nil))
+}

--- a/datetime/msgpack_v5_helper_test.go
+++ b/datetime/msgpack_v5_helper_test.go
@@ -1,19 +1,21 @@
-//go:build !go_tarantool_msgpack_v5
-// +build !go_tarantool_msgpack_v5
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
 
 package datetime_test
 
 import (
 	. "github.com/tarantool/go-tarantool/datetime"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 type encoder = msgpack.Encoder
 type decoder = msgpack.Decoder
 
 func toDatetime(i interface{}) (dt Datetime, ok bool) {
-	dt, ok = i.(Datetime)
+	var ptr *Datetime
+	if ptr, ok = i.(*Datetime); ok {
+		dt = *ptr
+	}
 	return
 }
 

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/shopspring/decimal"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // Decimal numbers have 38 digits of precision, that is, the total
@@ -55,9 +54,6 @@ func NewDecimalFromString(src string) (result *Decimal, err error) {
 	result = NewDecimal(dec)
 	return
 }
-
-var _ msgpack.Marshaler = (*Decimal)(nil)
-var _ msgpack.Unmarshaler = (*Decimal)(nil)
 
 func (decNum *Decimal) MarshalMsgpack() ([]byte, error) {
 	one := decimal.NewFromInt(1)
@@ -98,8 +94,4 @@ func (decNum *Decimal) UnmarshalMsgpack(b []byte) error {
 	}
 
 	return nil
-}
-
-func init() {
-	msgpack.RegisterExt(decimalExtID, &Decimal{})
 }

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -41,7 +41,7 @@ type TupleDecimal struct {
 }
 
 func (t *TupleDecimal) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(1); err != nil {
+	if err := e.EncodeArrayLen(1); err != nil {
 		return err
 	}
 	return e.EncodeValue(reflect.ValueOf(&t.number))
@@ -50,7 +50,7 @@ func (t *TupleDecimal) EncodeMsgpack(e *msgpack.Encoder) error {
 func (t *TupleDecimal) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 1 {

--- a/decimal/msgpack.go
+++ b/decimal/msgpack.go
@@ -1,0 +1,9 @@
+package decimal
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+func init() {
+	msgpack.RegisterExt(decimalExtID, &Decimal{})
+}

--- a/decimal/msgpack.go
+++ b/decimal/msgpack.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package decimal
 
 import (

--- a/decimal/msgpack_helper_test.go
+++ b/decimal/msgpack_helper_test.go
@@ -1,0 +1,16 @@
+package decimal_test
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder
+
+func marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}
+
+func unmarshal(data []byte, v interface{}) error {
+	return msgpack.Unmarshal(data, v)
+}

--- a/decimal/msgpack_v5.go
+++ b/decimal/msgpack_v5.go
@@ -1,0 +1,12 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package decimal
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func init() {
+	msgpack.RegisterExt(decimalExtID, (*Decimal)(nil))
+}

--- a/decimal/msgpack_v5_helper_test.go
+++ b/decimal/msgpack_v5_helper_test.go
@@ -1,19 +1,21 @@
-//go:build !go_tarantool_msgpack_v5
-// +build !go_tarantool_msgpack_v5
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
 
 package decimal_test
 
 import (
 	. "github.com/tarantool/go-tarantool/decimal"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 type encoder = msgpack.Encoder
 type decoder = msgpack.Decoder
 
 func toDecimal(i interface{}) (dec Decimal, ok bool) {
-	dec, ok = i.(Decimal)
+	var ptr *Decimal
+	if ptr, ok = i.(*Decimal); ok {
+		dec = *ptr
+	}
 	return
 }
 

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -27,7 +27,7 @@ func (c *Tuple2) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
-	if err := e.EncodeUint(c.Cid); err != nil {
+	if err := encodeUint(e, uint64(c.Cid)); err != nil {
 		return err
 	}
 	if err := e.EncodeString(c.Orig); err != nil {

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -25,7 +25,7 @@ type Tuple3 struct {
 }
 
 func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(3); err != nil {
+	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
 	if err := e.EncodeUint(c.Cid); err != nil {
@@ -41,7 +41,7 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 3 {
@@ -53,7 +53,7 @@ func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	if c.Orig, err = d.DecodeString(); err != nil {
 		return err
 	}
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	c.Members = make([]Member, l)

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/tarantool/go-tarantool"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type Tuple2 struct {
@@ -24,7 +23,7 @@ type Tuple3 struct {
 	Members []Member
 }
 
-func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
+func (c *Tuple2) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(3); err != nil {
 		return err
 	}
@@ -38,7 +37,7 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 	return nil
 }
 
-func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
+func (c *Tuple2) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -471,10 +471,10 @@ func ExampleFuture_GetIterator() {
 		resp := it.Value()
 		if resp.Code == tarantool.PushCode {
 			// It is a push message.
-			fmt.Printf("push message: %d\n", resp.Data[0].(uint64))
+			fmt.Printf("push message: %v\n", resp.Data[0])
 		} else if resp.Code == tarantool.OkCode {
 			// It is a regular response.
-			fmt.Printf("response: %d", resp.Data[0].(uint64))
+			fmt.Printf("response: %v", resp.Data[0])
 		} else {
 			fmt.Printf("an unexpected response code %d", resp.Code)
 		}
@@ -645,17 +645,17 @@ func ExampleConnection_Call() {
 	conn := example_connect()
 	defer conn.Close()
 
-	// Call a function 'simple_incr' with arguments.
-	resp, err := conn.Call17("simple_incr", []interface{}{1})
-	fmt.Println("Call simple_incr()")
+	// Call a function 'simple_concat' with arguments.
+	resp, err := conn.Call17("simple_concat", []interface{}{"1"})
+	fmt.Println("Call simple_concat()")
 	fmt.Println("Error", err)
 	fmt.Println("Code", resp.Code)
 	fmt.Println("Data", resp.Data)
 	// Output:
-	// Call simple_incr()
+	// Call simple_concat()
 	// Error <nil>
 	// Code 0
-	// Data [2]
+	// Data [11]
 }
 
 func ExampleConnection_Eval() {

--- a/export_test.go
+++ b/export_test.go
@@ -1,10 +1,9 @@
 package tarantool
 
 import (
+	"io"
 	"net"
 	"time"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 func SslDialTimeout(network, address string, timeout time.Duration,
@@ -18,96 +17,100 @@ func SslCreateContext(opts SslOpts) (ctx interface{}, err error) {
 
 // RefImplPingBody is reference implementation for filling of a ping
 // request's body.
-func RefImplPingBody(enc *msgpack.Encoder) error {
+func RefImplPingBody(enc *encoder) error {
 	return fillPing(enc)
 }
 
 // RefImplSelectBody is reference implementation for filling of a select
 // request's body.
-func RefImplSelectBody(enc *msgpack.Encoder, space, index, offset, limit, iterator uint32, key interface{}) error {
+func RefImplSelectBody(enc *encoder, space, index, offset, limit, iterator uint32, key interface{}) error {
 	return fillSelect(enc, space, index, offset, limit, iterator, key)
 }
 
 // RefImplInsertBody is reference implementation for filling of an insert
 // request's body.
-func RefImplInsertBody(enc *msgpack.Encoder, space uint32, tuple interface{}) error {
+func RefImplInsertBody(enc *encoder, space uint32, tuple interface{}) error {
 	return fillInsert(enc, space, tuple)
 }
 
 // RefImplReplaceBody is reference implementation for filling of a replace
 // request's body.
-func RefImplReplaceBody(enc *msgpack.Encoder, space uint32, tuple interface{}) error {
+func RefImplReplaceBody(enc *encoder, space uint32, tuple interface{}) error {
 	return fillInsert(enc, space, tuple)
 }
 
 // RefImplDeleteBody is reference implementation for filling of a delete
 // request's body.
-func RefImplDeleteBody(enc *msgpack.Encoder, space, index uint32, key interface{}) error {
+func RefImplDeleteBody(enc *encoder, space, index uint32, key interface{}) error {
 	return fillDelete(enc, space, index, key)
 }
 
 // RefImplUpdateBody is reference implementation for filling of an update
 // request's body.
-func RefImplUpdateBody(enc *msgpack.Encoder, space, index uint32, key, ops interface{}) error {
+func RefImplUpdateBody(enc *encoder, space, index uint32, key, ops interface{}) error {
 	return fillUpdate(enc, space, index, key, ops)
 }
 
 // RefImplUpsertBody is reference implementation for filling of an upsert
 // request's body.
-func RefImplUpsertBody(enc *msgpack.Encoder, space uint32, tuple, ops interface{}) error {
+func RefImplUpsertBody(enc *encoder, space uint32, tuple, ops interface{}) error {
 	return fillUpsert(enc, space, tuple, ops)
 }
 
 // RefImplCallBody is reference implementation for filling of a call or call17
 // request's body.
-func RefImplCallBody(enc *msgpack.Encoder, function string, args interface{}) error {
+func RefImplCallBody(enc *encoder, function string, args interface{}) error {
 	return fillCall(enc, function, args)
 }
 
 // RefImplEvalBody is reference implementation for filling of an eval
 // request's body.
-func RefImplEvalBody(enc *msgpack.Encoder, expr string, args interface{}) error {
+func RefImplEvalBody(enc *encoder, expr string, args interface{}) error {
 	return fillEval(enc, expr, args)
 }
 
 // RefImplExecuteBody is reference implementation for filling of an execute
 // request's body.
-func RefImplExecuteBody(enc *msgpack.Encoder, expr string, args interface{}) error {
+func RefImplExecuteBody(enc *encoder, expr string, args interface{}) error {
 	return fillExecute(enc, expr, args)
 }
 
 // RefImplPrepareBody is reference implementation for filling of an prepare
 // request's body.
-func RefImplPrepareBody(enc *msgpack.Encoder, expr string) error {
+func RefImplPrepareBody(enc *encoder, expr string) error {
 	return fillPrepare(enc, expr)
 }
 
 // RefImplUnprepareBody is reference implementation for filling of an execute prepared
 // request's body.
-func RefImplExecutePreparedBody(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
+func RefImplExecutePreparedBody(enc *encoder, stmt Prepared, args interface{}) error {
 	return fillExecutePrepared(enc, stmt, args)
 }
 
 // RefImplUnprepareBody is reference implementation for filling of an unprepare
 // request's body.
-func RefImplUnprepareBody(enc *msgpack.Encoder, stmt Prepared) error {
+func RefImplUnprepareBody(enc *encoder, stmt Prepared) error {
 	return fillUnprepare(enc, stmt)
 }
 
 // RefImplBeginBody is reference implementation for filling of an begin
 // request's body.
-func RefImplBeginBody(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
+func RefImplBeginBody(enc *encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
 	return fillBegin(enc, txnIsolation, timeout)
 }
 
 // RefImplCommitBody is reference implementation for filling of an commit
 // request's body.
-func RefImplCommitBody(enc *msgpack.Encoder) error {
+func RefImplCommitBody(enc *encoder) error {
 	return fillCommit(enc)
 }
 
 // RefImplRollbackBody is reference implementation for filling of an rollback
 // request's body.
-func RefImplRollbackBody(enc *msgpack.Encoder) error {
+func RefImplRollbackBody(enc *encoder) error {
 	return fillRollback(enc)
+}
+
+func NewEncoder(w io.Writer) *encoder {
+	return newEncoder(w)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.2
 	gotest.tools/v3 v3.2.0 // indirect
+	github.com/vmihailenco/msgpack/v5 v5.3.5
 )

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,15 @@ github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarantool/go-openssl v0.0.8-0.20220711094538-d93c1eff4f49 h1:rZYYi1cI3QXZ3yRFZd2ItYM1XA2BaJqP0buDroMbjNo=
 github.com/tarantool/go-openssl v0.0.8-0.20220711094538-d93c1eff4f49/go.mod h1:M7H4xYSbzqpW/ZRBMyH0eyqQBsnhAMfsYk5mv0yid7A=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/msgpack.go
+++ b/msgpack.go
@@ -18,6 +18,14 @@ func newDecoder(r io.Reader) *decoder {
 	return msgpack.NewDecoder(r)
 }
 
+func encodeUint(e *encoder, v uint64) error {
+	return e.EncodeUint(uint(v))
+}
+
+func encodeInt(e *encoder, v int64) error {
+	return e.EncodeInt(int(v))
+}
+
 func msgpackIsUint(code byte) bool {
 	return code == msgpcode.Uint8 || code == msgpcode.Uint16 ||
 		code == msgpcode.Uint32 || code == msgpcode.Uint64 ||

--- a/msgpack.go
+++ b/msgpack.go
@@ -1,0 +1,39 @@
+package tarantool
+
+import (
+	"io"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
+	msgpcode "gopkg.in/vmihailenco/msgpack.v2/codes"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder
+
+func newEncoder(w io.Writer) *encoder {
+	return msgpack.NewEncoder(w)
+}
+
+func newDecoder(r io.Reader) *decoder {
+	return msgpack.NewDecoder(r)
+}
+
+func msgpackIsUint(code byte) bool {
+	return code == msgpcode.Uint8 || code == msgpcode.Uint16 ||
+		code == msgpcode.Uint32 || code == msgpcode.Uint64 ||
+		msgpcode.IsFixedNum(code)
+}
+
+func msgpackIsMap(code byte) bool {
+	return code == msgpcode.Map16 || code == msgpcode.Map32 || msgpcode.IsFixedMap(code)
+}
+
+func msgpackIsArray(code byte) bool {
+	return code == msgpcode.Array16 || code == msgpcode.Array32 ||
+		msgpcode.IsFixedArray(code)
+}
+
+func msgpackIsString(code byte) bool {
+	return msgpcode.IsFixedString(code) || code == msgpcode.Str8 ||
+		code == msgpcode.Str16 || code == msgpcode.Str32
+}

--- a/msgpack_helper_test.go
+++ b/msgpack_helper_test.go
@@ -1,0 +1,8 @@
+package tarantool_test
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder

--- a/msgpack_helper_test.go
+++ b/msgpack_helper_test.go
@@ -6,3 +6,7 @@ import (
 
 type encoder = msgpack.Encoder
 type decoder = msgpack.Decoder
+
+func encodeUint(e *encoder, v uint64) error {
+	return e.EncodeUint(uint(v))
+}

--- a/msgpack_v5.go
+++ b/msgpack_v5.go
@@ -1,13 +1,13 @@
-//go:build !go_tarantool_msgpack_v5
-// +build !go_tarantool_msgpack_v5
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
 
 package tarantool
 
 import (
 	"io"
 
-	"gopkg.in/vmihailenco/msgpack.v2"
-	msgpcode "gopkg.in/vmihailenco/msgpack.v2/codes"
+	"github.com/vmihailenco/msgpack/v5"
+	"github.com/vmihailenco/msgpack/v5/msgpcode"
 )
 
 type encoder = msgpack.Encoder
@@ -18,15 +18,19 @@ func newEncoder(w io.Writer) *encoder {
 }
 
 func newDecoder(r io.Reader) *decoder {
-	return msgpack.NewDecoder(r)
+	dec := msgpack.NewDecoder(r)
+	dec.SetMapDecoder(func(dec *msgpack.Decoder) (interface{}, error) {
+		return dec.DecodeUntypedMap()
+	})
+	return dec
 }
 
 func encodeUint(e *encoder, v uint64) error {
-	return e.EncodeUint(uint(v))
+	return e.EncodeUint(v)
 }
 
 func encodeInt(e *encoder, v int64) error {
-	return e.EncodeInt(int(v))
+	return e.EncodeInt(v)
 }
 
 func msgpackIsUint(code byte) bool {

--- a/msgpack_v5_helper_test.go
+++ b/msgpack_v5_helper_test.go
@@ -1,15 +1,15 @@
-//go:build !go_tarantool_msgpack_v5
-// +build !go_tarantool_msgpack_v5
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
 
 package tarantool_test
 
 import (
-	"gopkg.in/vmihailenco/msgpack.v2"
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 type encoder = msgpack.Encoder
 type decoder = msgpack.Decoder
 
 func encodeUint(e *encoder, v uint64) error {
-	return e.EncodeUint(uint(v))
+	return e.EncodeUint(v)
 }

--- a/multi/call_16_test.go
+++ b/multi/call_16_test.go
@@ -23,11 +23,11 @@ func TestCall(t *testing.T) {
 	defer multiConn.Close()
 
 	// Call16
-	resp, err = multiConn.Call("simple_incr", []interface{}{1})
+	resp, err = multiConn.Call("simple_concat", []interface{}{"t"})
 	if err != nil {
 		t.Fatalf("Failed to use Call: %s", err.Error())
 	}
-	if resp.Data[0].([]interface{})[0].(uint64) != 2 {
+	if resp.Data[0].([]interface{})[0].(string) != "tt" {
 		t.Fatalf("result is not {{1}} : %v", resp.Data)
 	}
 }

--- a/multi/call_17_test.go
+++ b/multi/call_17_test.go
@@ -23,11 +23,11 @@ func TestCall(t *testing.T) {
 	defer multiConn.Close()
 
 	// Call17
-	resp, err = multiConn.Call("simple_incr", []interface{}{1})
+	resp, err = multiConn.Call("simple_concat", []interface{}{"t"})
 	if err != nil {
 		t.Fatalf("Failed to use Call: %s", err.Error())
 	}
-	if resp.Data[0].(uint64) != 2 {
+	if resp.Data[0].(string) != "tt" {
 		t.Fatalf("result is not {{1}} : %v", resp.Data)
 	}
 }

--- a/multi/config.lua
+++ b/multi/config.lua
@@ -16,7 +16,7 @@ box.once("init", function()
         id = 517,
         if_not_exists = true,
     })
-    s:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
+    s:create_index('primary', {type = 'tree', parts = {1, 'string'}, if_not_exists = true})
 
     box.schema.user.create('test', { password = 'test' })
     box.schema.user.grant('test', 'read,write,execute', 'universe')
@@ -37,11 +37,11 @@ box.once("init", function()
     box.schema.user.grant('test', 'create', 'sequence')
 end)
 
-local function simple_incr(a)
-    return a + 1
+local function simple_concat(a)
+    return a .. a
 end
 
-rawset(_G, 'simple_incr', simple_incr)
+rawset(_G, 'simple_concat', simple_concat)
 
 -- Set listen only when every other thing is configured.
 box.cfg{

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -229,11 +229,11 @@ func TestCall17(t *testing.T) {
 	defer multiConn.Close()
 
 	// Call17
-	resp, err = multiConn.Call17("simple_incr", []interface{}{1})
+	resp, err = multiConn.Call17("simple_concat", []interface{}{"s"})
 	if err != nil {
 		t.Fatalf("Failed to use Call: %s", err.Error())
 	}
-	if resp.Data[0].(uint64) != 2 {
+	if resp.Data[0].(string) != "ss" {
 		t.Fatalf("result is not {{1}} : %v", resp.Data)
 	}
 }
@@ -351,7 +351,7 @@ func TestStream_Commit(t *testing.T) {
 
 	// Insert in stream
 	req = tarantool.NewInsertRequest(spaceName).
-		Tuple([]interface{}{uint(1001), "hello2", "world2"})
+		Tuple([]interface{}{"1001", "hello2", "world2"})
 	resp, err = stream.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Insert: %s", err.Error())
@@ -359,7 +359,7 @@ func TestStream_Commit(t *testing.T) {
 	if resp.Code != tarantool.OkCode {
 		t.Errorf("Failed to Insert: wrong code returned %d", resp.Code)
 	}
-	defer test_helpers.DeleteRecordByKey(t, multiConn, spaceNo, indexNo, []interface{}{uint(1001)})
+	defer test_helpers.DeleteRecordByKey(t, multiConn, spaceNo, indexNo, []interface{}{"1001"})
 
 	// Select not related to the transaction
 	// while transaction is not committed
@@ -368,7 +368,7 @@ func TestStream_Commit(t *testing.T) {
 		Index(indexNo).
 		Limit(1).
 		Iterator(tarantool.IterEq).
-		Key([]interface{}{uint(1001)})
+		Key([]interface{}{"1001"})
 	resp, err = multiConn.Do(selectReq).Get()
 	if err != nil {
 		t.Fatalf("Failed to Select: %s", err.Error())
@@ -394,7 +394,7 @@ func TestStream_Commit(t *testing.T) {
 	if tpl, ok := resp.Data[0].([]interface{}); !ok {
 		t.Fatalf("Unexpected body of Select")
 	} else {
-		if id, ok := tpl[0].(uint64); !ok || id != 1001 {
+		if id, ok := tpl[0].(string); !ok || id != "1001" {
 			t.Fatalf("Unexpected body of Select (0)")
 		}
 		if h, ok := tpl[1].(string); !ok || h != "hello2" {
@@ -429,7 +429,7 @@ func TestStream_Commit(t *testing.T) {
 	if tpl, ok := resp.Data[0].([]interface{}); !ok {
 		t.Fatalf("Unexpected body of Select")
 	} else {
-		if id, ok := tpl[0].(uint64); !ok || id != 1001 {
+		if id, ok := tpl[0].(string); !ok || id != "1001" {
 			t.Fatalf("Unexpected body of Select (0)")
 		}
 		if h, ok := tpl[1].(string); !ok || h != "hello2" {
@@ -471,7 +471,7 @@ func TestStream_Rollback(t *testing.T) {
 
 	// Insert in stream
 	req = tarantool.NewInsertRequest(spaceName).
-		Tuple([]interface{}{uint(1001), "hello2", "world2"})
+		Tuple([]interface{}{"1001", "hello2", "world2"})
 	resp, err = stream.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Insert: %s", err.Error())
@@ -479,7 +479,7 @@ func TestStream_Rollback(t *testing.T) {
 	if resp.Code != tarantool.OkCode {
 		t.Errorf("Failed to Insert: wrong code returned %d", resp.Code)
 	}
-	defer test_helpers.DeleteRecordByKey(t, multiConn, spaceNo, indexNo, []interface{}{uint(1001)})
+	defer test_helpers.DeleteRecordByKey(t, multiConn, spaceNo, indexNo, []interface{}{"1001"})
 
 	// Select not related to the transaction
 	// while transaction is not committed
@@ -488,7 +488,7 @@ func TestStream_Rollback(t *testing.T) {
 		Index(indexNo).
 		Limit(1).
 		Iterator(tarantool.IterEq).
-		Key([]interface{}{uint(1001)})
+		Key([]interface{}{"1001"})
 	resp, err = multiConn.Do(selectReq).Get()
 	if err != nil {
 		t.Fatalf("Failed to Select: %s", err.Error())
@@ -514,7 +514,7 @@ func TestStream_Rollback(t *testing.T) {
 	if tpl, ok := resp.Data[0].([]interface{}); !ok {
 		t.Fatalf("Unexpected body of Select")
 	} else {
-		if id, ok := tpl[0].(uint64); !ok || id != 1001 {
+		if id, ok := tpl[0].(string); !ok || id != "1001" {
 			t.Fatalf("Unexpected body of Select (0)")
 		}
 		if h, ok := tpl[1].(string); !ok || h != "hello2" {

--- a/prepared.go
+++ b/prepared.go
@@ -3,8 +3,6 @@ package tarantool
 import (
 	"context"
 	"fmt"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // PreparedID is a type for Prepared Statement ID
@@ -20,19 +18,19 @@ type Prepared struct {
 	Conn        *Connection
 }
 
-func fillPrepare(enc *msgpack.Encoder, expr string) error {
+func fillPrepare(enc *encoder, expr string) error {
 	enc.EncodeMapLen(1)
 	enc.EncodeUint(KeySQLText)
 	return enc.EncodeString(expr)
 }
 
-func fillUnprepare(enc *msgpack.Encoder, stmt Prepared) error {
+func fillUnprepare(enc *encoder, stmt Prepared) error {
 	enc.EncodeMapLen(1)
 	enc.EncodeUint(KeyStmtID)
 	return enc.EncodeUint(uint(stmt.StatementID))
 }
 
-func fillExecutePrepared(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
+func fillExecutePrepared(enc *encoder, stmt Prepared, args interface{}) error {
 	enc.EncodeMapLen(2)
 	enc.EncodeUint(KeyStmtID)
 	enc.EncodeUint(uint(stmt.StatementID))
@@ -75,7 +73,7 @@ func NewPrepareRequest(expr string) *PrepareRequest {
 }
 
 // Body fills an encoder with the execute request body.
-func (req *PrepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *PrepareRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillPrepare(enc, req.expr)
 }
 
@@ -111,7 +109,7 @@ func (req *UnprepareRequest) Conn() *Connection {
 }
 
 // Body fills an encoder with the execute request body.
-func (req *UnprepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *UnprepareRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillUnprepare(enc, *req.stmt)
 }
 
@@ -156,7 +154,7 @@ func (req *ExecutePreparedRequest) Args(args interface{}) *ExecutePreparedReques
 }
 
 // Body fills an encoder with the execute request body.
-func (req *ExecutePreparedRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *ExecutePreparedRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillExecutePrepared(enc, *req.stmt, req.args)
 }
 

--- a/prepared.go
+++ b/prepared.go
@@ -22,21 +22,21 @@ type Prepared struct {
 
 func fillPrepare(enc *msgpack.Encoder, expr string) error {
 	enc.EncodeMapLen(1)
-	enc.EncodeUint64(KeySQLText)
+	enc.EncodeUint(KeySQLText)
 	return enc.EncodeString(expr)
 }
 
 func fillUnprepare(enc *msgpack.Encoder, stmt Prepared) error {
 	enc.EncodeMapLen(1)
-	enc.EncodeUint64(KeyStmtID)
-	return enc.EncodeUint64(uint64(stmt.StatementID))
+	enc.EncodeUint(KeyStmtID)
+	return enc.EncodeUint(uint(stmt.StatementID))
 }
 
 func fillExecutePrepared(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeyStmtID)
-	enc.EncodeUint64(uint64(stmt.StatementID))
-	enc.EncodeUint64(KeySQLBind)
+	enc.EncodeUint(KeyStmtID)
+	enc.EncodeUint(uint(stmt.StatementID))
+	enc.EncodeUint(KeySQLBind)
 	return encodeSQLBind(enc, args)
 }
 

--- a/prepared.go
+++ b/prepared.go
@@ -20,21 +20,21 @@ type Prepared struct {
 
 func fillPrepare(enc *encoder, expr string) error {
 	enc.EncodeMapLen(1)
-	enc.EncodeUint(KeySQLText)
+	encodeUint(enc, KeySQLText)
 	return enc.EncodeString(expr)
 }
 
 func fillUnprepare(enc *encoder, stmt Prepared) error {
 	enc.EncodeMapLen(1)
-	enc.EncodeUint(KeyStmtID)
-	return enc.EncodeUint(uint(stmt.StatementID))
+	encodeUint(enc, KeyStmtID)
+	return encodeUint(enc, uint64(stmt.StatementID))
 }
 
 func fillExecutePrepared(enc *encoder, stmt Prepared, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint(KeyStmtID)
-	enc.EncodeUint(uint(stmt.StatementID))
-	enc.EncodeUint(KeySQLBind)
+	encodeUint(enc, KeyStmtID)
+	encodeUint(enc, uint64(stmt.StatementID))
+	encodeUint(enc, KeySQLBind)
 	return encodeSQLBind(enc, args)
 }
 

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -15,14 +15,13 @@ import (
 
 	"github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/queue"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type dummyData struct {
 	Dummy bool
 }
 
-func (c *dummyData) DecodeMsgpack(d *msgpack.Decoder) error {
+func (c *dummyData) DecodeMsgpack(d *decoder) error {
 	var err error
 	if c.Dummy, err = d.DecodeBool(); err != nil {
 		return err
@@ -30,7 +29,7 @@ func (c *dummyData) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (c *dummyData) EncodeMsgpack(e *msgpack.Encoder) error {
+func (c *dummyData) EncodeMsgpack(e *encoder) error {
 	return e.EncodeBool(c.Dummy)
 }
 

--- a/queue/msgpack.go
+++ b/queue/msgpack.go
@@ -1,0 +1,7 @@
+package queue
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type decoder = msgpack.Decoder

--- a/queue/msgpack.go
+++ b/queue/msgpack.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package queue
 
 import (

--- a/queue/msgpack_helper_test.go
+++ b/queue/msgpack_helper_test.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package queue_test
 
 import (

--- a/queue/msgpack_helper_test.go
+++ b/queue/msgpack_helper_test.go
@@ -1,0 +1,8 @@
+package queue_test
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder

--- a/queue/msgpack_v5.go
+++ b/queue/msgpack_v5.go
@@ -1,0 +1,10 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package queue
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type decoder = msgpack.Decoder

--- a/queue/msgpack_v5_helper_test.go
+++ b/queue/msgpack_v5_helper_test.go
@@ -1,0 +1,11 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package queue_test
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/tarantool/go-tarantool"
-	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // Queue is a handle to Tarantool queue's tube.
@@ -336,7 +335,7 @@ type queueData struct {
 	result interface{}
 }
 
-func (qd *queueData) DecodeMsgpack(d *msgpack.Decoder) error {
+func (qd *queueData) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -339,7 +339,7 @@ type queueData struct {
 func (qd *queueData) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l > 1 {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -186,7 +186,7 @@ type customData struct {
 func (c *customData) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 1 {
@@ -199,7 +199,7 @@ func (c *customData) DecodeMsgpack(d *msgpack.Decoder) error {
 }
 
 func (c *customData) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(1); err != nil {
+	if err := e.EncodeArrayLen(1); err != nil {
 		return err
 	}
 	if err := e.EncodeString(c.customField); err != nil {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/queue"
 	"github.com/tarantool/go-tarantool/test_helpers"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 var server = "127.0.0.1:3013"
@@ -183,7 +182,7 @@ type customData struct {
 	customField string
 }
 
-func (c *customData) DecodeMsgpack(d *msgpack.Decoder) error {
+func (c *customData) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {
@@ -198,7 +197,7 @@ func (c *customData) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (c *customData) EncodeMsgpack(e *msgpack.Encoder) error {
+func (c *customData) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(1); err != nil {
 		return err
 	}

--- a/queue/task.go
+++ b/queue/task.go
@@ -17,7 +17,7 @@ type Task struct {
 func (t *Task) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l < 3 {

--- a/queue/task.go
+++ b/queue/task.go
@@ -2,8 +2,6 @@ package queue
 
 import (
 	"fmt"
-
-	msgpack "gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // Task represents a task from Tarantool queue's tube.
@@ -14,7 +12,7 @@ type Task struct {
 	q      *queue
 }
 
-func (t *Task) DecodeMsgpack(d *msgpack.Decoder) error {
+func (t *Task) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {

--- a/request.go
+++ b/request.go
@@ -9,28 +9,28 @@ import (
 )
 
 func fillSearch(enc *encoder, spaceNo, indexNo uint32, key interface{}) error {
-	enc.EncodeUint(KeySpaceNo)
-	enc.EncodeUint(uint(spaceNo))
-	enc.EncodeUint(KeyIndexNo)
-	enc.EncodeUint(uint(indexNo))
-	enc.EncodeUint(KeyKey)
+	encodeUint(enc, KeySpaceNo)
+	encodeUint(enc, uint64(spaceNo))
+	encodeUint(enc, KeyIndexNo)
+	encodeUint(enc, uint64(indexNo))
+	encodeUint(enc, KeyKey)
 	return enc.Encode(key)
 }
 
 func fillIterator(enc *encoder, offset, limit, iterator uint32) {
-	enc.EncodeUint(KeyIterator)
-	enc.EncodeUint(uint(iterator))
-	enc.EncodeUint(KeyOffset)
-	enc.EncodeUint(uint(offset))
-	enc.EncodeUint(KeyLimit)
-	enc.EncodeUint(uint(limit))
+	encodeUint(enc, KeyIterator)
+	encodeUint(enc, uint64(iterator))
+	encodeUint(enc, KeyOffset)
+	encodeUint(enc, uint64(offset))
+	encodeUint(enc, KeyLimit)
+	encodeUint(enc, uint64(limit))
 }
 
 func fillInsert(enc *encoder, spaceNo uint32, tuple interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint(KeySpaceNo)
-	enc.EncodeUint(uint(spaceNo))
-	enc.EncodeUint(KeyTuple)
+	encodeUint(enc, KeySpaceNo)
+	encodeUint(enc, uint64(spaceNo))
+	encodeUint(enc, KeyTuple)
 	return enc.Encode(tuple)
 }
 
@@ -45,19 +45,19 @@ func fillUpdate(enc *encoder, spaceNo, indexNo uint32, key, ops interface{}) err
 	if err := fillSearch(enc, spaceNo, indexNo, key); err != nil {
 		return err
 	}
-	enc.EncodeUint(KeyTuple)
+	encodeUint(enc, KeyTuple)
 	return enc.Encode(ops)
 }
 
 func fillUpsert(enc *encoder, spaceNo uint32, tuple, ops interface{}) error {
 	enc.EncodeMapLen(3)
-	enc.EncodeUint(KeySpaceNo)
-	enc.EncodeUint(uint(spaceNo))
-	enc.EncodeUint(KeyTuple)
+	encodeUint(enc, KeySpaceNo)
+	encodeUint(enc, uint64(spaceNo))
+	encodeUint(enc, KeyTuple)
 	if err := enc.Encode(tuple); err != nil {
 		return err
 	}
-	enc.EncodeUint(KeyDefTuple)
+	encodeUint(enc, KeyDefTuple)
 	return enc.Encode(ops)
 }
 
@@ -68,25 +68,25 @@ func fillDelete(enc *encoder, spaceNo, indexNo uint32, key interface{}) error {
 
 func fillCall(enc *encoder, functionName string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint(KeyFunctionName)
+	encodeUint(enc, KeyFunctionName)
 	enc.EncodeString(functionName)
-	enc.EncodeUint(KeyTuple)
+	encodeUint(enc, KeyTuple)
 	return enc.Encode(args)
 }
 
 func fillEval(enc *encoder, expr string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint(KeyExpression)
+	encodeUint(enc, KeyExpression)
 	enc.EncodeString(expr)
-	enc.EncodeUint(KeyTuple)
+	encodeUint(enc, KeyTuple)
 	return enc.Encode(args)
 }
 
 func fillExecute(enc *encoder, expr string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint(KeySQLText)
+	encodeUint(enc, KeySQLText)
 	enc.EncodeString(expr)
-	enc.EncodeUint(KeySQLBind)
+	encodeUint(enc, KeySQLBind)
 	return encodeSQLBind(enc, args)
 }
 

--- a/request.go
+++ b/request.go
@@ -11,28 +11,28 @@ import (
 )
 
 func fillSearch(enc *msgpack.Encoder, spaceNo, indexNo uint32, key interface{}) error {
-	enc.EncodeUint64(KeySpaceNo)
-	enc.EncodeUint64(uint64(spaceNo))
-	enc.EncodeUint64(KeyIndexNo)
-	enc.EncodeUint64(uint64(indexNo))
-	enc.EncodeUint64(KeyKey)
+	enc.EncodeUint(KeySpaceNo)
+	enc.EncodeUint(uint(spaceNo))
+	enc.EncodeUint(KeyIndexNo)
+	enc.EncodeUint(uint(indexNo))
+	enc.EncodeUint(KeyKey)
 	return enc.Encode(key)
 }
 
 func fillIterator(enc *msgpack.Encoder, offset, limit, iterator uint32) {
-	enc.EncodeUint64(KeyIterator)
-	enc.EncodeUint64(uint64(iterator))
-	enc.EncodeUint64(KeyOffset)
-	enc.EncodeUint64(uint64(offset))
-	enc.EncodeUint64(KeyLimit)
-	enc.EncodeUint64(uint64(limit))
+	enc.EncodeUint(KeyIterator)
+	enc.EncodeUint(uint(iterator))
+	enc.EncodeUint(KeyOffset)
+	enc.EncodeUint(uint(offset))
+	enc.EncodeUint(KeyLimit)
+	enc.EncodeUint(uint(limit))
 }
 
 func fillInsert(enc *msgpack.Encoder, spaceNo uint32, tuple interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeySpaceNo)
-	enc.EncodeUint64(uint64(spaceNo))
-	enc.EncodeUint64(KeyTuple)
+	enc.EncodeUint(KeySpaceNo)
+	enc.EncodeUint(uint(spaceNo))
+	enc.EncodeUint(KeyTuple)
 	return enc.Encode(tuple)
 }
 
@@ -47,19 +47,19 @@ func fillUpdate(enc *msgpack.Encoder, spaceNo, indexNo uint32, key, ops interfac
 	if err := fillSearch(enc, spaceNo, indexNo, key); err != nil {
 		return err
 	}
-	enc.EncodeUint64(KeyTuple)
+	enc.EncodeUint(KeyTuple)
 	return enc.Encode(ops)
 }
 
 func fillUpsert(enc *msgpack.Encoder, spaceNo uint32, tuple, ops interface{}) error {
 	enc.EncodeMapLen(3)
-	enc.EncodeUint64(KeySpaceNo)
-	enc.EncodeUint64(uint64(spaceNo))
-	enc.EncodeUint64(KeyTuple)
+	enc.EncodeUint(KeySpaceNo)
+	enc.EncodeUint(uint(spaceNo))
+	enc.EncodeUint(KeyTuple)
 	if err := enc.Encode(tuple); err != nil {
 		return err
 	}
-	enc.EncodeUint64(KeyDefTuple)
+	enc.EncodeUint(KeyDefTuple)
 	return enc.Encode(ops)
 }
 
@@ -70,25 +70,25 @@ func fillDelete(enc *msgpack.Encoder, spaceNo, indexNo uint32, key interface{}) 
 
 func fillCall(enc *msgpack.Encoder, functionName string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeyFunctionName)
+	enc.EncodeUint(KeyFunctionName)
 	enc.EncodeString(functionName)
-	enc.EncodeUint64(KeyTuple)
+	enc.EncodeUint(KeyTuple)
 	return enc.Encode(args)
 }
 
 func fillEval(enc *msgpack.Encoder, expr string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeyExpression)
+	enc.EncodeUint(KeyExpression)
 	enc.EncodeString(expr)
-	enc.EncodeUint64(KeyTuple)
+	enc.EncodeUint(KeyTuple)
 	return enc.Encode(args)
 }
 
 func fillExecute(enc *msgpack.Encoder, expr string, args interface{}) error {
 	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeySQLText)
+	enc.EncodeUint(KeySQLText)
 	enc.EncodeString(expr)
-	enc.EncodeUint64(KeySQLBind)
+	enc.EncodeUint(KeySQLBind)
 	return encodeSQLBind(enc, args)
 }
 

--- a/request.go
+++ b/request.go
@@ -200,7 +200,7 @@ type single struct {
 func (s *single) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var len int
-	if len, err = d.DecodeSliceLen(); err != nil {
+	if len, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if s.found = len >= 1; !s.found {
@@ -433,7 +433,7 @@ func encodeSQLBind(enc *msgpack.Encoder, from interface{}) error {
 	}
 
 	encodeNamedFromMap := func(mp map[string]interface{}) error {
-		if err := enc.EncodeSliceLen(len(mp)); err != nil {
+		if err := enc.EncodeArrayLen(len(mp)); err != nil {
 			return err
 		}
 		for k, v := range mp {
@@ -445,7 +445,7 @@ func encodeSQLBind(enc *msgpack.Encoder, from interface{}) error {
 	}
 
 	encodeNamedFromStruct := func(val reflect.Value) error {
-		if err := enc.EncodeSliceLen(val.NumField()); err != nil {
+		if err := enc.EncodeArrayLen(val.NumField()); err != nil {
 			return err
 		}
 		cached, ok := lowerCaseNames.Load(val.Type())
@@ -479,7 +479,7 @@ func encodeSQLBind(enc *msgpack.Encoder, from interface{}) error {
 		if !ok {
 			castedKVSlice := from.([]KeyValueBind)
 			t := len(castedKVSlice)
-			if err := enc.EncodeSliceLen(t); err != nil {
+			if err := enc.EncodeArrayLen(t); err != nil {
 				return err
 			}
 			for _, v := range castedKVSlice {
@@ -490,7 +490,7 @@ func encodeSQLBind(enc *msgpack.Encoder, from interface{}) error {
 			return nil
 		}
 
-		if err := enc.EncodeSliceLen(len(castedSlice)); err != nil {
+		if err := enc.EncodeArrayLen(len(castedSlice)); err != nil {
 			return err
 		}
 		for i := 0; i < len(castedSlice); i++ {

--- a/request_test.go
+++ b/request_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/tarantool/go-tarantool"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 const invalidSpaceMsg = "invalid space"
@@ -61,7 +60,7 @@ func assertBodyCall(t testing.TB, requests []Request, errorMsg string) {
 	const errBegin = "An unexpected Request.Body() "
 	for _, req := range requests {
 		var reqBuf bytes.Buffer
-		enc := msgpack.NewEncoder(&reqBuf)
+		enc := NewEncoder(&reqBuf)
 
 		err := req.Body(&resolver, enc)
 		if err != nil && errorMsg != "" && err.Error() != errorMsg {
@@ -80,7 +79,7 @@ func assertBodyEqual(t testing.TB, reference []byte, req Request) {
 	t.Helper()
 
 	var reqBuf bytes.Buffer
-	reqEnc := msgpack.NewEncoder(&reqBuf)
+	reqEnc := NewEncoder(&reqBuf)
 
 	err := req.Body(&resolver, reqEnc)
 	if err != nil {
@@ -196,7 +195,7 @@ func TestRequestsCodes(t *testing.T) {
 func TestPingRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplPingBody(refEnc)
 	if err != nil {
 		t.Errorf("An unexpected RefImplPingBody() error: %q", err.Error())
@@ -210,7 +209,7 @@ func TestPingRequestDefaultValues(t *testing.T) {
 func TestSelectRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplSelectBody(refEnc, validSpace, defaultIndex, 0, 0xFFFFFFFF, IterAll, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
@@ -225,7 +224,7 @@ func TestSelectRequestDefaultIteratorEqIfKey(t *testing.T) {
 	var refBuf bytes.Buffer
 	key := []interface{}{uint(18)}
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplSelectBody(refEnc, validSpace, defaultIndex, 0, 0xFFFFFFFF, IterEq, key)
 	if err != nil {
 		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
@@ -242,7 +241,7 @@ func TestSelectRequestIteratorNotChangedIfKey(t *testing.T) {
 	key := []interface{}{uint(678)}
 	const iter = IterGe
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplSelectBody(refEnc, validSpace, defaultIndex, 0, 0xFFFFFFFF, iter, key)
 	if err != nil {
 		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
@@ -262,7 +261,7 @@ func TestSelectRequestSetters(t *testing.T) {
 	key := []interface{}{uint(36)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplSelectBody(refEnc, validSpace, validIndex, offset, limit, iter, key)
 	if err != nil {
 		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
@@ -281,7 +280,7 @@ func TestSelectRequestSetters(t *testing.T) {
 func TestInsertRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplInsertBody(refEnc, validSpace, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplInsertBody() error: %q", err.Error())
@@ -296,7 +295,7 @@ func TestInsertRequestSetters(t *testing.T) {
 	tuple := []interface{}{uint(24)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplInsertBody(refEnc, validSpace, tuple)
 	if err != nil {
 		t.Errorf("An unexpected RefImplInsertBody() error: %q", err.Error())
@@ -311,7 +310,7 @@ func TestInsertRequestSetters(t *testing.T) {
 func TestReplaceRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplReplaceBody(refEnc, validSpace, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplReplaceBody() error: %q", err.Error())
@@ -326,7 +325,7 @@ func TestReplaceRequestSetters(t *testing.T) {
 	tuple := []interface{}{uint(99)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplReplaceBody(refEnc, validSpace, tuple)
 	if err != nil {
 		t.Errorf("An unexpected RefImplReplaceBody() error: %q", err.Error())
@@ -341,7 +340,7 @@ func TestReplaceRequestSetters(t *testing.T) {
 func TestDeleteRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplDeleteBody(refEnc, validSpace, defaultIndex, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplDeleteBody() error: %q", err.Error())
@@ -356,7 +355,7 @@ func TestDeleteRequestSetters(t *testing.T) {
 	key := []interface{}{uint(923)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplDeleteBody(refEnc, validSpace, validIndex, key)
 	if err != nil {
 		t.Errorf("An unexpected RefImplDeleteBody() error: %q", err.Error())
@@ -372,7 +371,7 @@ func TestDeleteRequestSetters(t *testing.T) {
 func TestUpdateRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplUpdateBody(refEnc, validSpace, defaultIndex, []interface{}{}, []Op{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplUpdateBody() error: %q", err.Error())
@@ -388,7 +387,7 @@ func TestUpdateRequestSetters(t *testing.T) {
 	refOps, reqOps := getTestOps()
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplUpdateBody(refEnc, validSpace, validIndex, key, refOps)
 	if err != nil {
 		t.Errorf("An unexpected RefImplUpdateBody() error: %q", err.Error())
@@ -405,7 +404,7 @@ func TestUpdateRequestSetters(t *testing.T) {
 func TestUpsertRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplUpsertBody(refEnc, validSpace, []interface{}{}, []Op{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplUpsertBody() error: %q", err.Error())
@@ -421,7 +420,7 @@ func TestUpsertRequestSetters(t *testing.T) {
 	refOps, reqOps := getTestOps()
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplUpsertBody(refEnc, validSpace, tuple, refOps)
 	if err != nil {
 		t.Errorf("An unexpected RefImplUpsertBody() error: %q", err.Error())
@@ -437,7 +436,7 @@ func TestUpsertRequestSetters(t *testing.T) {
 func TestCallRequestsDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplCallBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
@@ -456,7 +455,7 @@ func TestCallRequestsSetters(t *testing.T) {
 	args := []interface{}{uint(34)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplCallBody(refEnc, validExpr, args)
 	if err != nil {
 		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
@@ -477,7 +476,7 @@ func TestCallRequestsSetters(t *testing.T) {
 func TestEvalRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplEvalBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplEvalBody() error: %q", err.Error())
@@ -492,7 +491,7 @@ func TestEvalRequestSetters(t *testing.T) {
 	args := []interface{}{uint(34), int(12)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplEvalBody(refEnc, validExpr, args)
 	if err != nil {
 		t.Errorf("An unexpected RefImplEvalBody() error: %q", err.Error())
@@ -507,7 +506,7 @@ func TestEvalRequestSetters(t *testing.T) {
 func TestExecuteRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplExecuteBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplExecuteBody() error: %q", err.Error())
@@ -522,7 +521,7 @@ func TestExecuteRequestSetters(t *testing.T) {
 	args := []interface{}{uint(11)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplExecuteBody(refEnc, validExpr, args)
 	if err != nil {
 		t.Errorf("An unexpected RefImplExecuteBody() error: %q", err.Error())
@@ -537,7 +536,7 @@ func TestExecuteRequestSetters(t *testing.T) {
 func TestPrepareRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplPrepareBody(refEnc, validExpr)
 	if err != nil {
 		t.Errorf("An unexpected RefImplPrepareBody() error: %q", err.Error())
@@ -551,7 +550,7 @@ func TestPrepareRequestDefaultValues(t *testing.T) {
 func TestUnprepareRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplUnprepareBody(refEnc, *validStmt)
 	if err != nil {
 		t.Errorf("An unexpected RefImplUnprepareBody() error: %q", err.Error())
@@ -567,7 +566,7 @@ func TestExecutePreparedRequestSetters(t *testing.T) {
 	args := []interface{}{uint(11)}
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplExecutePreparedBody(refEnc, *validStmt, args)
 	if err != nil {
 		t.Errorf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
@@ -583,7 +582,7 @@ func TestExecutePreparedRequestSetters(t *testing.T) {
 func TestExecutePreparedRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplExecutePreparedBody(refEnc, *validStmt, []interface{}{})
 	if err != nil {
 		t.Errorf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
@@ -598,7 +597,7 @@ func TestExecutePreparedRequestDefaultValues(t *testing.T) {
 func TestBeginRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplBeginBody(refEnc, defaultIsolationLevel, defaultTimeout)
 	if err != nil {
 		t.Errorf("An unexpected RefImplBeginBody() error: %q", err.Error())
@@ -612,7 +611,7 @@ func TestBeginRequestDefaultValues(t *testing.T) {
 func TestBeginRequestSetters(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplBeginBody(refEnc, ReadConfirmedLevel, validTimeout)
 	if err != nil {
 		t.Errorf("An unexpected RefImplBeginBody() error: %q", err.Error())
@@ -626,7 +625,7 @@ func TestBeginRequestSetters(t *testing.T) {
 func TestCommitRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplCommitBody(refEnc)
 	if err != nil {
 		t.Errorf("An unexpected RefImplCommitBody() error: %q", err.Error())
@@ -640,7 +639,7 @@ func TestCommitRequestDefaultValues(t *testing.T) {
 func TestRollbackRequestDefaultValues(t *testing.T) {
 	var refBuf bytes.Buffer
 
-	refEnc := msgpack.NewEncoder(&refBuf)
+	refEnc := NewEncoder(&refBuf)
 	err := RefImplRollbackBody(refEnc)
 	if err != nil {
 		t.Errorf("An unexpected RefImplRollbackBody() error: %q", err.Error())

--- a/response.go
+++ b/response.go
@@ -2,8 +2,6 @@ package tarantool
 
 import (
 	"fmt"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type Response struct {
@@ -31,7 +29,7 @@ type SQLInfo struct {
 	InfoAutoincrementIds []uint64
 }
 
-func (meta *ColumnMetaData) DecodeMsgpack(d *msgpack.Decoder) error {
+func (meta *ColumnMetaData) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeMapLen(); err != nil {
@@ -69,7 +67,7 @@ func (meta *ColumnMetaData) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (info *SQLInfo) DecodeMsgpack(d *msgpack.Decoder) error {
+func (info *SQLInfo) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeMapLen(); err != nil {
@@ -99,7 +97,7 @@ func (info *SQLInfo) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func (resp *Response) smallInt(d *msgpack.Decoder) (i int, err error) {
+func (resp *Response) smallInt(d *decoder) (i int, err error) {
 	b, err := resp.buf.ReadByte()
 	if err != nil {
 		return
@@ -111,7 +109,7 @@ func (resp *Response) smallInt(d *msgpack.Decoder) (i int, err error) {
 	return d.DecodeInt()
 }
 
-func (resp *Response) decodeHeader(d *msgpack.Decoder) (err error) {
+func (resp *Response) decodeHeader(d *decoder) (err error) {
 	var l int
 	d.Reset(&resp.buf)
 	if l, err = d.DecodeMapLen(); err != nil {
@@ -148,7 +146,9 @@ func (resp *Response) decodeBody() (err error) {
 	if resp.buf.Len() > 2 {
 		var l int
 		var stmtID, bindCount uint64
-		d := msgpack.NewDecoder(&resp.buf)
+
+		d := newDecoder(&resp.buf)
+
 		if l, err = d.DecodeMapLen(); err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func (resp *Response) decodeBody() (err error) {
 func (resp *Response) decodeBodyTyped(res interface{}) (err error) {
 	if resp.buf.Len() > 0 {
 		var l int
-		d := msgpack.NewDecoder(&resp.buf)
+		d := newDecoder(&resp.buf)
 		if l, err = d.DecodeMapLen(); err != nil {
 			return err
 		}

--- a/schema.go
+++ b/schema.go
@@ -1,7 +1,21 @@
 package tarantool
 
 import (
+	"errors"
 	"fmt"
+	"gopkg.in/vmihailenco/msgpack.v2"
+	msgpcode "gopkg.in/vmihailenco/msgpack.v2/codes"
+)
+
+//nolint: varcheck,deadcode
+const (
+	maxSchemas             = 10000
+	spaceSpId              = 280
+	vspaceSpId             = 281
+	indexSpId              = 288
+	vindexSpId             = 289
+	vspaceSpTypeFieldNum   = 6
+	vspaceSpFormatFieldNum = 7
 )
 
 // SchemaResolver is an interface for resolving schema details.
@@ -37,19 +51,218 @@ type Space struct {
 	IndexesById map[uint32]*Index
 }
 
+func isUint(code byte) bool {
+	return code == msgpcode.Uint8 || code == msgpcode.Uint16 ||
+		code == msgpcode.Uint32 || code == msgpcode.Uint64 ||
+		msgpcode.IsFixedNum(code)
+}
+
+func isMap(code byte) bool {
+	return code == msgpcode.Map16 || code == msgpcode.Map32 || msgpcode.IsFixedMap(code)
+}
+
+func isArray(code byte) bool {
+	return code == msgpcode.Array16 || code == msgpcode.Array32 ||
+		msgpcode.IsFixedArray(code)
+}
+
+func isString(code byte) bool {
+	return msgpcode.IsFixedString(code) || code == msgpcode.Str8 ||
+		code == msgpcode.Str16 || code == msgpcode.Str32
+}
+
+func (space *Space) DecodeMsgpack(d *msgpack.Decoder) error {
+	arrayLen, err := d.DecodeArrayLen()
+	if err != nil {
+		return err
+	}
+	if space.Id, err = d.DecodeUint32(); err != nil {
+		return err
+	}
+	if err := d.Skip(); err != nil {
+		return err
+	}
+	if space.Name, err = d.DecodeString(); err != nil {
+		return err
+	}
+	if space.Engine, err = d.DecodeString(); err != nil {
+		return err
+	}
+	if space.FieldsCount, err = d.DecodeUint32(); err != nil {
+		return err
+	}
+	if arrayLen >= vspaceSpTypeFieldNum {
+		code, err := d.PeekCode()
+		if err != nil {
+			return err
+		}
+		if isString(code) {
+			val, err := d.DecodeString()
+			if err != nil {
+				return err
+			}
+			space.Temporary = val == "temporary"
+		} else if isMap(code) {
+			mapLen, err := d.DecodeMapLen()
+			if err != nil {
+				return err
+			}
+			for i := 0; i < mapLen; i++ {
+				key, err := d.DecodeString()
+				if err != nil {
+					return err
+				}
+				if key == "temporary" {
+					if space.Temporary, err = d.DecodeBool(); err != nil {
+						return err
+					}
+				} else {
+					if err = d.Skip(); err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			return errors.New("unexpected schema format (space flags)")
+		}
+	}
+	space.FieldsById = make(map[uint32]*Field)
+	space.Fields = make(map[string]*Field)
+	space.IndexesById = make(map[uint32]*Index)
+	space.Indexes = make(map[string]*Index)
+	if arrayLen >= vspaceSpFormatFieldNum {
+		fieldCount, err := d.DecodeArrayLen()
+		if err != nil {
+			return err
+		}
+		for i := 0; i < fieldCount; i++ {
+			field := &Field{}
+			if err := field.DecodeMsgpack(d); err != nil {
+				return err
+			}
+			field.Id = uint32(i)
+			space.FieldsById[field.Id] = field
+			if field.Name != "" {
+				space.Fields[field.Name] = field
+			}
+		}
+	}
+	return nil
+}
+
 type Field struct {
 	Id   uint32
 	Name string
 	Type string
 }
 
+func (field *Field) DecodeMsgpack(d *msgpack.Decoder) error {
+	l, err := d.DecodeMapLen()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < l; i++ {
+		key, err := d.DecodeString()
+		if err != nil {
+			return err
+		}
+		switch key {
+		case "name":
+			if field.Name, err = d.DecodeString(); err != nil {
+				return err
+			}
+		case "type":
+			if field.Type, err = d.DecodeString(); err != nil {
+				return err
+			}
+		default:
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Index contains information about index.
 type Index struct {
-	Id     uint32
-	Name   string
-	Type   string
-	Unique bool
-	Fields []*IndexField
+	Id      uint32
+	SpaceId uint32
+	Name    string
+	Type    string
+	Unique  bool
+	Fields  []*IndexField
+}
+
+func (index *Index) DecodeMsgpack(d *msgpack.Decoder) error {
+	_, err := d.DecodeArrayLen()
+	if err != nil {
+		return err
+	}
+
+	if index.SpaceId, err = d.DecodeUint32(); err != nil {
+		return err
+	}
+	if index.Id, err = d.DecodeUint32(); err != nil {
+		return err
+	}
+	if index.Name, err = d.DecodeString(); err != nil {
+		return err
+	}
+	if index.Type, err = d.DecodeString(); err != nil {
+		return err
+	}
+
+	var code byte
+	if code, err = d.PeekCode(); err != nil {
+		return err
+	}
+
+	if isUint(code) {
+		optsUint64, err := d.DecodeUint64()
+		if err != nil {
+			return nil
+		}
+		index.Unique = optsUint64 > 0
+	} else {
+		var optsMap map[string]interface{}
+		if err := d.Decode(&optsMap); err != nil {
+			return fmt.Errorf("unexpected schema format (index flags): %w", err)
+		}
+
+		var ok bool
+		if index.Unique, ok = optsMap["unique"].(bool); !ok {
+			/* see bug https://github.com/tarantool/tarantool/issues/2060 */
+			index.Unique = true
+		}
+	}
+
+	if code, err = d.PeekCode(); err != nil {
+		return err
+	}
+
+	if isUint(code) {
+		fieldCount, err := d.DecodeUint64()
+		if err != nil {
+			return err
+		}
+		index.Fields = make([]*IndexField, fieldCount)
+		for i := 0; i < int(fieldCount); i++ {
+			index.Fields[i] = new(IndexField)
+			if index.Fields[i].Id, err = d.DecodeUint32(); err != nil {
+				return err
+			}
+			if index.Fields[i].Type, err = d.DecodeString(); err != nil {
+				return err
+			}
+		}
+	} else {
+		if err := d.Decode(&index.Fields); err != nil {
+			return fmt.Errorf("unexpected schema format (index flags): %w", err)
+		}
+	}
+
+	return nil
 }
 
 type IndexField struct {
@@ -57,128 +270,87 @@ type IndexField struct {
 	Type string
 }
 
-//nolint: varcheck,deadcode
-const (
-	maxSchemas = 10000
-	spaceSpId  = 280
-	vspaceSpId = 281
-	indexSpId  = 288
-	vindexSpId = 289
-)
+func (indexField *IndexField) DecodeMsgpack(d *msgpack.Decoder) error {
+	code, err := d.PeekCode()
+	if err != nil {
+		return err
+	}
+
+	if isMap(code) {
+		mapLen, err := d.DecodeMapLen()
+		if err != nil {
+			return err
+		}
+		for i := 0; i < mapLen; i++ {
+			key, err := d.DecodeString()
+			if err != nil {
+				return err
+			}
+			switch key {
+			case "field":
+				if indexField.Id, err = d.DecodeUint32(); err != nil {
+					return err
+				}
+			case "type":
+				if indexField.Type, err = d.DecodeString(); err != nil {
+					return err
+				}
+			default:
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	} else if isArray(code) {
+		arrayLen, err := d.DecodeArrayLen()
+		if err != nil {
+			return err
+		}
+		if indexField.Id, err = d.DecodeUint32(); err != nil {
+			return err
+		}
+		if indexField.Type, err = d.DecodeString(); err != nil {
+			return err
+		}
+		for i := 2; i < arrayLen; i++ {
+			if err := d.Skip(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return errors.New("unexpected schema format (index fields)")
+}
 
 func (conn *Connection) loadSchema() (err error) {
-	var resp *Response
-
 	schema := new(Schema)
 	schema.SpacesById = make(map[uint32]*Space)
 	schema.Spaces = make(map[string]*Space)
 
 	// Reload spaces.
-	resp, err = conn.Select(vspaceSpId, 0, 0, maxSchemas, IterAll, []interface{}{})
+	var spaces []*Space
+	err = conn.SelectTyped(vspaceSpId, 0, 0, maxSchemas, IterAll, []interface{}{}, &spaces)
 	if err != nil {
 		return err
 	}
-	for _, row := range resp.Data {
-		row := row.([]interface{})
-		space := new(Space)
-		space.Id = uint32(row[0].(uint64))
-		space.Name = row[2].(string)
-		space.Engine = row[3].(string)
-		space.FieldsCount = uint32(row[4].(uint64))
-		if len(row) >= 6 {
-			switch row5 := row[5].(type) {
-			case string:
-				space.Temporary = row5 == "temporary"
-			case map[interface{}]interface{}:
-				if temp, ok := row5["temporary"]; ok {
-					space.Temporary = temp.(bool)
-				}
-			default:
-				panic("unexpected schema format (space flags)")
-			}
-		}
-		space.FieldsById = make(map[uint32]*Field)
-		space.Fields = make(map[string]*Field)
-		space.IndexesById = make(map[uint32]*Index)
-		space.Indexes = make(map[string]*Index)
-		if len(row) >= 7 {
-			for i, f := range row[6].([]interface{}) {
-				if f == nil {
-					continue
-				}
-				f := f.(map[interface{}]interface{})
-				field := new(Field)
-				field.Id = uint32(i)
-				if name, ok := f["name"]; ok && name != nil {
-					field.Name = name.(string)
-				}
-				if type1, ok := f["type"]; ok && type1 != nil {
-					field.Type = type1.(string)
-				}
-				space.FieldsById[field.Id] = field
-				if field.Name != "" {
-					space.Fields[field.Name] = field
-				}
-			}
-		}
-
+	for _, space := range spaces {
 		schema.SpacesById[space.Id] = space
 		schema.Spaces[space.Name] = space
 	}
 
 	// Reload indexes.
-	resp, err = conn.Select(vindexSpId, 0, 0, maxSchemas, IterAll, []interface{}{})
+	var indexes []*Index
+	err = conn.SelectTyped(vindexSpId, 0, 0, maxSchemas, IterAll, []interface{}{}, &indexes)
 	if err != nil {
 		return err
 	}
-	for _, row := range resp.Data {
-		row := row.([]interface{})
-		index := new(Index)
-		index.Id = uint32(row[1].(uint64))
-		index.Name = row[2].(string)
-		index.Type = row[3].(string)
-		switch row[4].(type) {
-		case uint64:
-			index.Unique = row[4].(uint64) > 0
-		case map[interface{}]interface{}:
-			opts := row[4].(map[interface{}]interface{})
-			var ok bool
-			if index.Unique, ok = opts["unique"].(bool); !ok {
-				/* See bug https://github.com/tarantool/tarantool/issues/2060. */
-				index.Unique = true
-			}
-		default:
-			panic("unexpected schema format (index flags)")
-		}
-		switch fields := row[5].(type) {
-		case uint64:
-			cnt := int(fields)
-			for i := 0; i < cnt; i++ {
-				field := new(IndexField)
-				field.Id = uint32(row[6+i*2].(uint64))
-				field.Type = row[7+i*2].(string)
-				index.Fields = append(index.Fields, field)
-			}
-		case []interface{}:
-			for _, f := range fields {
-				field := new(IndexField)
-				switch f := f.(type) {
-				case []interface{}:
-					field.Id = uint32(f[0].(uint64))
-					field.Type = f[1].(string)
-				case map[interface{}]interface{}:
-					field.Id = uint32(f["field"].(uint64))
-					field.Type = f["type"].(string)
-				}
-				index.Fields = append(index.Fields, field)
-			}
-		default:
-			panic("unexpected schema format (index fields)")
-		}
-		spaceId := uint32(row[0].(uint64))
-		schema.SpacesById[spaceId].IndexesById[index.Id] = index
-		schema.SpacesById[spaceId].Indexes[index.Name] = index
+	for _, index := range indexes {
+		schema.SpacesById[index.SpaceId].IndexesById[index.Id] = index
+		schema.SpacesById[index.SpaceId].Indexes[index.Name] = index
 	}
+
 	conn.Schema = schema
 	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -46,7 +46,7 @@ func fillBegin(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout tim
 	}
 
 	if hasTimeout {
-		err = enc.EncodeUint64(KeyTimeout)
+		err = enc.EncodeUint(KeyTimeout)
 		if err != nil {
 			return err
 		}

--- a/stream.go
+++ b/stream.go
@@ -44,7 +44,7 @@ func fillBegin(enc *encoder, txnIsolation TxnIsolationLevel, timeout time.Durati
 	}
 
 	if hasTimeout {
-		err = enc.EncodeUint(KeyTimeout)
+		err = encodeUint(enc, KeyTimeout)
 		if err != nil {
 			return err
 		}
@@ -56,12 +56,12 @@ func fillBegin(enc *encoder, txnIsolation TxnIsolationLevel, timeout time.Durati
 	}
 
 	if hasIsolationLevel {
-		err = enc.EncodeUint(KeyTxnIsolation)
+		err = encodeUint(enc, KeyTxnIsolation)
 		if err != nil {
 			return err
 		}
 
-		err = enc.Encode(txnIsolation)
+		err = encodeUint(enc, uint64(txnIsolation))
 		if err != nil {
 			return err
 		}

--- a/stream.go
+++ b/stream.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type TxnIsolationLevel uint
@@ -29,7 +27,7 @@ type Stream struct {
 	Conn *Connection
 }
 
-func fillBegin(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
+func fillBegin(enc *encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
 	hasTimeout := timeout > 0
 	hasIsolationLevel := txnIsolation != DefaultIsolationLevel
 	mapLen := 0
@@ -72,11 +70,11 @@ func fillBegin(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout tim
 	return err
 }
 
-func fillCommit(enc *msgpack.Encoder) error {
+func fillCommit(enc *encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
-func fillRollback(enc *msgpack.Encoder) error {
+func fillRollback(enc *encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
@@ -111,7 +109,7 @@ func (req *BeginRequest) Timeout(timeout time.Duration) *BeginRequest {
 }
 
 // Body fills an encoder with the begin request body.
-func (req *BeginRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *BeginRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillBegin(enc, req.txnIsolation, req.timeout)
 }
 
@@ -141,7 +139,7 @@ func NewCommitRequest() *CommitRequest {
 }
 
 // Body fills an encoder with the commit request body.
-func (req *CommitRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *CommitRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillCommit(enc)
 }
 
@@ -171,7 +169,7 @@ func NewRollbackRequest() *RollbackRequest {
 }
 
 // Body fills an encoder with the rollback request body.
-func (req *RollbackRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req *RollbackRequest) Body(res SchemaResolver, enc *encoder) error {
 	return fillRollback(enc)
 }
 

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -32,7 +32,7 @@ func (m *Member) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeString(m.Name); err != nil {
 		return err
 	}
-	if err := e.EncodeUint(m.Val); err != nil {
+	if err := encodeUint(e, uint64(m.Val)); err != nil {
 		return err
 	}
 	return nil

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	. "github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/test_helpers"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type Member struct {
@@ -26,7 +25,7 @@ type Member struct {
 	Val   uint
 }
 
-func (m *Member) EncodeMsgpack(e *msgpack.Encoder) error {
+func (m *Member) EncodeMsgpack(e *encoder) error {
 	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
@@ -39,7 +38,7 @@ func (m *Member) EncodeMsgpack(e *msgpack.Encoder) error {
 	return nil
 }
 
-func (m *Member) DecodeMsgpack(d *msgpack.Decoder) error {
+func (m *Member) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -27,7 +27,7 @@ type Member struct {
 }
 
 func (m *Member) EncodeMsgpack(e *msgpack.Encoder) error {
-	if err := e.EncodeSliceLen(2); err != nil {
+	if err := e.EncodeArrayLen(2); err != nil {
 		return err
 	}
 	if err := e.EncodeString(m.Name); err != nil {
@@ -42,7 +42,7 @@ func (m *Member) EncodeMsgpack(e *msgpack.Encoder) error {
 func (m *Member) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 2 {

--- a/test_helpers/msgpack.go
+++ b/test_helpers/msgpack.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package test_helpers
 
 import (

--- a/test_helpers/msgpack.go
+++ b/test_helpers/msgpack.go
@@ -1,0 +1,7 @@
+package test_helpers
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder

--- a/test_helpers/msgpack_v5.go
+++ b/test_helpers/msgpack_v5.go
@@ -1,0 +1,10 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package test_helpers
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type encoder = msgpack.Encoder

--- a/test_helpers/request_mock.go
+++ b/test_helpers/request_mock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/tarantool/go-tarantool"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type StrangerRequest struct {
@@ -18,7 +17,7 @@ func (sr *StrangerRequest) Code() int32 {
 	return 0
 }
 
-func (sr *StrangerRequest) Body(resolver tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (sr *StrangerRequest) Body(resolver tarantool.SchemaResolver, enc *encoder) error {
 	return nil
 }
 

--- a/uuid/msgpack.go
+++ b/uuid/msgpack.go
@@ -1,0 +1,16 @@
+package uuid
+
+import (
+	"reflect"
+
+	"github.com/google/uuid"
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder
+
+func init() {
+	msgpack.Register(reflect.TypeOf((*uuid.UUID)(nil)).Elem(), encodeUUID, decodeUUID)
+	msgpack.RegisterExt(UUID_extId, (*uuid.UUID)(nil))
+}

--- a/uuid/msgpack.go
+++ b/uuid/msgpack.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package uuid
 
 import (

--- a/uuid/msgpack_helper_test.go
+++ b/uuid/msgpack_helper_test.go
@@ -1,0 +1,7 @@
+package uuid_test
+
+import (
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type decoder = msgpack.Decoder

--- a/uuid/msgpack_helper_test.go
+++ b/uuid/msgpack_helper_test.go
@@ -1,3 +1,6 @@
+//go:build !go_tarantool_msgpack_v5
+// +build !go_tarantool_msgpack_v5
+
 package uuid_test
 
 import (

--- a/uuid/msgpack_v5.go
+++ b/uuid/msgpack_v5.go
@@ -1,0 +1,27 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package uuid
+
+import (
+	"reflect"
+
+	"github.com/google/uuid"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type encoder = msgpack.Encoder
+type decoder = msgpack.Decoder
+
+func init() {
+	msgpack.Register(reflect.TypeOf((*uuid.UUID)(nil)).Elem(), encodeUUID, decodeUUID)
+	msgpack.RegisterExtEncoder(UUID_extId, uuid.UUID{},
+		func(e *msgpack.Encoder, v reflect.Value) ([]byte, error) {
+			uuid := v.Interface().(uuid.UUID)
+			return uuid.MarshalBinary()
+		})
+	msgpack.RegisterExtDecoder(UUID_extId, uuid.UUID{},
+		func(d *msgpack.Decoder, v reflect.Value, extLen int) error {
+			return decodeUUID(d, v)
+		})
+}

--- a/uuid/msgpack_v5_helper_test.go
+++ b/uuid/msgpack_v5_helper_test.go
@@ -1,0 +1,10 @@
+//go:build go_tarantool_msgpack_v5
+// +build go_tarantool_msgpack_v5
+
+package uuid_test
+
+import (
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type decoder = msgpack.Decoder

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -18,13 +18,12 @@ import (
 	"reflect"
 
 	"github.com/google/uuid"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // UUID external type.
 const UUID_extId = 2
 
-func encodeUUID(e *msgpack.Encoder, v reflect.Value) error {
+func encodeUUID(e *encoder, v reflect.Value) error {
 	id := v.Interface().(uuid.UUID)
 
 	bytes, err := id.MarshalBinary()
@@ -40,7 +39,7 @@ func encodeUUID(e *msgpack.Encoder, v reflect.Value) error {
 	return nil
 }
 
-func decodeUUID(d *msgpack.Decoder, v reflect.Value) error {
+func decodeUUID(d *decoder, v reflect.Value) error {
 	var bytesCount int = 16
 	bytes := make([]byte, bytesCount)
 
@@ -59,9 +58,4 @@ func decodeUUID(d *msgpack.Decoder, v reflect.Value) error {
 
 	v.Set(reflect.ValueOf(id))
 	return nil
-}
-
-func init() {
-	msgpack.Register(reflect.TypeOf((*uuid.UUID)(nil)).Elem(), encodeUUID, decodeUUID)
-	msgpack.RegisterExt(UUID_extId, (*uuid.UUID)(nil))
 }

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/test_helpers"
 	_ "github.com/tarantool/go-tarantool/uuid"
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 // There is no way to skip tests in testing.M,
@@ -33,7 +32,7 @@ type TupleUUID struct {
 	id uuid.UUID
 }
 
-func (t *TupleUUID) DecodeMsgpack(d *msgpack.Decoder) error {
+func (t *TupleUUID) DecodeMsgpack(d *decoder) error {
 	var err error
 	var l int
 	if l, err = d.DecodeArrayLen(); err != nil {

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -36,7 +36,7 @@ type TupleUUID struct {
 func (t *TupleUUID) DecodeMsgpack(d *msgpack.Decoder) error {
 	var err error
 	var l int
-	if l, err = d.DecodeSliceLen(); err != nil {
+	if l, err = d.DecodeArrayLen(); err != nil {
 		return err
 	}
 	if l != 1 {


### PR DESCRIPTION
I found incompatibilities between msgpack.v2 and msgpack.v5 which affect our code:

1. EncodeUint64/EncodeInt64 logic:
[msgpack.v2](https://github.com/vmihailenco/msgpack/blob/5c8f1fd660437f13fb81d5551a281650ad3e2d55/encode_number.go#L26)
[msgpack.v5](https://github.com/vmihailenco/msgpack/blob/233c977ae92b215a9aa7eb420bbe67da99f05ab6/encode_number.go#L47)

2. EncodeInt/EncodeUint signature:
https://pkg.go.dev/github.com/vmihailenco/msgpack@v2.9.2+incompatible#Encoder.EncodeUint
https://pkg.go.dev/github.com/vmihailenco/msgpack@v2.9.2+incompatible#Encoder.EncodeInt
https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Encoder.EncodeUint
https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#Encoder.EncodeInt

3. RegisterExt logic and signature:
[msgpack.v2](https://pkg.go.dev/github.com/vmihailenco/msgpack@v2.9.2+incompatible#RegisterExt)
[msgpack.v5](https://pkg.go.dev/github.com/vmihailenco/msgpack/v5#RegisterExt)

4. Decode Map logic:
https://github.com/vmihailenco/msgpack/issues/327/
https://msgpack.uptrace.dev/guide/#decoding-maps-into-an-interface/

5. Decode numbers logic:
[msgpack.v2](https://github.com/vmihailenco/msgpack/blob/5c8f1fd660437f13fb81d5551a281650ad3e2d55/decode.go#L273)
[msgpack.v5](https://github.com/vmihailenco/msgpack/blob/233c977ae92b215a9aa7eb420bbe67da99f05ab6/decode.go#L401)

Most of the problems can be solved easily and do not affect a `go-tarantool` clients code (1, 2, 3, 4), but it is impossible to get the same decoding logic for all cases (5). The changes will break the client code.

The pull request solves problems for the `go-tarantool` code and  provide `msgpack.v5` as an option for the current version. In the future, `msgpack.v5` may be used by default.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #124