### PR TITLE
Replace gofmt with goimports for golangci-lint

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,4 +47,4 @@ jobs:
           # The `//nolint` workaround was not the acceptable way of warnings suppression,
           # cause those comments get rendered in documentation by godoc.
           # See https://github.com/tarantool/go-tarantool/pull/160#discussion_r858608221
-          args: -E gofmt -D errcheck
+          args: -E goimports -D errcheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,16 @@ make test-multi test-uuid test-main
 ```
 
 To check if the current changes will pass the linter in CI, install
-golnagci-lint from [sources](https://golangci-lint.run/usage/install/)
-and run it with next flags:
+golangci-lint from [sources](https://golangci-lint.run/usage/install/)
+and run it with next command:
 ```bash
-golangci-lint run -E goimports -D errcheck
+make golangci-lint
+```
+
+To format the code install [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)
+and run it with next command:
+```bash
+make format
 ```
 
 ## Benchmarking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To check if the current changes will pass the linter in CI, install
 golnagci-lint from [sources](https://golangci-lint.run/usage/install/)
 and run it with next flags:
 ```bash
-golangci-lint run -E gofmt -D errcheck
+golangci-lint run -E goimports -D errcheck
 ```
 
 ## Benchmarking

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ clean:
 deps: clean
 	( cd ./queue; tarantoolctl rocks install queue 1.1.0 )
 
+.PHONY: format
+format:
+	goimports -l -w .
+
+.PHONY: golangci-lint
+golangci-lint:
+	golangci-lint run -E goimports -D errcheck
+
 .PHONY: test
 test:
 	go test ./... -v -p 1

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -2,10 +2,11 @@ package tarantool_test
 
 import (
 	"fmt"
-	"github.com/tarantool/go-tarantool"
-	"gopkg.in/vmihailenco/msgpack.v2"
 	"log"
 	"time"
+
+	"github.com/tarantool/go-tarantool"
+	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
 type Tuple2 struct {

--- a/example_test.go
+++ b/example_test.go
@@ -2,10 +2,10 @@ package tarantool_test
 
 import (
 	"fmt"
-	"github.com/tarantool/go-tarantool/test_helpers"
 	"time"
 
 	"github.com/tarantool/go-tarantool"
+	"github.com/tarantool/go-tarantool/test_helpers"
 )
 
 type Tuple struct {

--- a/multi/example_test.go
+++ b/multi/example_test.go
@@ -2,8 +2,9 @@ package multi
 
 import (
 	"fmt"
-	"github.com/tarantool/go-tarantool"
 	"time"
+
+	"github.com/tarantool/go-tarantool"
 )
 
 func ExampleConnect() {

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -10,12 +10,12 @@ package queue_test
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/queue"
 	"gopkg.in/vmihailenco/msgpack.v2"
-	"log"
 )
 
 type dummyData struct {

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -2,7 +2,6 @@ package tarantool_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"reflect"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	. "github.com/tarantool/go-tarantool"
 	"github.com/tarantool/go-tarantool/test_helpers"
 	"gopkg.in/vmihailenco/msgpack.v2"


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Some source files have an alphabet order of imports, some have not. It confuses me. I propose to replace `gofmt` with `goimports`:

[goimports](https://golangci-lint.run/usage/linters/) linter for `golangci-lint` checks if imports are sorted in the alhabet order. In addition to checking imports, goimports also checks the code formatting in the same style as gofmt so it can be used as a replacement.

Also, I added targets to the Makefile to make it easier to run [the formatter ](https://pkg.go.dev/golang.org/x/tools/cmd/goimports)and the linter locally.

I didn't forget about (remove if it is not applicable):

- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)
