### PR TITLE
sql: support prepared statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - Build with OpenSSL < 1.1.1 (#194)
+- Add `ExecuteAsync` and `ExecuteTyped` to common connector interface (#62)
 
 ## [1.6.0] - 2022-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Public API with request object types (#126)
 - Support decimal type in msgpack (#96)
 - Support datetime type in msgpack (#118)
+- Prepared SQL statements (#117)
 
 ### Changed
 

--- a/connection_pool/config.lua
+++ b/connection_pool/config.lua
@@ -21,6 +21,21 @@ box.once("init", function()
         parts = {{ field = 1, type = 'string' }},
         if_not_exists = true
     })
+
+    local sp = box.schema.space.create('SQL_TEST', {
+        id = 521,
+        if_not_exists = true,
+        format = {
+            {name = "NAME0", type = "unsigned"},
+            {name = "NAME1", type = "string"},
+            {name = "NAME2", type = "string"},
+        }
+    })
+    sp:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
+    sp:insert{1, "test", "test"}
+    -- grants for sql tests
+    box.schema.user.grant('test', 'create,read,write,drop,alter', 'space')
+    box.schema.user.grant('test', 'create', 'sequence')
 end)
 
 local function simple_incr(a)

--- a/connection_pool/example_test.go
+++ b/connection_pool/example_test.go
@@ -548,3 +548,28 @@ func ExampleConnectionPool_Do() {
 	// Ping Data []
 	// Ping Error <nil>
 }
+
+func ExampleConnectionPool_NewPrepared() {
+	pool, err := examplePool(testRoles)
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer pool.Close()
+
+	stmt, err := pool.NewPrepared("SELECT 1", connection_pool.ANY)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	executeReq := tarantool.NewExecutePreparedRequest(stmt)
+	unprepareReq := tarantool.NewUnprepareRequest(stmt)
+
+	_, err = pool.Do(executeReq, connection_pool.ANY).Get()
+	if err != nil {
+		fmt.Printf("Failed to execute prepared stmt")
+	}
+	_, err = pool.Do(unprepareReq, connection_pool.ANY).Get()
+	if err != nil {
+		fmt.Printf("Failed to prepare")
+	}
+}

--- a/connector.go
+++ b/connector.go
@@ -30,6 +30,7 @@ type Connector interface {
 	Call16Typed(functionName string, args interface{}, result interface{}) (err error)
 	Call17Typed(functionName string, args interface{}, result interface{}) (err error)
 	EvalTyped(expr string, args interface{}, result interface{}) (err error)
+	ExecuteTyped(expr string, args interface{}, result interface{}) (SQLInfo, []ColumnMetaData, error)
 
 	SelectAsync(space, index interface{}, offset, limit, iterator uint32, key interface{}) *Future
 	InsertAsync(space interface{}, tuple interface{}) *Future
@@ -41,6 +42,7 @@ type Connector interface {
 	Call16Async(functionName string, args interface{}) *Future
 	Call17Async(functionName string, args interface{}) *Future
 	EvalAsync(expr string, args interface{}) *Future
+	ExecuteAsync(expr string, args interface{}) *Future
 
 	Do(req Request) (fut *Future)
 }

--- a/connector.go
+++ b/connector.go
@@ -44,5 +44,7 @@ type Connector interface {
 	EvalAsync(expr string, args interface{}) *Future
 	ExecuteAsync(expr string, args interface{}) *Future
 
+	NewPrepared(expr string) (*Prepared, error)
+
 	Do(req Request) (fut *Future)
 }

--- a/const.go
+++ b/const.go
@@ -12,6 +12,7 @@ const (
 	UpsertRequestCode    = 9
 	Call17RequestCode    = 10 /* call in >= 1.7 format */
 	ExecuteRequestCode   = 11
+	PrepareRequestCode   = 13
 	PingRequestCode      = 64
 	SubscribeRequestCode = 66
 
@@ -31,9 +32,11 @@ const (
 	KeyData         = 0x30
 	KeyError        = 0x31
 	KeyMetaData     = 0x32
+	KeyBindCount    = 0x34
 	KeySQLText      = 0x40
 	KeySQLBind      = 0x41
 	KeySQLInfo      = 0x42
+	KeyStmtID       = 0x43
 
 	KeyFieldName               = 0x00
 	KeyFieldType               = 0x01

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,6 @@
 package tarantool
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Error is wrapper around error returned by Tarantool.
 type Error struct {

--- a/example_test.go
+++ b/example_test.go
@@ -651,3 +651,43 @@ func ExampleConnection_Execute() {
 	fmt.Println("MetaData", resp.MetaData)
 	fmt.Println("SQL Info", resp.SQLInfo)
 }
+
+// To use prepared statements to query a tarantool instance, call NewPrepared.
+func ExampleConnection_NewPrepared() {
+	// Tarantool supports SQL since version 2.0.0
+	isLess, err := test_helpers.IsTarantoolVersionLess(2, 0, 0)
+	if err != nil || isLess {
+		return
+	}
+
+	server := "127.0.0.1:3013"
+	opts := tarantool.Opts{
+		Timeout:       500 * time.Millisecond,
+		Reconnect:     1 * time.Second,
+		MaxReconnects: 3,
+		User:          "test",
+		Pass:          "test",
+	}
+	conn, err := tarantool.Connect(server, opts)
+	if err != nil {
+		fmt.Printf("Failed to connect: %s", err.Error())
+	}
+
+	stmt, err := conn.NewPrepared("SELECT 1")
+	if err != nil {
+		fmt.Printf("Failed to connect: %s", err.Error())
+	}
+
+	executeReq := tarantool.NewExecutePreparedRequest(stmt)
+	unprepareReq := tarantool.NewUnprepareRequest(stmt)
+
+	_, err = conn.Do(executeReq).Get()
+	if err != nil {
+		fmt.Printf("Failed to execute prepared stmt")
+	}
+
+	_, err = conn.Do(unprepareReq).Get()
+	if err != nil {
+		fmt.Printf("Failed to prepare")
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -75,3 +75,21 @@ func RefImplEvalBody(enc *msgpack.Encoder, expr string, args interface{}) error 
 func RefImplExecuteBody(enc *msgpack.Encoder, expr string, args interface{}) error {
 	return fillExecute(enc, expr, args)
 }
+
+// RefImplPrepareBody is reference implementation for filling of an prepare
+// request's body.
+func RefImplPrepareBody(enc *msgpack.Encoder, expr string) error {
+	return fillPrepare(enc, expr)
+}
+
+// RefImplUnprepareBody is reference implementation for filling of an execute prepared
+// request's body.
+func RefImplExecutePreparedBody(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
+	return fillExecutePrepared(enc, stmt, args)
+}
+
+// RefImplUnprepareBody is reference implementation for filling of an unprepare
+// request's body.
+func RefImplUnprepareBody(enc *msgpack.Encoder, stmt Prepared) error {
+	return fillUnprepare(enc, stmt)
+}

--- a/multi/config.lua
+++ b/multi/config.lua
@@ -13,6 +13,21 @@ rawset(_G, 'get_cluster_nodes', get_cluster_nodes)
 box.once("init", function()
     box.schema.user.create('test', { password = 'test' })
     box.schema.user.grant('test', 'read,write,execute', 'universe')
+
+    local sp = box.schema.space.create('SQL_TEST', {
+        id = 521,
+        if_not_exists = true,
+        format = {
+            {name = "NAME0", type = "unsigned"},
+            {name = "NAME1", type = "string"},
+            {name = "NAME2", type = "string"},
+        }
+    })
+    sp:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
+    sp:insert{1, "test", "test"}
+    -- grants for sql tests
+    box.schema.user.grant('test', 'create,read,write,drop,alter', 'space')
+    box.schema.user.grant('test', 'create', 'sequence')
 end)
 
 local function simple_incr(a)

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -419,6 +419,11 @@ func (connMulti *ConnectionMulti) EvalTyped(expr string, args interface{}, resul
 	return connMulti.getCurrentConnection().EvalTyped(expr, args, result)
 }
 
+// ExecuteTyped passes sql expression to Tarantool for execution.
+func (connMulti *ConnectionMulti) ExecuteTyped(expr string, args interface{}, result interface{}) (tarantool.SQLInfo, []tarantool.ColumnMetaData, error) {
+	return connMulti.getCurrentConnection().ExecuteTyped(expr, args, result)
+}
+
 // SelectAsync sends select request to Tarantool and returns Future.
 func (connMulti *ConnectionMulti) SelectAsync(space, index interface{}, offset, limit, iterator uint32, key interface{}) *tarantool.Future {
 	return connMulti.getCurrentConnection().SelectAsync(space, index, offset, limit, iterator, key)
@@ -480,6 +485,11 @@ func (connMulti *ConnectionMulti) Call17Async(functionName string, args interfac
 // EvalAsync passes Lua expression for evaluation.
 func (connMulti *ConnectionMulti) EvalAsync(expr string, args interface{}) *tarantool.Future {
 	return connMulti.getCurrentConnection().EvalAsync(expr, args)
+}
+
+// ExecuteAsync passes sql expression to Tarantool for execution.
+func (connMulti *ConnectionMulti) ExecuteAsync(expr string, args interface{}) *tarantool.Future {
+	return connMulti.getCurrentConnection().ExecuteAsync(expr, args)
 }
 
 // Do sends the request and returns a future.

--- a/prepared.go
+++ b/prepared.go
@@ -1,0 +1,138 @@
+package tarantool
+
+import (
+	"fmt"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+// PreparedID is a type for Prepared Statement ID
+type PreparedID uint64
+
+// Prepared is a type for handling prepared statements
+//
+// Since 1.7.0
+type Prepared struct {
+	StatementID PreparedID
+	MetaData    []ColumnMetaData
+	ParamCount  uint64
+	Conn        *Connection
+}
+
+// NewPreparedFromResponse constructs a Prepared object.
+func NewPreparedFromResponse(conn *Connection, resp *Response) (*Prepared, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("pased nil response")
+	}
+	if resp.Data == nil {
+		return nil, fmt.Errorf("response Data is nil")
+	}
+	if len(resp.Data) == 0 {
+		return nil, fmt.Errorf("response Data format is wrong")
+	}
+	stmt, ok := resp.Data[0].(*Prepared)
+	if !ok {
+		return nil, fmt.Errorf("response Data format is wrong")
+	}
+	stmt.Conn = conn
+	return stmt, nil
+}
+
+// PrepareRequest helps you to create a prepare request object for execution
+// by a Connection.
+type PrepareRequest struct {
+	baseRequest
+	expr string
+}
+
+// NewPrepareRequest returns a new empty PrepareRequest.
+func NewPrepareRequest(expr string) *PrepareRequest {
+	req := new(PrepareRequest)
+	req.requestCode = PrepareRequestCode
+	req.expr = expr
+	return req
+}
+
+// Body fills an encoder with the execute request body.
+func (req *PrepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillPrepare(enc, req.expr)
+}
+
+// UnprepareRequest helps you to create an unprepare request object for
+// execution by a Connection.
+type UnprepareRequest struct {
+	baseRequest
+	stmt *Prepared
+}
+
+// NewUnprepareRequest returns a new empty UnprepareRequest.
+func NewUnprepareRequest(stmt *Prepared) *UnprepareRequest {
+	req := new(UnprepareRequest)
+	req.requestCode = PrepareRequestCode
+	req.stmt = stmt
+	return req
+}
+
+// Conn returns the Connection object the request belongs to
+func (req *UnprepareRequest) Conn() *Connection {
+	return req.stmt.Conn
+}
+
+// Body fills an encoder with the execute request body.
+func (req *UnprepareRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillUnprepare(enc, *req.stmt)
+}
+
+// ExecutePreparedRequest helps you to create an execute prepared request
+// object for execution by a Connection.
+type ExecutePreparedRequest struct {
+	baseRequest
+	stmt *Prepared
+	args interface{}
+}
+
+// NewExecutePreparedRequest returns a new empty preparedExecuteRequest.
+func NewExecutePreparedRequest(stmt *Prepared) *ExecutePreparedRequest {
+	req := new(ExecutePreparedRequest)
+	req.requestCode = ExecuteRequestCode
+	req.stmt = stmt
+	req.args = []interface{}{}
+	return req
+}
+
+// Conn returns the Connection object the request belongs to
+func (req *ExecutePreparedRequest) Conn() *Connection {
+	return req.stmt.Conn
+}
+
+// Args sets the args for execute the prepared request.
+// Note: default value is empty.
+func (req *ExecutePreparedRequest) Args(args interface{}) *ExecutePreparedRequest {
+	req.args = args
+	return req
+}
+
+// Body fills an encoder with the execute request body.
+func (req *ExecutePreparedRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillExecutePrepared(enc, *req.stmt, req.args)
+}
+
+func fillPrepare(enc *msgpack.Encoder, expr string) error {
+	enc.EncodeMapLen(1)
+	enc.EncodeUint64(KeySQLText)
+	return enc.EncodeString(expr)
+}
+
+func fillUnprepare(enc *msgpack.Encoder, stmt Prepared) error {
+	enc.EncodeMapLen(1)
+	enc.EncodeUint64(KeyStmtID)
+	return enc.EncodeUint64(uint64(stmt.StatementID))
+}
+
+func fillExecutePrepared(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
+	enc.EncodeMapLen(2)
+	enc.EncodeUint64(KeyStmtID)
+	enc.EncodeUint64(uint64(stmt.StatementID))
+	enc.EncodeUint64(KeySQLBind)
+	return encodeSQLBind(enc, args)
+}

--- a/request.go
+++ b/request.go
@@ -539,6 +539,14 @@ type Request interface {
 	Body(resolver SchemaResolver, enc *msgpack.Encoder) error
 }
 
+// ConnectedRequest is an interface that provides the info about a Connection
+// the request belongs to.
+type ConnectedRequest interface {
+	Request
+	// Conn returns a Connection the request belongs to.
+	Conn() *Connection
+}
+
 type baseRequest struct {
 	requestCode int32
 }

--- a/test_helpers/request_mock.go
+++ b/test_helpers/request_mock.go
@@ -1,0 +1,25 @@
+package test_helpers
+
+import (
+	"github.com/tarantool/go-tarantool"
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type StrangerRequest struct {
+}
+
+func NewStrangerRequest() *StrangerRequest {
+	return &StrangerRequest{}
+}
+
+func (sr *StrangerRequest) Code() int32 {
+	return 0
+}
+
+func (sr *StrangerRequest) Body(resolver tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+	return nil
+}
+
+func (sr *StrangerRequest) Conn() *tarantool.Connection {
+	return &tarantool.Connection{}
+}

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -23,3 +23,16 @@ func ConnectWithValidation(t testing.TB,
 	}
 	return conn
 }
+
+func SkipIfSQLUnsupported(t testing.TB) {
+	t.Helper()
+
+	// Tarantool supports SQL since version 2.0.0
+	isLess, err := IsTarantoolVersionLess(2, 0, 0)
+	if err != nil {
+		t.Fatalf("Could not check the Tarantool version")
+	}
+	if isLess {
+		t.Skip()
+	}
+}


### PR DESCRIPTION
## What has been done? Why? What problem is being solved?
This patch adds the support of prepared statements.
Added a new type for handling prepared statements.
Added new methods for connector's interface in connector.go.
Added new IPROTO-constants for support of prepared statements
in const.go. Updated multi-package for corresponding it to connector's
interface.

Added a new function for checking the count of prepared statements in
config.lua in tests for Prepare and Unprepare.
Added benchmarks for SQL-select prepared statement.
Added examples of using Prepare in example_test.go.
Fixed some grammar inconsistencies for the method Execute.
Updated CHANGELOG.md.
## I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

## Related issues:

Follows up #62
Closes #117

# Considered variants of API

## v1

Prepared Statement is just an object only having a constructor.
All requests get constructed with request objects.

Single connection usage:
```go
    conn, err := tarantool.Connect(server, opts)
	
    prepareReq := tarantool.NewPrepareRequest("SQL statement")
    prepareResp, err := conn.Do(prepareReq).Get()

    stmt := tarantool.NewPreparedStatement(conn, prepareResp)
	
    execPreparedReq := tarantool.NewPreparedExecuteRequest(stmt).Args([]interface{}{1, "test"})
    unprepareReq := tarantool.NewUnprepareRequest(stmt)
	
    resp, err = conn.Do(execPreparedReq).Get()
    resp, err = conn.Do(unprepareReq).Get()
```

For connection pool it is complicated to use without any method that returns
a connection from pool explicitly.

Consider the example:

```go
    pool, err := examplePool(Roles)
	
    preapreReq := tarantool.NewPrepareRequest("SELECT 1")
    prepareResp, err := pool.Do(preapreReq, connection_pool.ANY).Get()
	
	// We cannot know what for a connection is used to prepare a statement.
	// There is need to save it anywhere, the response object is not suited
	// cause it is an object that returns only after synchronous call .Get()
	// so it breaks the scenario of using Future objects
	
    stmt := connection_pool.NewPreparedStatement(pool, prepareResp)
	
    execPreparedReq := tarantool.NewPreparedExecuteRequest(stmt).Args([]interface{}{1, "test"})
    unprepareReq := tarantool.NewUnprepareRequest(stmt)

    resp, err := pool.Do(execPreparedReq, connection_pool.ANY).Get()
    resp, err := pool.Do(unprepareReq, connection_pool.ANY).Get()
```

Implementation:

```go
type PreparedStatement struct {
    StatementID PreparedStatementID
    MetaData    []ColumnMetaData
    ParamCount  uint64
    Conn        *Connection
}

func NewPreparedStatement(conn *Connection, resp *Response) *PreparedStatement {
    stmt := new(PreparedStatement)
    stmt.Conn = conn
    stmt.ParamCount = resp.BindCount
    stmt.MetaData = resp.MetaData
    stmt.StatementID = PreparedStatementID(resp.StmtID)
    return stmt
}
```

Advantages:
- unified approach to all requests
- extendable (context support is easy to provide)

Disadvantages:
- tonnes of code
- a lot of preparation
- need to workaround connection_pool problem

## v2

Prepared Statement object is mapped from lua interface 
with specific extensions for connectors interface.
It has own methods for execute and unprepare actions.

Connector interface:
```go
type Connector interface {
    ...
    Prepare(expr string) (stmt *PreparedStatement, err error)
    PrepareAsync(expr string) *PreparedStatement
    Do(req Request) (fut *Future)
    ...
}
```

Single connection usage:
```go
    client, err := tarantool.Connect(server, opts)
	// pass a query to prepare
    stmtResp, err := client.Prepare("SELECT id FROM SQL_TEST WHERE id=? AND name=?")
	// pass the id of the statement to Execute
    resp, err := stmtResp.Execute([]interface{}{1, "test_1"})
	// use the same object for execute with other arguments
    resp, err = stmtResp.Execute([]interface{}{2, "test_2"})
```

Connection pool usage:
```go
    pool, err := examplePool(Roles)
    // pass a query to prepare
    stmtResp, err := pool.Prepare("SELECT id FROM SQL_TEST WHERE id=? AND name=?")
    // pass the id of the statement to Execute
    resp, err := stmtResp.Execute([]interface{}{1, "test_1"})
    // use the same object for execute with other arguments
    resp, err = stmtResp.Execute([]interface{}{2, "test_2"})
```

Implementation:

`request.go`:
```go
type PreparedStatement struct {
    StatementID PreparedStatementID
    MetaData    []ColumnMetaData
    ParamCount  uint64
    conn        *Connection
    fut         *Future
}

func newPreparedStatement(fut *Future, conn *Connection) *PreparedStatement {
    stmt := new(PreparedStatement)
    stmt.fut = fut
    stmt.conn = conn
    return stmt
}

// wait until the prepared statement is ready and fill the statement object
func (stmt *PreparedStatement) wait() error {
    resp, err := stmt.fut.Get()
    stmt.StatementID = PreparedStatementID(resp.StmtID)
    stmt.MetaData = resp.MetaData
    stmt.ParamCount = resp.BindCount
    return err
}

// UnprepareAsync sends an undo request and returns Future
func (stmt *PreparedStatement) UnprepareAsync() *Future {
    err := stmt.wait()
    if err != nil {
        errFut := &Future{err: err}
        return errFut
    }
    req := newUnprepareRequest(*stmt)
    fut := stmt.conn.Do(req)
    return fut
}

// Unprepare undo the prepared statement
func (stmt *PreparedStatement) Unprepare() (resp *Response, err error) {
    return stmt.UnprepareAsync().Get()
}

// ExecuteAsync sends the prepared SQL statement for execution and returns Future
func (stmt *PreparedStatement) ExecuteAsync(args interface{}) *Future {
    err := stmt.wait()
    if err != nil {
        errFut := &Future{err: err}
        return errFut
    }
    req := newPreparedExecuteRequest(*stmt)
    req.Args(args)
    fut := stmt.conn.Do(req)
    return fut
}

// Execute sends the prepared SQL statement for execution
func (stmt *PreparedStatement) Execute(args interface{}) (resp *Response, err error) {
    return stmt.ExecuteAsync(args).Get()
}
```

`connection.go`:
```go
func (conn *Connection) PrepareAsync(expr string) *PreparedStatement {
    req := newPrepareRequest(expr)
    fut := conn.Do(req)
    stmt := newPreparedStatement(fut, conn)
    return stmt
}

func (conn *Connection) Prepare(expr string) (stmt *PreparedStatement, err error) {
    stmt = conn.PrepareAsync(expr)
    err = stmt.wait()
    return stmt, err
}

```

Advantages;
- less code for use
- expressive
- pretty close to Lua api
- easy to solve connection_pool problem

Disadvantages:
- inconsistent API
- looks more difficult to extend it (for context support we need to bring more inconsistency to API - very BAD)
- not using Future objects

## v3 - the final one

Try to mix both approaches.
We leave the option for constructing prepared statement manually with request objects.
(But it doesn't work well with connection_pool without some method like pool.GetConnectionFromPool())
We give a user more friendly API with wrappers for request objects.

Connector interface:
```go
type Connector interface {
    ...
    Do(req Request) (fut *Future)
    ...
}
```

### Single connection Usage

Single connection usage:
```go
    client, err := tarantool.Connect(server, opts)
    // pass a query to prepare
    stmt, err := client.NewPreparedStatement("SELECT id FROM SQL_TEST WHERE id=? AND name=?")
	
    execReq := tarantool.NewExecuteRequest(stmt)
            .Args([]interface{}{})
    	    .Context(context.Background())
	
    unprepareReq := tarantool.NewUnprepareRequest(stmt)
        .Context(context.Background())
	
    resp, err := client.Do(execReq).Get()
    resp, err = client.Do(unpreapreReq).Get()
```

Connection pool usage:
```go
    pool, err := examplePool(Roles)
	
    stmt, err := pool.NewPreparedStatement("SELECT id FROM SQL_TEST WHERE id=? AND name=?")
    
    execReq := pool.NewExecuteRequest(stmt)
        .Args([]interface{}{})
	.Context(context.Background())
    
    unprepareReq := pool.NewUnprepareRequest(stmt)
        .Context(context.Background())
    
    resp, err := pool.Do(execReq).Get()
    resp, err = pool.Do(unpreapreReq).Get()
```

Advantages:
- easy to use
- ability to use futures if it is needed

Disadvantages:
- inconsistant with new Do-API
- only synchronous prepare call

## v4 - the proposed one
Purposes:

1. Make a same interface. All requests have a Connection.Request, Connection.RequestAsync and Connection.RequestTyped calls.
2. Request object support. To have support of [context](https://pkg.go.dev/context) at least, extensibility.
3. It should work for Connection and ConnectionPool.

A public API proposal:

```Go
// PreparedStatement

type PreparedStatement {
    Conn               Connection
    StatementID        PreparedStatementID
    MetaData           []ColumnMetaData
    ParamCount         uint64
}

func NewPreparedStatement(conn Connection, StatementID PreparedStatementID, MetaData []ColumntMetaData, ParamCount uint64) *PreparedStatement {}
func NewPreparedStatementFromResponse(conn Connection, resp Response) *PreparedStatement {}

// Connection

func (conn *Connection) Prepare(expr string) (resp *Response, err error)
func (conn *Connection) PrepareTyped(expr string, stmt interface{}) err error
func (conn *Connection) PrepareAsync(expr string) *Future

// Request objects

type PrepareRequest {
	baseRequest
}

type PreparedStatementRequest interface {
	Request
	GetPreparedStatement() *PreparedStatement 
}

type ExecutePreparedStatementRequest {
	PrepearedStatementRequest
}

type UnpreparePreparedStatementRequest {
	PrepearedStatementRequest
}

```
Usage example:
```Go
stmt = conn.Do(NewPrepareStatementRequest("statement string")).Get().Data.(PreparedStatement)
conn.Do(NewExecutePrepareStatementRequest(stmt))
conn.Do(NewUnpreparePreparedStatementRequest(stmt))

stmt = pool.Do(NewPrepareStatementRequest("statement string")).Get().Data.(PreparedStatement)
pool.Do(NewExecutePrepareStatementRequest(stmt, args))
pool.Do(NewUnpreparePreparedStatementRequest(stmt))
```

+ We can add a wrappers for PrepareStatement. it's a bit redundant, but it's looks like a Lua interface:

```Go
func (stmt *PreparedStatement) Execute(args interface{}) (resp Response, err error)
func (stmt *PreparedStatement) ExecuteTyped(args interface{}, tup interface{}) (err error)
func (stmt *PreparedStatement) ExecuteAsync(args interface{}) (*Future)

func (stmt *PreparedStatement) Unprepare() (resp Response, err error)
func (stmt *PreparedStatement) UnprepareTyped(tup interface{}) (err error)
func (stmt *PreparedStatement) UnprepareAsync() (*Future)
```

In addition, we can replace `PreparedStatement` with a shortest naming. Maybe just `Prepared`?

See:

1. https://www.tarantool.io/ru/doc/latest/reference/reference_lua/box_sql/prepare/