### PR TITLE
code health: run gofmt from GoLang 1.19

### DIFF
--- a/connection_pool/const.go
+++ b/connection_pool/const.go
@@ -17,18 +17,18 @@ Mode parameter:
 
 - PREFER_RW (prefer write only instance (master)) - if there is one, otherwise fallback to a read only one (replica).
 
-   Request   Default mode
- ---------- --------------
- | call    | no default  |
- | eval    | no default  |
- | ping    | no default  |
- | insert  | RW          |
- | delete  | RW          |
- | replace | RW          |
- | update  | RW          |
- | upsert  | RW          |
- | select  | ANY         |
- | get     | ANY         |
+	  Request   Default mode
+	---------- --------------
+	| call    | no default  |
+	| eval    | no default  |
+	| ping    | no default  |
+	| insert  | RW          |
+	| delete  | RW          |
+	| replace | RW          |
+	| update  | RW          |
+	| upsert  | RW          |
+	| select  | ANY         |
+	| get     | ANY         |
 */
 const (
 	ANY = iota

--- a/decimal/bcd.go
+++ b/decimal/bcd.go
@@ -9,15 +9,15 @@
 // The first byte of the BCD array contains the first digit of the number,
 // represented as follows:
 //
-//     |  4 bits           |  4 bits           |
-//        = 0x                = the 1st digit
+//	|  4 bits           |  4 bits           |
+//	   = 0x                = the 1st digit
 //
 // (The first nibble contains 0 if the decimal number has an even number of
 // digits). The last byte of the BCD array contains the last digit of the
 // number and the final nibble, represented as follows:
 //
-//     |  4 bits           |  4 bits           |
-//        = the last digit    = nibble
+//	|  4 bits           |  4 bits           |
+//	   = the last digit    = nibble
 //
 // The final nibble represents the number's sign: 0x0a, 0x0c, 0x0e, 0x0f stand
 // for plus, 0x0b and 0x0d stand for minus.

--- a/future.go
+++ b/future.go
@@ -210,10 +210,9 @@ func (fut *Future) GetTyped(result interface{}) error {
 // and a response. Push messages and the response will contain deserialized
 // result in Data field as for the Get() function.
 //
-// See also
+// # See also
 //
 // * box.session.push() https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_session/push/
-//
 func (fut *Future) GetIterator() (it TimeoutResponseIterator) {
 	futit := &asyncResponseIterator{
 		fut: fut,

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -3,7 +3,7 @@
 //
 // Since: 1.5.
 //
-// See also
+// # See also
 //
 // * Tarantool queue module https://github.com/tarantool/queue
 package queue

--- a/schema.go
+++ b/schema.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-//nolint: varcheck,deadcode
+// nolint: varcheck,deadcode
 const (
 	maxSchemas             = 10000
 	spaceSpId              = 280

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -198,20 +198,20 @@ type test struct {
 }
 
 /*
-	Requirements from Tarantool Enterprise Edition manual:
-	https://www.tarantool.io/ru/enterprise_doc/security/#configuration
+Requirements from Tarantool Enterprise Edition manual:
+https://www.tarantool.io/ru/enterprise_doc/security/#configuration
 
-	For a server:
-	KeyFile - mandatory
-	CertFile - mandatory
-	CaFile - optional
-	Ciphers - optional
+For a server:
+KeyFile - mandatory
+CertFile - mandatory
+CaFile - optional
+Ciphers - optional
 
-	For a client:
-	KeyFile - optional, mandatory if server.CaFile set
-	CertFile - optional, mandatory if server.CaFile set
-	CaFile - optional,
-	Ciphers - optional
+For a client:
+KeyFile - optional, mandatory if server.CaFile set
+CertFile - optional, mandatory if server.CaFile set
+CaFile - optional,
+Ciphers - optional
 */
 var tests = []test{
 	{

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -4,7 +4,7 @@
 //
 // Since: 1.6.0.
 //
-// See also
+// # See also
 //
 // * Tarantool commit with UUID support https://github.com/tarantool/tarantool/commit/d68fc29246714eee505bc9bbcd84a02de17972c5
 //


### PR DESCRIPTION
golangci-lint on GitHub Actions uses a latest gofmt from GoLang 1.19. The patch contains changes from gofmt 1.19 run to fix golangci-lint check on CI.