### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.8.0] - 2022-08-17
+
+### Added
+
 - Optional msgpack.v5 usage (#124)
 - TZ support for datetime (#163)
 - Interval support for datetime (#165)


### PR DESCRIPTION
## Overview

The minor release with time zones and interval support for datetime.

Also now you can use `go-tarantool` with `msgpack.v5`. To do this, add `go_tarantool_msgpack_v5` to your build tags:
```bash
$ go build -tags=go_tarantool_msgpack_v5 .
```

## Breaking changes

There are no breaking changes in the release.

## New features

* Optional msgpack.v5 usage (#124).
* TZ support for datetime (#163).
* Interval support for datetime (#165).

## Bugfixes

* Markdown of documentation for the decimal subpackage (#201).