### PR TITLE
fixes for race conditions with Future objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Build with OpenSSL < 1.1.1 (#194)
 - Add `ExecuteAsync` and `ExecuteTyped` to common connector interface (#62)
+- Race conditions in methods of `Future` type (#195)
 
 ## [1.6.0] - 2022-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Build with OpenSSL < 1.1.1 (#194)
 - Add `ExecuteAsync` and `ExecuteTyped` to common connector interface (#62)
 - Race conditions in methods of `Future` type (#195)
+- Usage of nil pointer in Connection.peekFuture (#195)
 
 ## [1.6.0] - 2022-06-01
 

--- a/connection.go
+++ b/connection.go
@@ -854,11 +854,12 @@ func (conn *Connection) peekFuture(reqid uint32) (fut *Future) {
 	defer shard.rmut.Unlock()
 
 	if conn.opts.Timeout > 0 {
-		fut = conn.getFutureImp(reqid, true)
-		pair := &shard.requests[pos]
-		*pair.last = fut
-		pair.last = &fut.next
-		fut.timeout = time.Since(epoch) + conn.opts.Timeout
+		if fut = conn.getFutureImp(reqid, true); fut != nil {
+			pair := &shard.requests[pos]
+			*pair.last = fut
+			pair.last = &fut.next
+			fut.timeout = time.Since(epoch) + conn.opts.Timeout
+		}
 	} else {
 		fut = conn.getFutureImp(reqid, false)
 	}

--- a/future.go
+++ b/future.go
@@ -129,25 +129,27 @@ func NewFuture() (fut *Future) {
 // AppendPush appends the push response to the future.
 // Note: it works only before SetResponse() or SetError()
 func (fut *Future) AppendPush(resp *Response) {
+	fut.mutex.Lock()
+	defer fut.mutex.Unlock()
+
 	if fut.isDone() {
 		return
 	}
 	resp.Code = PushCode
-	fut.mutex.Lock()
 	fut.pushes = append(fut.pushes, resp)
-	fut.mutex.Unlock()
 
 	fut.ready <- struct{}{}
 }
 
 // SetResponse sets a response for the future and finishes the future.
 func (fut *Future) SetResponse(resp *Response) {
+	fut.mutex.Lock()
+	defer fut.mutex.Unlock()
+
 	if fut.isDone() {
 		return
 	}
-	fut.mutex.Lock()
 	fut.resp = resp
-	fut.mutex.Unlock()
 
 	close(fut.ready)
 	close(fut.done)
@@ -155,12 +157,13 @@ func (fut *Future) SetResponse(resp *Response) {
 
 // SetError sets an error for the future and finishes the future.
 func (fut *Future) SetError(err error) {
+	fut.mutex.Lock()
+	defer fut.mutex.Unlock()
+
 	if fut.isDone() {
 		return
 	}
-	fut.mutex.Lock()
 	fut.err = err
-	fut.mutex.Unlock()
 
 	close(fut.ready)
 	close(fut.done)

--- a/future_test.go
+++ b/future_test.go
@@ -233,3 +233,26 @@ func TestFutureGetIteratorError(t *testing.T) {
 		}
 	}
 }
+
+func TestFutureSetStateRaceCondition(t *testing.T) {
+	err := errors.New("any error")
+	resp := &Response{}
+	respAppend := &Response{}
+
+	for i := 0; i < 1000; i++ {
+		fut := NewFuture()
+		for j := 0; j < 9; j++ {
+			go func(opt int) {
+				if opt%3 == 0 {
+					fut.AppendPush(respAppend)
+				} else if opt%3 == 1 {
+					fut.SetError(err)
+				} else {
+					fut.SetResponse(resp)
+				}
+			}(j)
+		}
+	}
+	// It may be false-positive, but very rarely - it's ok for such very
+	// simple race conditions tests.
+}


### PR DESCRIPTION
The pull request contains two fixes:

1. bugfix: race conditions in Future methods
    
Before the patch it may be possible to close several times fut.ready and fut.done channels from the public API calls.

2. bugfix: usage of nil in Connection.peekFuture()
    
It may be possible to get a nil value from conn.getFutureImp(). We need to check the value before using.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)