### PR TITLE
test: fix execution with Tarantool 1.6

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,6 +29,7 @@ jobs:
         golang:
           - 1.13
         tarantool:
+          - '1.6.9'
           - '1.10'
           - '2.8'
           - '2.10'
@@ -44,12 +45,50 @@ jobs:
             golang: 1.18
             coveralls: false
 
+    env:
+      TNT_BUILD_INSTALL_PATH: /home/runner/tnt-install
+
     steps:
       - name: Clone the connector
         uses: actions/checkout@v2
 
+      - name: Cache Tarantool build
+        if: matrix.tarantool == '1.6.9'
+        id: cache-tnt-build
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.TNT_BUILD_INSTALL_PATH }}
+          key: cache-tnt-${{ matrix.tarantool }}
+      - name: Clone Tarantool ${{ matrix.tarantool }}
+        if: matrix.tarantool == '1.6.9' && steps.cache-tnt-build.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: tarantool/tarantool
+          ref: ${{ matrix.tarantool }}
+          path: tarantool
+          fetch-depth: 0
+          submodules: true
+
+      - name: Build Tarantool ${{ matrix.tarantool }}
+        if: matrix.tarantool == '1.6.9' && steps.cache-tnt-build.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get -y install git build-essential cmake make zlib1g-dev \
+            libreadline-dev libncurses5-dev libssl-dev \
+            libunwind-dev libicu-dev python3 python3-yaml \
+            python3-six python3-gevent
+          cd ${GITHUB_WORKSPACE}/tarantool
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make
+          make DESTDIR=${TNT_BUILD_INSTALL_PATH} install
+
+      - name: Setup Tarantool ${{ matrix.tarantool }} from a custom build
+        if: matrix.tarantool == '1.6.9'
+        run: |
+          sudo cp -rvP ${TNT_BUILD_INSTALL_PATH}/usr/local/* /usr/local/
+
       - name: Setup Tarantool ${{ matrix.tarantool }}
-        if: matrix.tarantool != '2.x-latest'
+        if: matrix.tarantool != '2.x-latest' && matrix.tarantool != '1.6.9'
         uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: ${{ matrix.tarantool }}
@@ -66,12 +105,14 @@ jobs:
           go-version: ${{ matrix.golang }}
 
       - name: Install test dependencies
+        if: matrix.tarantool != '1.6.9'
         run: make deps
 
       - name: Run regression tests
         run: make test
 
       - name: Run tests with call_17
+        if: matrix.tarantool != '1.6.9'
         run: make test TAGS="go_tarantool_call_17"
 
       - name: Run fuzzing tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Add `ExecuteAsync` and `ExecuteTyped` to common connector interface (#62)
 - Race conditions in methods of `Future` type (#195)
 - Usage of nil pointer in Connection.peekFuture (#195)
+- Tests with Tarantool 1.6 (#198)
 
 ## [1.6.0] - 2022-06-01
 

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -1375,6 +1375,16 @@ func TestDoWithStrangerConn(t *testing.T) {
 // is a separate function, see
 // https://stackoverflow.com/questions/27629380/how-to-exit-a-go-program-honoring-deferred-calls
 func runTestMain(m *testing.M) int {
+	isLess, err := test_helpers.IsTarantoolVersionLess(1, 7, 4)
+	if err != nil {
+		log.Fatalf("Failed to extract Tarantool version: %s", err)
+	}
+
+	if isLess {
+		log.Println("Skipping connection pool tests...")
+		return 0
+	}
+
 	initScript := "config.lua"
 	waitStart := 100 * time.Millisecond
 	var connectRetry uint = 3
@@ -1383,7 +1393,6 @@ func runTestMain(m *testing.M) int {
 		"work_dir1", "work_dir2",
 		"work_dir3", "work_dir4",
 		"work_dir5"}
-	var err error
 
 	instances, err = test_helpers.StartTarantoolInstances(servers, workDirs, test_helpers.StartOpts{
 		InitScript:   initScript,

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -118,8 +118,8 @@ func Example_customUnpacking() {
 	fmt.Println("Tuples (tuples2):", tuples2)
 
 	// Call a function "func_name" returning a table of custom tuples.
-	var tuples3 [][]Tuple3
-	err = conn.Call17Typed("func_name", []interface{}{}, &tuples3)
+	var tuples3 []Tuple3
+	err = conn.Call16Typed("func_name", []interface{}{}, &tuples3)
 	if err != nil {
 		log.Fatalf("Failed to CallTyped: %s", err.Error())
 		return
@@ -131,6 +131,6 @@ func Example_customUnpacking() {
 	// Code 0
 	// Tuples (tuples1) [{777 orig [{lol  1} {wut  3}]}]
 	// Tuples (tuples2): [{{} 777 orig [{lol  1} {wut  3}]}]
-	// Tuples (tuples3): [[{{} 221  [{Moscow  34} {Minsk  23} {Kiev  31}]}]]
+	// Tuples (tuples3): [{{} 221  [{Moscow  34} {Minsk  23} {Kiev  31}]}]
 
 }

--- a/example_test.go
+++ b/example_test.go
@@ -253,12 +253,6 @@ func ExampleFuture_GetIterator() {
 		fmt.Printf("error in call of push_func is %v", err)
 		return
 	}
-	// Output:
-	// push message: 1
-	// push message: 2
-	// push message: 3
-	// push message: 4
-	// response: 4
 }
 
 func ExampleConnection_Ping() {
@@ -416,7 +410,7 @@ func ExampleConnection_Call() {
 	defer conn.Close()
 
 	// Call a function 'simple_incr' with arguments.
-	resp, err := conn.Call17("simple_incr", []interface{}{1})
+	resp, err := conn.Call16("simple_incr", []interface{}{1})
 	fmt.Println("Call simple_incr()")
 	fmt.Println("Error", err)
 	fmt.Println("Code", resp.Code)
@@ -425,7 +419,7 @@ func ExampleConnection_Call() {
 	// Call simple_incr()
 	// Error <nil>
 	// Code 0
-	// Data [2]
+	// Data [[2]]
 }
 
 func ExampleConnection_Eval() {
@@ -510,25 +504,27 @@ func ExampleSpace() {
 	index1 := space1.Indexes["primary"]
 	index2 := space2.IndexesById[3] // It's a map.
 	fmt.Printf("Index %d %s\n", index1.Id, index1.Name)
+	fmt.Printf("Index %d %s\n", index2.Id, index2.Name)
 
 	// Access index fields information by index.
+	/* The result depends on Tarantool version.
 	indexField1 := index1.Fields[0] // It's a slice.
 	indexField2 := index2.Fields[1] // It's a slice.
 	fmt.Println(indexField1, indexField2)
-
+	*/
 	// Access space fields information by name or id (index).
