### PR TITLE
datetime: sync datetime range with Tarantool

### DIFF
--- a/datetime/example_test.go
+++ b/datetime/example_test.go
@@ -35,7 +35,11 @@ func Example() {
 		fmt.Printf("error in time.Parse() is %v", err)
 		return
 	}
-	dt := NewDatetime(tm)
+	dt, err := NewDatetime(tm)
+	if err != nil {
+		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
+		return
+	}
 
 	space := "testDatetime_1"
 	index := "primary"


### PR DESCRIPTION
The patch adds check for supported Datetime values. The supported range
comes from Tarantool implementation [1] and c-dt library [2].

1. https://github.com/tarantool/tarantool/blob/a99ccce5f517d2a04670289d3d09a8cc2f5916f9/src/lib/core/datetime.h#L44-L61
2. https://github.com/tarantool/c-dt/blob/e6214325fe8d4336464ebae859ac2b456fd22b77/API.pod#introduction

I didn't forget about (remove if it is not applicable):

I didn't add an entry to CHANGELOG.md because there hasn't been a release since datetime support. But I can add if necessary.

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #191