### PR TITLE
streams: interactive transactions and streams support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support datetime type in msgpack (#118)
 - Prepared SQL statements (#117)
 - Context support for request objects (#48)
+- Streams and interactive transactions support (#101)
 
 ### Changed
 

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,7 @@
 -- able to send requests until everything is configured.
 box.cfg{
     work_dir = os.getenv("TEST_TNT_WORK_DIR"),
+    memtx_use_mvcc_engine = os.getenv("TEST_TNT_MEMTX_USE_MVCC_ENGINE") == 'true' or nil,
 }
 
 box.once("init", function()

--- a/connection_pool/config.lua
+++ b/connection_pool/config.lua
@@ -2,6 +2,7 @@
 -- able to send requests until everything is configured.
 box.cfg{
     work_dir = os.getenv("TEST_TNT_WORK_DIR"),
+    memtx_use_mvcc_engine = os.getenv("TEST_TNT_MEMTX_USE_MVCC_ENGINE") == 'true' or nil,
 }
 
 box.once("init", function()

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -544,6 +544,20 @@ func (connPool *ConnectionPool) Do(req tarantool.Request, userMode Mode) *tarant
 	return conn.Do(req)
 }
 
+// NewStream creates new Stream object for connection selected
+// by userMode from connPool.
+//
+// Since v. 2.10.0, Tarantool supports streams and interactive transactions over them.
+// To use interactive transactions, memtx_use_mvcc_engine box option should be set to true.
+// Since 1.7.0
+func (connPool *ConnectionPool) NewStream(userMode Mode) (*tarantool.Stream, error) {
+	conn, err := connPool.getNextConnection(userMode)
+	if err != nil {
+		return nil, err
+	}
+	return conn.NewStream()
+}
+
 //
 // private
 //

--- a/connector.go
+++ b/connector.go
@@ -45,6 +45,7 @@ type Connector interface {
 	ExecuteAsync(expr string, args interface{}) *Future
 
 	NewPrepared(expr string) (*Prepared, error)
+	NewStream() (*Stream, error)
 
 	Do(req Request) (fut *Future)
 }

--- a/const.go
+++ b/const.go
@@ -13,11 +13,15 @@ const (
 	Call17RequestCode    = 10 /* call in >= 1.7 format */
 	ExecuteRequestCode   = 11
 	PrepareRequestCode   = 13
+	BeginRequestCode     = 14
+	CommitRequestCode    = 15
+	RollbackRequestCode  = 16
 	PingRequestCode      = 64
 	SubscribeRequestCode = 66
 
 	KeyCode         = 0x00
 	KeySync         = 0x01
+	KeyStreamId     = 0x0a
 	KeySpaceNo      = 0x10
 	KeyIndexNo      = 0x11
 	KeyLimit        = 0x12
@@ -37,6 +41,8 @@ const (
 	KeySQLBind      = 0x41
 	KeySQLInfo      = 0x42
 	KeyStmtID       = 0x43
+	KeyTimeout      = 0x56
+	KeyTxnIsolation = 0x59
 
 	KeyFieldName               = 0x00
 	KeyFieldType               = 0x01

--- a/export_test.go
+++ b/export_test.go
@@ -93,3 +93,21 @@ func RefImplExecutePreparedBody(enc *msgpack.Encoder, stmt Prepared, args interf
 func RefImplUnprepareBody(enc *msgpack.Encoder, stmt Prepared) error {
 	return fillUnprepare(enc, stmt)
 }
+
+// RefImplBeginBody is reference implementation for filling of an begin
+// request's body.
+func RefImplBeginBody(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
+	return fillBegin(enc, txnIsolation, timeout)
+}
+
+// RefImplCommitBody is reference implementation for filling of an commit
+// request's body.
+func RefImplCommitBody(enc *msgpack.Encoder) error {
+	return fillCommit(enc)
+}
+
+// RefImplRollbackBody is reference implementation for filling of an rollback
+// request's body.
+func RefImplRollbackBody(enc *msgpack.Encoder) error {
+	return fillRollback(enc)
+}

--- a/multi/config.lua
+++ b/multi/config.lua
@@ -4,6 +4,7 @@ local nodes_load = require("config_load_nodes")
 -- able to send requests until everything is configured.
 box.cfg{
     work_dir = os.getenv("TEST_TNT_WORK_DIR"),
+    memtx_use_mvcc_engine = os.getenv("TEST_TNT_MEMTX_USE_MVCC_ENGINE") == 'true' or nil,
 }
 
 -- Function to call for getting address list, part of tarantool/multi API.
@@ -11,6 +12,12 @@ local get_cluster_nodes = nodes_load.get_cluster_nodes
 rawset(_G, 'get_cluster_nodes', get_cluster_nodes)
 
 box.once("init", function()
+    local s = box.schema.space.create('test', {
+        id = 517,
+        if_not_exists = true,
+    })
+    s:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
+
     box.schema.user.create('test', { password = 'test' })
     box.schema.user.grant('test', 'read,write,execute', 'universe')
 

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -498,6 +498,15 @@ func (connMulti *ConnectionMulti) NewPrepared(expr string) (*tarantool.Prepared,
 	return connMulti.getCurrentConnection().NewPrepared(expr)
 }
 
+// NewStream creates new Stream object for connection.
+//
+// Since v. 2.10.0, Tarantool supports streams and interactive transactions over them.
+// To use interactive transactions, memtx_use_mvcc_engine box option should be set to true.
+// Since 1.7.0
+func (connMulti *ConnectionMulti) NewStream() (*tarantool.Stream, error) {
+	return connMulti.getCurrentConnection().NewStream()
+}
+
 // Do sends the request and returns a future.
 func (connMulti *ConnectionMulti) Do(req tarantool.Request) *tarantool.Future {
 	if connectedReq, ok := req.(tarantool.ConnectedRequest); ok {

--- a/prepared.go
+++ b/prepared.go
@@ -20,6 +20,26 @@ type Prepared struct {
 	Conn        *Connection
 }
 
+func fillPrepare(enc *msgpack.Encoder, expr string) error {
+	enc.EncodeMapLen(1)
+	enc.EncodeUint64(KeySQLText)
+	return enc.EncodeString(expr)
+}
+
+func fillUnprepare(enc *msgpack.Encoder, stmt Prepared) error {
+	enc.EncodeMapLen(1)
+	enc.EncodeUint64(KeyStmtID)
+	return enc.EncodeUint64(uint64(stmt.StatementID))
+}
+
+func fillExecutePrepared(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
+	enc.EncodeMapLen(2)
+	enc.EncodeUint64(KeyStmtID)
+	enc.EncodeUint64(uint64(stmt.StatementID))
+	enc.EncodeUint64(KeySQLBind)
+	return encodeSQLBind(enc, args)
+}
+
 // NewPreparedFromResponse constructs a Prepared object.
 func NewPreparedFromResponse(conn *Connection, resp *Response) (*Prepared, error) {
 	if resp == nil {
@@ -149,24 +169,4 @@ func (req *ExecutePreparedRequest) Body(res SchemaResolver, enc *msgpack.Encoder
 func (req *ExecutePreparedRequest) Context(ctx context.Context) *ExecutePreparedRequest {
 	req.ctx = ctx
 	return req
-}
-
-func fillPrepare(enc *msgpack.Encoder, expr string) error {
-	enc.EncodeMapLen(1)
-	enc.EncodeUint64(KeySQLText)
-	return enc.EncodeString(expr)
-}
-
-func fillUnprepare(enc *msgpack.Encoder, stmt Prepared) error {
-	enc.EncodeMapLen(1)
-	enc.EncodeUint64(KeyStmtID)
-	return enc.EncodeUint64(uint64(stmt.StatementID))
-}
-
-func fillExecutePrepared(enc *msgpack.Encoder, stmt Prepared, args interface{}) error {
-	enc.EncodeMapLen(2)
-	enc.EncodeUint64(KeyStmtID)
-	enc.EncodeUint64(uint64(stmt.StatementID))
-	enc.EncodeUint64(KeySQLBind)
-	return encodeSQLBind(enc, args)
 }

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,202 @@
+package tarantool
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+type TxnIsolationLevel uint
+
+const (
+	// By default, the isolation level of Tarantool is serializable.
+	DefaultIsolationLevel TxnIsolationLevel = 0
+	// The ReadCommittedLevel isolation level makes visible all transactions
+	// that started commit (stream.Do(NewCommitRequest()) was called).
+	ReadCommittedLevel TxnIsolationLevel = 1
+	// The ReadConfirmedLevel isolation level makes visible all transactions
+	// that finished the commit (stream.Do(NewCommitRequest()) was returned).
+	ReadConfirmedLevel TxnIsolationLevel = 2
+	// If the BestEffortLevel (serializable) isolation level becomes unreachable,
+	// the transaction is marked as «conflicted» and can no longer be committed.
+	BestEffortLevel TxnIsolationLevel = 3
+)
+
+type Stream struct {
+	Id   uint64
+	Conn *Connection
+}
+
+func fillBegin(enc *msgpack.Encoder, txnIsolation TxnIsolationLevel, timeout time.Duration) error {
+	hasTimeout := timeout > 0
+	hasIsolationLevel := txnIsolation != DefaultIsolationLevel
+	mapLen := 0
+	if hasTimeout {
+		mapLen += 1
+	}
+	if hasIsolationLevel {
+		mapLen += 1
+	}
+
+	err := enc.EncodeMapLen(mapLen)
+	if err != nil {
+		return err
+	}
+
+	if hasTimeout {
+		err = enc.EncodeUint64(KeyTimeout)
+		if err != nil {
+			return err
+		}
+
+		err = enc.Encode(timeout.Seconds())
+		if err != nil {
+			return err
+		}
+	}
+
+	if hasIsolationLevel {
+		err = enc.EncodeUint(KeyTxnIsolation)
+		if err != nil {
+			return err
+		}
+
+		err = enc.Encode(txnIsolation)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func fillCommit(enc *msgpack.Encoder) error {
+	return enc.EncodeMapLen(0)
+}
+
+func fillRollback(enc *msgpack.Encoder) error {
+	return enc.EncodeMapLen(0)
+}
+
+// BeginRequest helps you to create a begin request object for execution
+// by a Stream.
+// Begin request can not be processed out of stream.
+type BeginRequest struct {
+	baseRequest
+	txnIsolation TxnIsolationLevel
+	timeout      time.Duration
+}
+
+// NewBeginRequest returns a new BeginRequest.
+func NewBeginRequest() *BeginRequest {
+	req := new(BeginRequest)
+	req.requestCode = BeginRequestCode
+	req.txnIsolation = DefaultIsolationLevel
+	return req
+}
+
+// TxnIsolation sets the the transaction isolation level for transaction manager.
+// By default, the isolation level of Tarantool is serializable.
+func (req *BeginRequest) TxnIsolation(txnIsolation TxnIsolationLevel) *BeginRequest {
+	req.txnIsolation = txnIsolation
+	return req
+}
+
+// WithTimeout allows to set up a timeout for call BeginRequest.
+func (req *BeginRequest) Timeout(timeout time.Duration) *BeginRequest {
+	req.timeout = timeout
+	return req
+}
+
+// Body fills an encoder with the begin request body.
+func (req *BeginRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillBegin(enc, req.txnIsolation, req.timeout)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *BeginRequest) Context(ctx context.Context) *BeginRequest {
+	req.ctx = ctx
+	return req
+}
+
+// CommitRequest helps you to create a commit request object for execution
+// by a Stream.
+// Commit request can not be processed out of stream.
+type CommitRequest struct {
+	baseRequest
+}
+
+// NewCommitRequest returns a new CommitRequest.
+func NewCommitRequest() *CommitRequest {
+	req := new(CommitRequest)
+	req.requestCode = CommitRequestCode
+	return req
+}
+
+// Body fills an encoder with the commit request body.
+func (req *CommitRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillCommit(enc)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *CommitRequest) Context(ctx context.Context) *CommitRequest {
+	req.ctx = ctx
+	return req
+}
+
+// RollbackRequest helps you to create a rollback request object for execution
+// by a Stream.
+// Rollback request can not be processed out of stream.
+type RollbackRequest struct {
+	baseRequest
+}
+
+// NewRollbackRequest returns a new RollbackRequest.
+func NewRollbackRequest() *RollbackRequest {
+	req := new(RollbackRequest)
+	req.requestCode = RollbackRequestCode
+	return req
+}
+
+// Body fills an encoder with the rollback request body.
+func (req *RollbackRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+	return fillRollback(enc)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *RollbackRequest) Context(ctx context.Context) *RollbackRequest {
+	req.ctx = ctx
+	return req
+}
+
+// Do verifies, sends the request and returns a future.
+//
+// An error is returned if the request was formed incorrectly, or failure to
+// create the future.
+func (s *Stream) Do(req Request) *Future {
+	if connectedReq, ok := req.(ConnectedRequest); ok {
+		if connectedReq.Conn() != s.Conn {
+			fut := NewFuture()
+			fut.SetError(fmt.Errorf("the passed connected request doesn't belong to the current connection or connection pool"))
+			return fut
+		}
+	}
+	return s.Conn.send(req, s.Id)
+}

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -72,6 +72,10 @@ type StartOpts struct {
 
 	// RetryTimeout is a time between tarantool ping retries.
 	RetryTimeout time.Duration
+
+	// MemtxUseMvccEngine is flag to enable transactional
+	// manager if set to true.
+	MemtxUseMvccEngine bool
 }
 
 // TarantoolInstance is a data for instance graceful shutdown and cleanup.
@@ -190,6 +194,7 @@ func StartTarantool(startOpts StartOpts) (TarantoolInstance, error) {
 		os.Environ(),
 		fmt.Sprintf("TEST_TNT_WORK_DIR=%s", startOpts.WorkDir),
 		fmt.Sprintf("TEST_TNT_LISTEN=%s", startOpts.Listen),
+		fmt.Sprintf("TEST_TNT_MEMTX_USE_MVCC_ENGINE=%t", startOpts.MemtxUseMvccEngine),
 	)
 
 	// Clean up existing work_dir.

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -24,6 +24,22 @@ func ConnectWithValidation(t testing.TB,
 	return conn
 }
 
+func DeleteRecordByKey(t *testing.T, conn tarantool.Connector,
+	space interface{}, index interface{}, key []interface{}) {
+	t.Helper()
+
+	req := tarantool.NewDeleteRequest(space).
+		Index(index).
+		Key(key)
+	resp, err := conn.Do(req).Get()
+	if err != nil {
+		t.Fatalf("Failed to Delete: %s", err.Error())
+	}
+	if resp == nil {
+		t.Fatalf("Response is nil after Select")
+	}
+}
+
 func SkipIfSQLUnsupported(t testing.TB) {
 	t.Helper()
 
@@ -34,5 +50,19 @@ func SkipIfSQLUnsupported(t testing.TB) {
 	}
 	if isLess {
 		t.Skip()
+	}
+}
+
+func SkipIfStreamsUnsupported(t *testing.T) {
+	t.Helper()
+
+	// Tarantool supports streams and interactive transactions since version 2.10.0
+	isLess, err := IsTarantoolVersionLess(2, 10, 0)
+	if err != nil {
+		t.Fatalf("Could not check the Tarantool version")
+	}
+
+	if isLess {
+		t.Skip("Skipping test for Tarantool without streams support")
 	}
 }


### PR DESCRIPTION
The main purpose of streams is transactions via iproto.
    Since v. 2.10.0, Tarantool supports streams and
    interactive transactions over them. Each stream
    can start its own transaction, so they allows
    multiplexing several transactions over one connection.
    
    API for this feature is the following:
    
    * `NewStream()` method to create a stream object for `Connection`
       and `NewStream(userMode Mode)` method to create a stream object
       for `ConnectionPool`
    *  stream object `Stream` with `Do() method and
       new request objects to work with stream,
      `BeginRequest` - start transaction via iproto stream;
      `CommitRequest` - commit transaction;
      `RollbackRequest` - rollback transaction.

Closes #101 
