### PR TITLE
api: left only asynchronous Connection.Do(request)

### DIFF
--- a/call_16_test.go
+++ b/call_16_test.go
@@ -34,7 +34,7 @@ func TestCallRequest(t *testing.T) {
 	defer conn.Close()
 
 	req := NewCallRequest("simple_incr").Args([]interface{}{1})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}

--- a/call_17_test.go
+++ b/call_17_test.go
@@ -34,7 +34,7 @@ func TestCallRequest(t *testing.T) {
 	defer conn.Close()
 
 	req := NewCallRequest("simple_incr").Args([]interface{}{1})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}

--- a/connection.go
+++ b/connection.go
@@ -988,29 +988,11 @@ func (conn *Connection) nextRequestId() (requestId uint32) {
 	return atomic.AddUint32(&conn.requestId, 1)
 }
 
-// Do verifies, sends the request and returns a response.
-//
-// An error is returned if the request was formed incorrectly, or failed to
-// communicate by the connection, or unable to decode the response.
-func (conn *Connection) Do(req Request) (*Response, error) {
-	fut := conn.DoAsync(req)
-	return fut.Get()
-}
-
-// DoTyped verifies, sends the request and fills the typed result.
-//
-// An error is returned if the request was formed incorrectly, or failed to
-// communicate by the connection, or unable to decode the response.
-func (conn *Connection) DoTyped(req Request, result interface{}) error {
-	fut := conn.DoAsync(req)
-	return fut.GetTyped(result)
-}
-
-// DoAsync verifies, sends the request and returns a future.
+// Do performs a request asynchronously on the connection.
 //
 // An error is returned if the request was formed incorrectly, or failed to
 // create the future.
