### PR TITLE
code health: add test_helpers.ConnectWithValidation

### DIFF
--- a/call_16_test.go
+++ b/call_16_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	. "github.com/tarantool/go-tarantool"
+	"github.com/tarantool/go-tarantool/test_helpers"
 )
 
 func TestConnection_Call(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Call16
@@ -30,7 +31,7 @@ func TestCallRequest(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	req := NewCallRequest("simple_incr").Args([]interface{}{1})

--- a/call_17_test.go
+++ b/call_17_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	. "github.com/tarantool/go-tarantool"
+	"github.com/tarantool/go-tarantool/test_helpers"
 )
 
 func TestConnection_Call(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Call17
@@ -30,7 +31,7 @@ func TestCallRequest(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	req := NewCallRequest("simple_incr").Args([]interface{}{1})

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -739,10 +739,7 @@ func TestInsert(t *testing.T) {
 
 	// Connect to servers[2] to check if tuple
 	// was inserted on RW instance
-	conn, err := tarantool.Connect(servers[2], connOpts)
-	require.Nilf(t, err, "failed to connect %s", servers[2])
-	require.NotNilf(t, conn, "conn is nil after Connect")
-
+	conn := test_helpers.ConnectWithValidation(t, servers[2], connOpts)
 	defer conn.Close()
 
 	resp, err = conn.Select(spaceNo, indexNo, 0, 1, tarantool.IterEq, []interface{}{"rw_insert_key"})
@@ -812,10 +809,7 @@ func TestDelete(t *testing.T) {
 
 	// Connect to servers[2] to check if tuple
 	// was inserted on RW instance
-	conn, err := tarantool.Connect(servers[2], connOpts)
-	require.Nilf(t, err, "failed to connect %s", servers[2])
-	require.NotNilf(t, conn, "conn is nil after Connect")
-
+	conn := test_helpers.ConnectWithValidation(t, servers[2], connOpts)
 	defer conn.Close()
 
 	resp, err := conn.Insert(spaceNo, []interface{}{"delete_key", "delete_value"})
@@ -873,10 +867,7 @@ func TestUpsert(t *testing.T) {
 
 	// Connect to servers[2] to check if tuple
 	// was inserted on RW instance
-	conn, err := tarantool.Connect(servers[2], connOpts)
-	require.Nilf(t, err, "failed to connect %s", servers[2])
-	require.NotNilf(t, conn, "conn is nil after Connect")
-
+	conn := test_helpers.ConnectWithValidation(t, servers[2], connOpts)
 	defer conn.Close()
 
 	// Mode is `RW` by default, we have only one RW instance (servers[2])
@@ -941,10 +932,7 @@ func TestUpdate(t *testing.T) {
 
 	// Connect to servers[2] to check if tuple
 	// was inserted on RW instance
-	conn, err := tarantool.Connect(servers[2], connOpts)
-	require.Nilf(t, err, "failed to connect %s", servers[2])
-	require.NotNilf(t, conn, "conn is nil after Connect")
-
+	conn := test_helpers.ConnectWithValidation(t, servers[2], connOpts)
 	defer conn.Close()
 
 	resp, err := conn.Insert(spaceNo, []interface{}{"update_key", "update_value"})
@@ -1026,10 +1014,7 @@ func TestReplace(t *testing.T) {
 
 	// Connect to servers[2] to check if tuple
 	// was inserted on RW instance
-	conn, err := tarantool.Connect(servers[2], connOpts)
-	require.Nilf(t, err, "failed to connect %s", servers[2])
-	require.NotNilf(t, conn, "conn is nil after Connect")
-
+	conn := test_helpers.ConnectWithValidation(t, servers[2], connOpts)
 	defer conn.Close()
 
 	resp, err := conn.Insert(spaceNo, []interface{}{"replace_key", "replace_value"})

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -33,19 +33,6 @@ var spaceTuple1 = "testDatetime_1"
 var spaceTuple2 = "testDatetime_2"
 var index = "primary"
 
-func connectWithValidation(t *testing.T) *Connection {
-	t.Helper()
-
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Fatalf("conn is nil after Connect")
-	}
-	return conn
-}
-
 func skipIfDatetimeUnsupported(t *testing.T) {
 	t.Helper()
 
@@ -168,7 +155,7 @@ var datetimeSample = []struct {
 func TestDatetimeInsertSelectDelete(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	for _, testcase := range datetimeSample {
@@ -188,7 +175,7 @@ func TestDatetimeInsertSelectDelete(t *testing.T) {
 func TestDatetimeMax(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	tupleInsertSelectDelete(t, conn, maxTime)
@@ -197,7 +184,7 @@ func TestDatetimeMax(t *testing.T) {
 func TestDatetimeMin(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	tupleInsertSelectDelete(t, conn, minTime)
@@ -206,7 +193,7 @@ func TestDatetimeMin(t *testing.T) {
 func TestDatetimeReplace(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	tm, err := time.Parse(time.RFC3339, "2007-01-02T15:04:05Z")
@@ -356,7 +343,7 @@ func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 func TestCustomEncodeDecodeTuple1(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	dt1, _ := time.Parse(time.RFC3339, "2010-05-24T17:51:56.000000009Z")
@@ -416,7 +403,7 @@ func TestCustomEncodeDecodeTuple1(t *testing.T) {
 func TestCustomDecodeFunction(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Call function 'call_datetime_testdata' returning a table of custom tuples.
@@ -459,7 +446,7 @@ func TestCustomDecodeFunction(t *testing.T) {
 func TestCustomEncodeDecodeTuple5(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	tm := time.Unix(500, 1000)

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -337,19 +337,6 @@ func BenchmarkMPDecodeDecimal(b *testing.B) {
 	}
 }
 
-func connectWithValidation(t *testing.T) *Connection {
-	t.Helper()
-
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Fatalf("conn is nil after Connect")
-	}
-	return conn
-}
-
 func tupleValueIsDecimal(t *testing.T, tuples []interface{}, number decimal.Decimal) {
 	if len(tuples) != 1 {
 		t.Fatalf("Response Data len (%d) != 1", len(tuples))
@@ -499,7 +486,7 @@ func BenchmarkDecodeStringFromBCD(b *testing.B) {
 func TestSelect(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	number, err := decimal.NewFromString("-12.34")
@@ -559,7 +546,7 @@ func assertInsert(t *testing.T, conn *Connection, numString string) {
 func TestInsert(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	samples := append(correctnessSamples, benchmarkSamples...)
@@ -573,7 +560,7 @@ func TestInsert(t *testing.T) {
 func TestReplace(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	number, err := decimal.NewFromString("-12.34")

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -26,45 +26,29 @@ var opts = Opts{
 /////////QUEUE/////////
 
 func TestFifoQueue(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
 
 	//Drop
-	if err = q.Drop(); err != nil {
+	if err := q.Drop(); err != nil {
 		t.Errorf("Failed drop queue: %s", err.Error())
 	}
 }
 
 func TestFifoQueue_GetExist_Statistic(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -102,15 +86,7 @@ func TestFifoQueue_GetExist_Statistic(t *testing.T) {
 }
 
 func TestFifoQueue_Put(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
@@ -145,20 +121,12 @@ func TestFifoQueue_Put(t *testing.T) {
 }
 
 func TestFifoQueue_Take(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -241,20 +209,12 @@ func (c *customData) EncodeMsgpack(e *msgpack.Encoder) error {
 }
 
 func TestFifoQueue_TakeTyped(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -318,20 +278,12 @@ func TestFifoQueue_TakeTyped(t *testing.T) {
 }
 
 func TestFifoQueue_Peek(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -377,20 +329,12 @@ func TestFifoQueue_Peek(t *testing.T) {
 }
 
 func TestFifoQueue_Bury_Kick(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -464,15 +408,7 @@ func TestFifoQueue_Bury_Kick(t *testing.T) {
 func TestFifoQueue_Delete(t *testing.T) {
 	var err error
 
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
@@ -539,20 +475,12 @@ func TestFifoQueue_Delete(t *testing.T) {
 }
 
 func TestFifoQueue_Release(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Errorf("Failed to connect: %s", err.Error())
-		return
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
 	q := queue.New(conn, name)
-	if err = q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
+	if err := q.Create(queue.Cfg{Temporary: true, Kind: queue.FIFO}); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -628,10 +556,7 @@ func TestFifoQueue_Release(t *testing.T) {
 }
 
 func TestTtlQueue(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
@@ -641,7 +566,7 @@ func TestTtlQueue(t *testing.T) {
 		Opts:      queue.Opts{Ttl: 5 * time.Second},
 	}
 	q := queue.New(conn, name)
-	if err = q.Create(cfg); err != nil {
+	if err := q.Create(cfg); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -680,13 +605,7 @@ func TestTtlQueue(t *testing.T) {
 }
 
 func TestTtlQueue_Put(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Fatalf("conn is nil after Connect")
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_queue"
@@ -696,7 +615,7 @@ func TestTtlQueue_Put(t *testing.T) {
 		Opts:      queue.Opts{Ttl: 5 * time.Second},
 	}
 	q := queue.New(conn, name)
-	if err = q.Create(cfg); err != nil {
+	if err := q.Create(cfg); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -750,13 +669,7 @@ func TestTtlQueue_Put(t *testing.T) {
 }
 
 func TestUtube_Put(t *testing.T) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Fatalf("conn is nil after Connect")
-	}
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	name := "test_utube"
@@ -766,7 +679,7 @@ func TestUtube_Put(t *testing.T) {
 		IfNotExists: true,
 	}
 	q := queue.New(conn, name)
-	if err = q.Create(cfg); err != nil {
+	if err := q.Create(cfg); err != nil {
 		t.Errorf("Failed to create queue: %s", err.Error())
 		return
 	}
@@ -779,7 +692,7 @@ func TestUtube_Put(t *testing.T) {
 	}()
 
 	data1 := &customData{"test-data-0"}
-	_, err = q.PutWithOpts(data1, queue.Opts{Utube: "test-utube-consumer-key"})
+	_, err := q.PutWithOpts(data1, queue.Opts{Utube: "test-utube-consumer-key"})
 	if err != nil {
 		t.Fatalf("Failed put task to queue: %s", err.Error())
 	}

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -22,19 +22,6 @@ type Member struct {
 	Val   uint
 }
 
-func connect(t testing.TB, server string, opts Opts) (conn *Connection) {
-	t.Helper()
-
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Fatalf("conn is nil after Connect")
-	}
-	return conn
-}
-
 func (m *Member) EncodeMsgpack(e *msgpack.Encoder) error {
 	if err := e.EncodeSliceLen(2); err != nil {
 		return err
@@ -84,7 +71,7 @@ const N = 500
 func BenchmarkClientSerial(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -104,7 +91,7 @@ func BenchmarkClientSerial(b *testing.B) {
 func BenchmarkClientSerialRequestObject(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -131,7 +118,7 @@ func BenchmarkClientSerialRequestObject(b *testing.B) {
 func BenchmarkClientSerialTyped(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -152,7 +139,7 @@ func BenchmarkClientSerialTyped(b *testing.B) {
 func BenchmarkClientFuture(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -179,7 +166,7 @@ func BenchmarkClientFuture(b *testing.B) {
 func BenchmarkClientFutureTyped(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -209,7 +196,7 @@ func BenchmarkClientFutureTyped(b *testing.B) {
 func BenchmarkClientFutureParallel(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -242,7 +229,7 @@ func BenchmarkClientFutureParallel(b *testing.B) {
 func BenchmarkClientFutureParallelTyped(b *testing.B) {
 	var err error
 
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -278,7 +265,7 @@ func BenchmarkClientFutureParallelTyped(b *testing.B) {
 }
 
 func BenchmarkClientParallel(b *testing.B) {
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -299,7 +286,7 @@ func BenchmarkClientParallel(b *testing.B) {
 }
 
 func BenchmarkClientParallelMassive(b *testing.B) {
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -334,7 +321,7 @@ func BenchmarkClientParallelMassive(b *testing.B) {
 }
 
 func BenchmarkClientParallelMassiveUntyped(b *testing.B) {
-	conn := connect(b, server, opts)
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
@@ -369,11 +356,7 @@ func BenchmarkClientParallelMassiveUntyped(b *testing.B) {
 }
 
 func BenchmarkClientReplaceParallel(b *testing.B) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		b.Errorf("No connection available")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 	spaceNo = 520
 
@@ -394,11 +377,7 @@ func BenchmarkClientReplaceParallel(b *testing.B) {
 }
 
 func BenchmarkClientLargeSelectParallel(b *testing.B) {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		b.Errorf("No connection available")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	schema := conn.Schema
@@ -429,11 +408,7 @@ func BenchmarkSQLParallel(b *testing.B) {
 		b.Skip()
 	}
 
-	conn, err := Connect(server, opts)
-	if err != nil {
-		b.Errorf("No connection available")
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	spaceNo := 519
@@ -464,11 +439,7 @@ func BenchmarkSQLSerial(b *testing.B) {
 		b.Skip()
 	}
 
-	conn, err := Connect(server, opts)
-	if err != nil {
-		b.Errorf("Failed to connect: %s", err)
-		return
-	}
+	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
 	spaceNo := 519
@@ -493,7 +464,7 @@ func TestClient(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Ping
@@ -796,7 +767,7 @@ func TestClient(t *testing.T) {
 }
 
 func TestClientSessionPush(t *testing.T) {
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	var it ResponseIterator
@@ -1065,7 +1036,7 @@ func TestSQL(t *testing.T) {
 		},
 	}
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	for i, test := range testCases {
@@ -1099,7 +1070,7 @@ func TestSQLTyped(t *testing.T) {
 		t.Skip()
 	}
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	mem := []Member{}
@@ -1135,7 +1106,7 @@ func TestSQLBindings(t *testing.T) {
 
 	var resp *Response
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// test all types of supported bindings
@@ -1244,7 +1215,7 @@ func TestStressSQL(t *testing.T) {
 
 	var resp *Response
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	resp, err = conn.Execute(createTableQuery, []interface{}{})
@@ -1340,7 +1311,7 @@ func TestStressSQL(t *testing.T) {
 func TestSchema(t *testing.T) {
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Schema
@@ -1515,7 +1486,7 @@ func TestClientNamed(t *testing.T) {
 	var resp *Response
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Insert
@@ -1608,7 +1579,7 @@ func TestClientRequestObjects(t *testing.T) {
 		err  error
 	)
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	// Ping
@@ -1947,7 +1918,7 @@ func TestClientRequestObjects(t *testing.T) {
 func TestComplexStructs(t *testing.T) {
 	var err error
 
-	conn := connect(t, server, opts)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	tuple := Tuple2{Cid: 777, Orig: "orig", Members: []Member{{"lol", "", 1}, {"wut", "", 3}}}

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -1,0 +1,25 @@
+package test_helpers
+
+import (
+	"testing"
+
+	"github.com/tarantool/go-tarantool"
+)
+
+// ConnectWithValidation tries to connect to a Tarantool instance.
+// It returns a valid connection if it is successful, otherwise finishes a test
+// with an error.
+func ConnectWithValidation(t testing.TB,
+	server string,
+	opts tarantool.Opts) *tarantool.Connection {
+	t.Helper()
+
+	conn, err := tarantool.Connect(server, opts)
+	if err != nil {
+		t.Fatalf("Failed to connect: %s", err.Error())
+	}
+	if conn == nil {
+		t.Fatalf("conn is nil after Connect")
+	}
+	return conn
+}

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -50,17 +50,6 @@ func (t *TupleUUID) DecodeMsgpack(d *msgpack.Decoder) error {
 	return nil
 }
 
-func connectWithValidation(t *testing.T) *Connection {
-	conn, err := Connect(server, opts)
-	if err != nil {
-		t.Fatalf("Failed to connect: %s", err.Error())
-	}
-	if conn == nil {
-		t.Errorf("conn is nil after Connect")
-	}
-	return conn
-}
-
 func tupleValueIsId(t *testing.T, tuples []interface{}, id uuid.UUID) {
 	if len(tuples) != 1 {
 		t.Fatalf("Response Data len != 1")
@@ -83,7 +72,7 @@ func TestSelect(t *testing.T) {
 		t.Skip("Skipping test for Tarantool without UUID support in msgpack")
 	}
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	id, uuidErr := uuid.Parse("c8f0fa1f-da29-438c-a040-393f1126ad39")
@@ -118,7 +107,7 @@ func TestReplace(t *testing.T) {
 		t.Skip("Skipping test for Tarantool without UUID support in msgpack")
 	}
 
-	conn := connectWithValidation(t)
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()
 
 	id, uuidErr := uuid.Parse("64d22e4d-ac92-4a23-899a-e59f34af5479")


### PR DESCRIPTION
The code that creates and verifies a connection to a Tarantool instance
spreads across tests. The patch extracts the code into a separate test
helper function.
