### PR TITLE
api: remove NewErrorFuture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - `IPROTO_*` constants that identify requests renamed from `<Name>Request` to
   `<Name>RequestCode` (#126)
 
+### Removed
+
+- NewErrorFuture function (#190)
+
 ### Fixed
 
 ## [1.6.0] - 2022-06-01

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -416,7 +416,7 @@ func (connPool *ConnectionPool) EvalTyped(expr string, args interface{}, result 
 func (connPool *ConnectionPool) SelectAsync(space, index interface{}, offset, limit, iterator uint32, key interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(ANY, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.SelectAsync(space, index, offset, limit, iterator, key)
@@ -427,7 +427,7 @@ func (connPool *ConnectionPool) SelectAsync(space, index interface{}, offset, li
 func (connPool *ConnectionPool) InsertAsync(space interface{}, tuple interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(RW, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.InsertAsync(space, tuple)
@@ -438,7 +438,7 @@ func (connPool *ConnectionPool) InsertAsync(space interface{}, tuple interface{}
 func (connPool *ConnectionPool) ReplaceAsync(space interface{}, tuple interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(RW, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.ReplaceAsync(space, tuple)
@@ -449,7 +449,7 @@ func (connPool *ConnectionPool) ReplaceAsync(space interface{}, tuple interface{
 func (connPool *ConnectionPool) DeleteAsync(space, index interface{}, key interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(RW, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.DeleteAsync(space, index, key)
@@ -460,7 +460,7 @@ func (connPool *ConnectionPool) DeleteAsync(space, index interface{}, key interf
 func (connPool *ConnectionPool) UpdateAsync(space, index interface{}, key, ops interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(RW, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.UpdateAsync(space, index, key, ops)
@@ -471,7 +471,7 @@ func (connPool *ConnectionPool) UpdateAsync(space, index interface{}, key, ops i
 func (connPool *ConnectionPool) UpsertAsync(space interface{}, tuple interface{}, ops interface{}, userMode ...Mode) *tarantool.Future {
 	conn, err := connPool.getConnByMode(RW, userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.UpsertAsync(space, tuple, ops)
@@ -484,7 +484,7 @@ func (connPool *ConnectionPool) UpsertAsync(space interface{}, tuple interface{}
 func (connPool *ConnectionPool) CallAsync(functionName string, args interface{}, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.CallAsync(functionName, args)
@@ -496,7 +496,7 @@ func (connPool *ConnectionPool) CallAsync(functionName string, args interface{},
 func (connPool *ConnectionPool) Call16Async(functionName string, args interface{}, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.Call16Async(functionName, args)
@@ -508,7 +508,7 @@ func (connPool *ConnectionPool) Call16Async(functionName string, args interface{
 func (connPool *ConnectionPool) Call17Async(functionName string, args interface{}, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.Call17Async(functionName, args)
@@ -518,7 +518,7 @@ func (connPool *ConnectionPool) Call17Async(functionName string, args interface{
 func (connPool *ConnectionPool) EvalAsync(expr string, args interface{}, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.EvalAsync(expr, args)
@@ -548,7 +548,7 @@ func (connPool *ConnectionPool) DoTyped(req tarantool.Request, result interface{
 func (connPool *ConnectionPool) DoAsync(req tarantool.Request, userMode Mode) *tarantool.Future {
 	conn, err := connPool.getNextConnection(userMode)
 	if err != nil {
-		return tarantool.NewErrorFuture(err)
+		return newErrorFuture(err)
 	}
 
 	return conn.DoAsync(req)
@@ -801,4 +801,10 @@ func (connPool *ConnectionPool) getConnByMode(defaultMode Mode, userMode []Mode)
 	}
 
 	return connPool.getNextConnection(mode)
+}
+
+func newErrorFuture(err error) *tarantool.Future {
+	fut := tarantool.NewFuture()
+	fut.SetError(err)
+	return fut
 }

--- a/future.go
+++ b/future.go
@@ -126,13 +126,6 @@ func NewFuture() (fut *Future) {
 	return fut
 }
 
-// NewErrorFuture returns new set empty Future with filled error field.
-func NewErrorFuture(err error) *Future {
-	fut := NewFuture()
-	fut.SetError(err)
-	return fut
-}
-
 // AppendPush appends the push response to the future.
 // Note: it works only before SetResponse() or SetError()
 func (fut *Future) AppendPush(resp *Response) {


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Before we do a release 1.7.0 I propose a little change: remove NewErrorFuture function from the public API.

It was introduced in e9b9ba1e . The function looks strange in the public API. The patch moves it to the connection_pool's internal implementation.

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)