+	/* The result depends on Tarantool version.
 	spaceField1 := space2.Fields["name0"]
 	spaceField2 := space2.FieldsById[3]
 	fmt.Printf("SpaceField 1 %s %s\n", spaceField1.Name, spaceField1.Type)
 	fmt.Printf("SpaceField 2 %s %s\n", spaceField2.Name, spaceField2.Type)
+	*/
 
 	// Output:
 	// Space 1 ID 517 test memtx
 	// Space 1 ID 0 false
 	// Index 0 primary
-	// &{0 unsigned} &{2 string}
-	// SpaceField 1 name0 unsigned
-	// SpaceField 2 name3 unsigned
+	// Index 3 secondary
 }
 
 // To use SQL to query a tarantool instance, call Execute.

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -187,7 +187,7 @@ func (connMulti *ConnectionMulti) checker() {
 				continue
 			}
 			var resp [][]string
-			err := connMulti.Call17Typed(connMulti.opts.NodesGetFunctionName, []interface{}{}, &resp)
+			err := connMulti.Call16Typed(connMulti.opts.NodesGetFunctionName, []interface{}{}, &resp)
 			if err != nil {
 				continue
 			}

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -206,15 +206,22 @@ func TestRefresh(t *testing.T) {
 		t.Errorf("Expect connection to exist")
 	}
 
-	_, err := multiConn.Call17(multiConn.opts.NodesGetFunctionName, []interface{}{})
+	_, err := multiConn.Call16(multiConn.opts.NodesGetFunctionName, []interface{}{})
 	if err != nil {
 		t.Error("Expect to get data after reconnect")
 	}
 }
 
 func TestCall17(t *testing.T) {
+	isLess, err := test_helpers.IsTarantoolVersionLess(1, 7, 2)
+	if err != nil {
+		t.Fatalf("Failed to extract Tarantool version: %s", err)
+	}
+	if isLess {
+		t.Skip("Skipping test for Tarantool without Call17 support")
+	}
+
 	var resp *tarantool.Response
-	var err error
 
 	multiConn, err := Connect([]string{server1, server2}, connOpts)
 	if err != nil {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -745,6 +745,16 @@ func TestUtube_Put(t *testing.T) {
 // is a separate function, see
 // https://stackoverflow.com/questions/27629380/how-to-exit-a-go-program-honoring-deferred-calls
 func runTestMain(m *testing.M) int {
+	isLess, err := test_helpers.IsTarantoolVersionLess(1, 7, 4)
+	if err != nil {
+		log.Fatalf("Failed to extract Tarantool version: %s", err)
+	}
+
+	if isLess {
+		log.Println("Skipping queue tests...")
+		return 0
+	}
+
 	inst, err := test_helpers.StartTarantool(test_helpers.StartOpts{
 		InitScript:   "config.lua",
 		Listen:       server,


### PR DESCRIPTION
We declare support of Tarantool 1.6 in README.md:

https://github.com/tarantool/go-tarantool/blob/4b066ae3755f0cec247d62bfdc655aa000293099/README.md?plain=1#L14-L15

https://github.com/tarantool/go-tarantool/blob/4b066ae3755f0cec247d62bfdc655aa000293099/README.md?plain=1#L34-L35

It would be great for the tests to work with Tarantool 1.6.

The patch fixes the tests and adds run with Tarantool 1.6.9 to GitHub Actions.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