-func (conn *Connection) DoAsync(req Request) *Future {
+func (conn *Connection) Do(req Request) *Future {
 	return conn.send(req)
 }
 

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -524,34 +524,14 @@ func (connPool *ConnectionPool) EvalAsync(expr string, args interface{}, userMod
 	return conn.EvalAsync(expr, args)
 }
 
-// Do sends the request and returns a response.
-func (connPool *ConnectionPool) Do(req tarantool.Request, userMode Mode) (*tarantool.Response, error) {
-	conn, err := connPool.getNextConnection(userMode)
-	if err != nil {
-		return nil, err
-	}
-
-	return conn.Do(req)
-}
-
-// DoTyped sends the request and fills the typed result.
-func (connPool *ConnectionPool) DoTyped(req tarantool.Request, result interface{}, userMode Mode) error {
-	conn, err := connPool.getNextConnection(userMode)
-	if err != nil {
-		return err
-	}
-
-	return conn.DoTyped(req, result)
-}
-
-// DoAsync sends the request and returns a future.
-func (connPool *ConnectionPool) DoAsync(req tarantool.Request, userMode Mode) *tarantool.Future {
+// Do sends the request and returns a future.
+func (connPool *ConnectionPool) Do(req tarantool.Request, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
 		return tarantool.NewErrorFuture(err)
 	}
 
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 //

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -1266,27 +1266,27 @@ func TestDo(t *testing.T) {
 
 	req := tarantool.NewPingRequest()
 	// ANY
-	resp, err := connPool.Do(req, connection_pool.ANY)
+	resp, err := connPool.Do(req, connection_pool.ANY).Get()
 	require.Nilf(t, err, "failed to Ping")
 	require.NotNilf(t, resp, "response is nil after Ping")
 
 	// RW
-	resp, err = connPool.Do(req, connection_pool.RW)
+	resp, err = connPool.Do(req, connection_pool.RW).Get()
 	require.Nilf(t, err, "failed to Ping")
 	require.NotNilf(t, resp, "response is nil after Ping")
 
 	// RO
-	resp, err = connPool.Do(req, connection_pool.RO)
+	resp, err = connPool.Do(req, connection_pool.RO).Get()
 	require.Nilf(t, err, "failed to Ping")
 	require.NotNilf(t, resp, "response is nil after Ping")
 
 	// PreferRW
-	resp, err = connPool.Do(req, connection_pool.PreferRW)
+	resp, err = connPool.Do(req, connection_pool.PreferRW).Get()
 	require.Nilf(t, err, "failed to Ping")
 	require.NotNilf(t, resp, "response is nil after Ping")
 
 	// PreferRO
-	resp, err = connPool.Do(req, connection_pool.PreferRO)
+	resp, err = connPool.Do(req, connection_pool.PreferRO).Get()
 	require.Nilf(t, err, "failed to Ping")
 	require.NotNilf(t, resp, "response is nil after Ping")
 }

--- a/connection_pool/example_test.go
+++ b/connection_pool/example_test.go
@@ -539,7 +539,7 @@ func ExampleConnectionPool_Do() {
 
 	// Ping a Tarantool instance to check connection.
 	req := tarantool.NewPingRequest()
-	resp, err := pool.Do(req, connection_pool.ANY)
+	resp, err := pool.Do(req, connection_pool.ANY).Get()
 	fmt.Println("Ping Code", resp.Code)
 	fmt.Println("Ping Data", resp.Data)
 	fmt.Println("Ping Error", err)

--- a/connector.go
+++ b/connector.go
@@ -42,7 +42,5 @@ type Connector interface {
 	Call17Async(functionName string, args interface{}) *Future
 	EvalAsync(expr string, args interface{}) *Future
 
-	Do(req Request) (resp *Response, err error)
-	DoTyped(req Request, result interface{}) (err error)
-	DoAsync(req Request) (fut *Future)
+	Do(req Request) (fut *Future)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -133,7 +133,7 @@ func ExampleSelectRequest() {
 	req := tarantool.NewSelectRequest(517).
 		Limit(100).
 		Key(tarantool.IntKey{1111})
-	resp, err := conn.Do(req)
+	resp, err := conn.Do(req).Get()
 	if err != nil {
 		fmt.Printf("error in do select request is %v", err)
 		return
@@ -144,7 +144,7 @@ func ExampleSelectRequest() {
 		Index("primary").
 		Limit(100).
 		Key(tarantool.IntKey{1111})
-	fut := conn.DoAsync(req)
+	fut := conn.Do(req)
 	resp, err = fut.Get()
 	if err != nil {
 		fmt.Printf("error in do async select request is %v", err)
@@ -163,7 +163,7 @@ func ExampleUpdateRequest() {
 	req := tarantool.NewUpdateRequest(517).
 		Key(tarantool.IntKey{1111}).
 		Operations(tarantool.NewOperations().Assign(1, "bye"))
-	resp, err := conn.Do(req)
+	resp, err := conn.Do(req).Get()
 	if err != nil {
 		fmt.Printf("error in do update request is %v", err)
 		return
@@ -174,7 +174,7 @@ func ExampleUpdateRequest() {
 		Index("primary").
 		Key(tarantool.IntKey{1111}).
 		Operations(tarantool.NewOperations().Assign(1, "hello"))
-	fut := conn.DoAsync(req)
+	fut := conn.Do(req)
 	resp, err = fut.Get()
 	if err != nil {
 		fmt.Printf("error in do async update request is %v", err)
@@ -194,7 +194,7 @@ func ExampleUpsertRequest() {
 	req = tarantool.NewUpsertRequest(517).
 		Tuple([]interface{}{uint(1113), "first", "first"}).
 		Operations(tarantool.NewOperations().Assign(1, "updated"))
-	resp, err := conn.Do(req)
+	resp, err := conn.Do(req).Get()
 	if err != nil {
 		fmt.Printf("error in do select upsert is %v", err)
 		return
@@ -204,7 +204,7 @@ func ExampleUpsertRequest() {
 	req = tarantool.NewUpsertRequest("test").
 		Tuple([]interface{}{uint(1113), "second", "second"}).
 		Operations(tarantool.NewOperations().Assign(2, "updated"))
-	fut := conn.DoAsync(req)
+	fut := conn.Do(req)
 	resp, err = fut.Get()
 	if err != nil {
 		fmt.Printf("error in do async upsert request is %v", err)
@@ -215,7 +215,7 @@ func ExampleUpsertRequest() {
 	req = tarantool.NewSelectRequest(517).
 		Limit(100).
 		Key(tarantool.IntKey{1113})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		fmt.Printf("error in do select request is %v", err)
 		return

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -482,17 +482,7 @@ func (connMulti *ConnectionMulti) EvalAsync(expr string, args interface{}) *tara
 	return connMulti.getCurrentConnection().EvalAsync(expr, args)
 }
 
-// Do sends the request and returns a response.
-func (connMulti *ConnectionMulti) Do(req tarantool.Request) (*tarantool.Response, error) {
+// Do sends the request and returns a future.
+func (connMulti *ConnectionMulti) Do(req tarantool.Request) *tarantool.Future {
 	return connMulti.getCurrentConnection().Do(req)
-}
-
-// DoTyped sends the request and fills the typed result.
-func (connMulti *ConnectionMulti) DoTyped(req tarantool.Request, result interface{}) error {
-	return connMulti.getCurrentConnection().DoTyped(req, result)
-}
-
-// DoAsync sends the request and returns a future.
-func (connMulti *ConnectionMulti) DoAsync(req tarantool.Request) *tarantool.Future {
-	return connMulti.getCurrentConnection().DoAsync(req)
 }

--- a/request.go
+++ b/request.go
@@ -97,7 +97,7 @@ func fillPing(enc *msgpack.Encoder) error {
 
 // Ping sends empty request to Tarantool to check connection.
 func (conn *Connection) Ping() (resp *Response, err error) {
-	return conn.Do(NewPingRequest())
+	return conn.Do(NewPingRequest()).Get()
 }
 
 // Select performs select to box space.
@@ -311,28 +311,28 @@ func (conn *Connection) SelectAsync(space, index interface{}, offset, limit, ite
 		Limit(limit).
 		Iterator(iterator).
 		Key(key)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // InsertAsync sends insert action to Tarantool and returns Future.
 // Tarantool will reject Insert when tuple with same primary key exists.
 func (conn *Connection) InsertAsync(space interface{}, tuple interface{}) *Future {
 	req := NewInsertRequest(space).Tuple(tuple)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // ReplaceAsync sends "insert or replace" action to Tarantool and returns Future.
 // If tuple with same primary key exists, it will be replaced.
 func (conn *Connection) ReplaceAsync(space interface{}, tuple interface{}) *Future {
 	req := NewReplaceRequest(space).Tuple(tuple)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // DeleteAsync sends deletion action to Tarantool and returns Future.
 // Future's result will contain array with deleted tuple.
 func (conn *Connection) DeleteAsync(space, index interface{}, key interface{}) *Future {
 	req := NewDeleteRequest(space).Index(index).Key(key)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // Update sends deletion of a tuple by key and returns Future.
@@ -340,7 +340,7 @@ func (conn *Connection) DeleteAsync(space, index interface{}, key interface{}) *
 func (conn *Connection) UpdateAsync(space, index interface{}, key, ops interface{}) *Future {
 	req := NewUpdateRequest(space).Index(index).Key(key)
 	req.ops = ops
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // UpsertAsync sends "update or insert" action to Tarantool and returns Future.
@@ -348,7 +348,7 @@ func (conn *Connection) UpdateAsync(space, index interface{}, key, ops interface
 func (conn *Connection) UpsertAsync(space interface{}, tuple interface{}, ops interface{}) *Future {
 	req := NewUpsertRequest(space).Tuple(tuple)
 	req.ops = ops
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // CallAsync sends a call to registered Tarantool function and returns Future.
@@ -357,7 +357,7 @@ func (conn *Connection) UpsertAsync(space interface{}, tuple interface{}, ops in
 // Otherwise, uses request code for Tarantool 1.6.
 func (conn *Connection) CallAsync(functionName string, args interface{}) *Future {
 	req := NewCallRequest(functionName).Args(args)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // Call16Async sends a call to registered Tarantool function and returns Future.
@@ -365,7 +365,7 @@ func (conn *Connection) CallAsync(functionName string, args interface{}) *Future
 // Deprecated since Tarantool 1.7.2.
 func (conn *Connection) Call16Async(functionName string, args interface{}) *Future {
 	req := NewCall16Request(functionName).Args(args)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // Call17Async sends a call to registered Tarantool function and returns Future.
@@ -373,20 +373,20 @@ func (conn *Connection) Call16Async(functionName string, args interface{}) *Futu
 // (though, keep in mind, result is always array)
 func (conn *Connection) Call17Async(functionName string, args interface{}) *Future {
 	req := NewCall17Request(functionName).Args(args)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // EvalAsync sends a Lua expression for evaluation and returns Future.
 func (conn *Connection) EvalAsync(expr string, args interface{}) *Future {
 	req := NewEvalRequest(expr).Args(args)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // ExecuteAsync sends a sql expression for execution and returns Future.
 // Since 1.6.0
 func (conn *Connection) ExecuteAsync(expr string, args interface{}) *Future {
 	req := NewExecuteRequest(expr).Args(args)
-	return conn.DoAsync(req)
+	return conn.Do(req)
 }
 
 // KeyValueBind is a type for encoding named SQL parameters

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -121,7 +121,7 @@ func BenchmarkClientSerialRequestObject(b *testing.B) {
 			Limit(1).
 			Iterator(IterEq).
 			Key([]interface{}{uint(1111)})
-		_, err := conn.Do(req)
+		_, err := conn.Do(req).Get()
 		if err != nil {
 			b.Error(err)
 		}
@@ -1613,7 +1613,7 @@ func TestClientRequestObjects(t *testing.T) {
 
 	// Ping
 	req = NewPingRequest()
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Ping: %s", err.Error())
 	}
@@ -1633,7 +1633,7 @@ func TestClientRequestObjects(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		req = NewInsertRequest(spaceName).
 			Tuple([]interface{}{uint(i), fmt.Sprintf("val %d", i), "bla"})
-		resp, err = conn.Do(req)
+		resp, err = conn.Do(req).Get()
 		if err != nil {
 			t.Fatalf("Failed to Insert: %s", err.Error())
 		}
@@ -1668,7 +1668,7 @@ func TestClientRequestObjects(t *testing.T) {
 	for i := 1015; i < 1020; i++ {
 		req = NewReplaceRequest(spaceName).
 			Tuple([]interface{}{uint(i), fmt.Sprintf("val %d", i), "blar"})
-		resp, err = conn.Do(req)
+		resp, err = conn.Do(req).Get()
 		if err != nil {
 			t.Fatalf("Failed to Replace: %s", err.Error())
 		}
@@ -1702,7 +1702,7 @@ func TestClientRequestObjects(t *testing.T) {
 	// Delete
 	req = NewDeleteRequest(spaceName).
 		Key([]interface{}{uint(1016)})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Delete: %s", err.Error())
 	}
@@ -1736,7 +1736,7 @@ func TestClientRequestObjects(t *testing.T) {
 	req = NewUpdateRequest(spaceName).
 		Index(indexName).
 		Key([]interface{}{uint(1010)})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to Update: %s", err.Error())
 	}
@@ -1768,7 +1768,7 @@ func TestClientRequestObjects(t *testing.T) {
 		Index(indexName).
 		Key([]interface{}{uint(1010)}).
 		Operations(NewOperations().Assign(1, "bye").Insert(2, 1))
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to Update: %s", err.Error())
 	}
@@ -1798,7 +1798,7 @@ func TestClientRequestObjects(t *testing.T) {
 	// Upsert without operations.
 	req = NewUpsertRequest(spaceNo).
 		Tuple([]interface{}{uint(1010), "hi", "hi"})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to Upsert (update): %s", err.Error())
 	}
@@ -1816,7 +1816,7 @@ func TestClientRequestObjects(t *testing.T) {
 	req = NewUpsertRequest(spaceNo).
 		Tuple([]interface{}{uint(1010), "hi", "hi"}).
 		Operations(NewOperations().Assign(2, "bye"))
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to Upsert (update): %s", err.Error())
 	}
@@ -1836,7 +1836,7 @@ func TestClientRequestObjects(t *testing.T) {
 		Limit(20).
 		Iterator(IterGe).
 		Key([]interface{}{uint(1010)})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to Select: %s", err.Error())
 	}
@@ -1863,7 +1863,7 @@ func TestClientRequestObjects(t *testing.T) {
 
 	// Call16 vs Call17
 	req = NewCall16Request("simple_incr").Args([]interface{}{1})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call")
 	}
@@ -1873,7 +1873,7 @@ func TestClientRequestObjects(t *testing.T) {
 
 	// Call17
 	req = NewCall17Request("simple_incr").Args([]interface{}{1})
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Errorf("Failed to use Call17")
 	}
@@ -1883,7 +1883,7 @@ func TestClientRequestObjects(t *testing.T) {
 
 	// Eval
 	req = NewEvalRequest("return 5 + 6")
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Eval: %s", err.Error())
 	}
@@ -1908,7 +1908,7 @@ func TestClientRequestObjects(t *testing.T) {
 	}
 
 	req = NewExecuteRequest(createTableQuery)
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Execute: %s", err.Error())
 	}
@@ -1926,7 +1926,7 @@ func TestClientRequestObjects(t *testing.T) {
 	}
 
 	req = NewExecuteRequest(dropQuery2)
-	resp, err = conn.Do(req)
+	resp, err = conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Execute: %s", err.Error())
 	}


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Before we do a release 1.7.0 I propose a little change: left only an asynchronous version of Connection.Do.

In fact existing now Connection.Do() and Connection.DoTyped() are just wrappers for other public API calls. We can remove it without consequences. A client code will not suffer much. Before:

```Go
resp, err := conn.Do(req)
err := conn.DoTyped(req, &tup)
fut := conn.Do(req)
```

After:

```Go
req, err := Conn.Do(req).Get()
err := conn.Do(req).GetTyped(&tup)
fut := conn.Do(req)
```

So there are reasons for the patch:

1. It helps to make the public API shorter.
2. It makes the asynchronous essence of the connector is more clear.
3. It helps not to spread the unnecessary API to submodules.
4. We will have more freedom for changes in the future.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)