### PR TITLE
api: support queue 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Support queue 1.2.0 (#177)
+
 ### Changed
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 
 .PHONY: deps
 deps: clean
-	( cd ./queue; tarantoolctl rocks install queue 1.1.0 )
+	( cd ./queue; tarantoolctl rocks install queue 1.2.0 )
 
 .PHONY: datetime-timezones
 datetime-timezones:

--- a/queue/config.lua
+++ b/queue/config.lua
@@ -9,6 +9,7 @@ box.cfg{
 
     box.once("init", function()
     box.schema.user.create('test', {password = 'test'})
+    box.schema.func.create('queue.tube.test_queue:touch')
     box.schema.func.create('queue.tube.test_queue:ack')
     box.schema.func.create('queue.tube.test_queue:put')
     box.schema.func.create('queue.tube.test_queue:drop')
@@ -17,7 +18,10 @@ box.cfg{
     box.schema.func.create('queue.tube.test_queue:take')
     box.schema.func.create('queue.tube.test_queue:delete')
     box.schema.func.create('queue.tube.test_queue:release')
+    box.schema.func.create('queue.tube.test_queue:release_all')
     box.schema.func.create('queue.tube.test_queue:bury')
+    box.schema.func.create('queue.identify')
+    box.schema.func.create('queue.state')
     box.schema.func.create('queue.statistics')
     box.schema.user.grant('test', 'create', 'space')
     box.schema.user.grant('test', 'write', 'space', '_schema')
@@ -33,6 +37,7 @@ box.cfg{
     box.schema.user.grant('test', 'read,write', 'space', '_queue_consumers')
     box.schema.user.grant('test', 'read,write', 'space', '_priv')
     box.schema.user.grant('test', 'read,write', 'space', '_queue_taken_2')
+    box.schema.user.grant('test', 'read,write', 'space', '_queue_shared_sessions')
     if box.space._trigger ~= nil then
         box.schema.user.grant('test', 'read', 'space', '_trigger')
     end

--- a/queue/const.go
+++ b/queue/const.go
@@ -16,3 +16,22 @@ const (
 	UTUBE     queueType = "utube"
 	UTUBE_TTL queueType = "utubettl"
 )
+
+type State int
+
+const (
+	UnknownState State = iota
+	InitState
+	StartupState
+	RunningState
+	EndingState
+	WaitingState
+)
+
+var strToState = map[string]State{
+	"INIT":    InitState,
+	"STARTUP": StartupState,
+	"RUNNING": RunningState,
+	"ENDING":  EndingState,
+	"WAITING": WaitingState,
+}

--- a/queue/task.go
+++ b/queue/task.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"fmt"
+	"time"
 )
 
 // Task represents a task from Tarantool queue's tube.
@@ -52,6 +53,11 @@ func (t *Task) Data() interface{} {
 // Status is a getter for task status.
 func (t *Task) Status() string {
 	return t.status
+}
+
+// Touch increases ttr of running task.
+func (t *Task) Touch(increment time.Duration) error {
+	return t.accept(t.q._touch(t.id, increment))
 }
 
 // Ack signals about task completion.


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

* bump queue package version to 1.2.0 [1]
* add Task.Touch(): increases TTR and/or TTL for tasks [2]
* add Queue.Cfg(): set queue settings [3]
* add Queue.ReleaseAll(): releases all taken tasks [4]
* add Queue.State(): returns a current queue state [5]
* add Queue.Identify(): identifies a shared session [6]

1. https://github.com/tarantool/queue/releases/tag/1.2.0
2. https://github.com/tarantool/queue/blob/1.2.0/README.md?plain=1#L562-L576
3. https://github.com/tarantool/queue/blob/1.2.0/README.md?plain=1#L450-L463
4. https://github.com/tarantool/queue/blob/1.2.0/README.md?plain=1#L698-L704
5. https://github.com/tarantool/queue/blob/1.2.0/README.md?plain=1#L377-L391
6. https://github.com/tarantool/queue/blob/1.2.0/README.md?plain=1#L465-L494

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #110
Closes #177

At first it was 5 separate commits, but they are perfectly merged into 1 logically.