### PR TITLE
Several fixes for the connection_pool subpackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Mode type description in the connection_pool subpackage (#208)
 - Missed Role type constants in the connection_pool subpackage (#208)
+- ConnectionPool does not close UnknownRole connections (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Mode type description in the connection_pool subpackage (#208)
+
 ## [1.8.0] - 2022-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Mode type description in the connection_pool subpackage (#208)
 - Missed Role type constants in the connection_pool subpackage (#208)
 - ConnectionPool does not close UnknownRole connections (#208)
+- Segmentation faults in ConnectionPool requests after disconnect (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Segmentation faults in ConnectionPool requests after disconnect (#208)
 - Addresses in ConnectionPool may be changed from an external code (#208)
 - ConnectionPool recreates connections too often (#208)
+- A connection is still opened after ConnectionPool.Close() (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Missed Role type constants in the connection_pool subpackage (#208)
 - ConnectionPool does not close UnknownRole connections (#208)
 - Segmentation faults in ConnectionPool requests after disconnect (#208)
+- Addresses in ConnectionPool may be changed from an external code (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - ConnectionPool does not close UnknownRole connections (#208)
 - Segmentation faults in ConnectionPool requests after disconnect (#208)
 - Addresses in ConnectionPool may be changed from an external code (#208)
+- ConnectionPool recreates connections too often (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - Mode type description in the connection_pool subpackage (#208)
+- Missed Role type constants in the connection_pool subpackage (#208)
 
 ## [1.8.0] - 2022-08-17
 

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -591,17 +591,6 @@ func (connPool *ConnectionPool) getConnectionRole(conn *tarantool.Connection) (R
 		return unknown, ErrIncorrectStatus
 	}
 
-	resp, err = conn.Call17("box.info", []interface{}{})
-	if err != nil {
-		return unknown, err
-	}
-	if resp == nil {
-		return unknown, ErrIncorrectResponse
-	}
-	if len(resp.Data) < 1 {
-		return unknown, ErrIncorrectResponse
-	}
-
 	replicaRole, ok := resp.Data[0].(map[interface{}]interface{})["ro"]
 	if !ok {
 		return unknown, ErrIncorrectResponse

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -97,7 +97,7 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsPool) (co
 	anyPool := NewEmptyRoundRobin(size)
 
 	connPool = &ConnectionPool{
-		addrs:    make([]string, len(addrs)),
+		addrs:    make([]string, 0, len(addrs)),
 		connOpts: connOpts,
 		opts:     opts,
 		notify:   notify,
@@ -107,7 +107,14 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsPool) (co
 		roPool:   roPool,
 		anyPool:  anyPool,
 	}
-	copy(connPool.addrs, addrs)
+
+	m := make(map[string]bool)
+	for _, addr := range addrs {
+		if _, ok := m[addr]; !ok {
+			m[addr] = true
+			connPool.addrs = append(connPool.addrs, addr)
+		}
+	}
 
 	somebodyAlive := connPool.fillPools()
 	if !somebodyAlive {

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -25,11 +25,11 @@ var (
 	ErrWrongCheckTimeout = errors.New("wrong check timeout, must be greater than 0")
 	ErrNoConnection      = errors.New("no active connections")
 	ErrTooManyArgs       = errors.New("too many arguments")
-	ErrIncorrectResponse = errors.New("Incorrect response format")
-	ErrIncorrectStatus   = errors.New("Incorrect instance status: status should be `running`")
-	ErrNoRwInstance      = errors.New("Can't find rw instance in pool")
-	ErrNoRoInstance      = errors.New("Can't find ro instance in pool")
-	ErrNoHealthyInstance = errors.New("Can't find healthy instance in pool")
+	ErrIncorrectResponse = errors.New("incorrect response format")
+	ErrIncorrectStatus   = errors.New("incorrect instance status: status should be `running`")
+	ErrNoRwInstance      = errors.New("can't find rw instance in pool")
+	ErrNoRoInstance      = errors.New("can't find ro instance in pool")
+	ErrNoHealthyInstance = errors.New("can't find healthy instance in pool")
 )
 
 /*

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -702,20 +702,7 @@ func (connPool *ConnectionPool) checker() {
 				return
 			}
 			if e.Conn.ClosedNow() {
-				addr := e.Conn.Addr()
-				if conn, _ := connPool.getConnectionFromPool(addr); conn == nil {
-					continue
-				}
-				conn, _ := tarantool.Connect(addr, connPool.connOpts)
-				if conn != nil {
-					err := connPool.setConnectionToPool(addr, conn)
-					if err != nil {
-						conn.Close()
-						log.Printf("tarantool: storing connection to %s failed: %s\n", addr, err.Error())
-					}
-				} else {
-					connPool.deleteConnectionFromPool(addr)
-				}
+				connPool.deleteConnectionFromPool(e.Conn.Addr())
 			}
 		case <-timer.C:
 			for _, addr := range connPool.addrs {

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -558,6 +558,15 @@ func (connPool *ConnectionPool) NewStream(userMode Mode) (*tarantool.Stream, err
 	return conn.NewStream()
 }
 
+// NewPrepared passes a sql statement to Tarantool for preparation synchronously.
+func (connPool *ConnectionPool) NewPrepared(expr string, userMode Mode) (*tarantool.Prepared, error) {
+	conn, err := connPool.getNextConnection(userMode)
+	if err != nil {
+		return nil, err
+	}
+	return conn.NewPrepared(expr)
+}
+
 //
 // private
 //
@@ -811,13 +820,4 @@ func newErrorFuture(err error) *tarantool.Future {
 	fut := tarantool.NewFuture()
 	fut.SetError(err)
 	return fut
-}
-
-// NewPrepared passes a sql statement to Tarantool for preparation synchronously.
-func (connPool *ConnectionPool) NewPrepared(expr string, userMode Mode) (*tarantool.Prepared, error) {
-	conn, err := connPool.getNextConnection(userMode)
-	if err != nil {
-		return nil, err
-	}
-	return conn.NewPrepared(expr)
 }

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -96,7 +96,7 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsPool) (co
 	anyPool := NewEmptyRoundRobin(size)
 
 	connPool = &ConnectionPool{
-		addrs:    addrs,
+		addrs:    make([]string, len(addrs)),
 		connOpts: connOpts,
 		opts:     opts,
 		notify:   notify,
@@ -105,6 +105,7 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsPool) (co
 		roPool:   roPool,
 		anyPool:  anyPool,
 	}
+	copy(connPool.addrs, addrs)
 
 	somebodyAlive := connPool.fillPools()
 	if !somebodyAlive {
@@ -178,7 +179,9 @@ func (connPool *ConnectionPool) Close() []error {
 
 // GetAddrs gets addresses of connections in pool.
 func (connPool *ConnectionPool) GetAddrs() []string {
-	return connPool.addrs
+	cpy := make([]string, len(connPool.addrs))
+	copy(cpy, connPool.addrs)
+	return cpy
 }
 
 // GetPoolInfo gets information of connections (connected status, ro/rw role).

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -1295,7 +1295,7 @@ func TestNewPrepared(t *testing.T) {
 	stmt, err := connPool.NewPrepared("SELECT NAME0, NAME1 FROM SQL_TEST WHERE NAME0=:id AND NAME1=:name;", connection_pool.RO)
 	require.Nilf(t, err, "fail to prepare statement: %v", err)
 
-	if connPool.GetPoolInfo()[stmt.Conn.Addr()].ConnRole != connection_pool.RO {
+	if connPool.GetPoolInfo()[stmt.Conn.Addr()].ConnRole != connection_pool.ReplicaRole {
 		t.Errorf("wrong role for the statement's connection")
 	}
 

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -244,6 +244,25 @@ func TestRequestOnClosed(t *testing.T) {
 	require.Nilf(t, err, "failed to restart tarantool")
 }
 
+func TestGetPoolInfo(t *testing.T) {
+	server1 := servers[0]
+	server2 := servers[1]
+
+	srvs := []string{server1, server2}
+	expected := []string{server1, server2}
+	connPool, err := connection_pool.Connect(srvs, connOpts)
+	require.Nilf(t, err, "failed to connect")
+	require.NotNilf(t, connPool, "conn is nil after Connect")
+
+	defer connPool.Close()
+
+	srvs[0] = "x"
+	connPool.GetAddrs()[1] = "y"
+	for i, addr := range connPool.GetAddrs() {
+		require.Equal(t, expected[i], addr)
+	}
+}
+
 func TestCall17(t *testing.T) {
 	roles := []bool{false, true, false, false, true}
 

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -80,6 +80,31 @@ func TestConnSuccessfully(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestConnSuccessfullyDuplicates(t *testing.T) {
+	server := servers[0]
+	connPool, err := connection_pool.Connect([]string{server, server, server, server}, connOpts)
+	require.Nilf(t, err, "failed to connect")
+	require.NotNilf(t, connPool, "conn is nil after Connect")
+
+	defer connPool.Close()
+
+	args := test_helpers.CheckStatusesArgs{
+		ConnPool:           connPool,
+		Mode:               connection_pool.ANY,
+		Servers:            []string{server},
+		ExpectedPoolStatus: true,
+		ExpectedStatuses: map[string]bool{
+			server: true,
+		},
+	}
+
+	err = test_helpers.CheckPoolStatuses(args)
+	require.Nil(t, err)
+
+	addrs := connPool.GetAddrs()
+	require.Equalf(t, []string{server}, addrs, "should be only one address")
+}
+
 func TestReconnect(t *testing.T) {
 	server := servers[0]
 

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -431,7 +431,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	// RO
 	_, err = connPool.Eval("return box.cfg.listen", []interface{}{}, connection_pool.RO)
 	require.NotNilf(t, err, "expected to fail after Eval, but error is nil")
-	require.Equal(t, "Can't find ro instance in pool", err.Error())
+	require.Equal(t, "can't find ro instance in pool", err.Error())
 
 	// ANY
 	args := test_helpers.ListenOnInstanceArgs{
@@ -502,7 +502,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	// RW
 	_, err = connPool.Eval("return box.cfg.listen", []interface{}{}, connection_pool.RW)
 	require.NotNilf(t, err, "expected to fail after Eval, but error is nil")
-	require.Equal(t, "Can't find rw instance in pool", err.Error())
+	require.Equal(t, "can't find rw instance in pool", err.Error())
 
 	// ANY
 	args := test_helpers.ListenOnInstanceArgs{

--- a/connection_pool/const.go
+++ b/connection_pool/const.go
@@ -26,13 +26,13 @@ const (
 	PreferRO             // If there is one, otherwise fallback to a read only one (replica).
 )
 
+// Role describes a role of an instance by its mode.
 type Role uint32
 
-// master/replica role
 const (
-	unknown = iota
-	master
-	replica
+	UnknownRole Role = iota // A connection pool failed to discover mode of the instance.
+	MasterRole              // The instance is read-write mode.
+	ReplicaRole             // The instance is in read-only mode.
 )
 
 type State uint32

--- a/connection_pool/const.go
+++ b/connection_pool/const.go
@@ -34,11 +34,3 @@ const (
 	MasterRole              // The instance is read-write mode.
 	ReplicaRole             // The instance is in read-only mode.
 )
-
-type State uint32
-
-// pool state
-const (
-	connConnected = iota
-	connClosed
-)

--- a/connection_pool/const.go
+++ b/connection_pool/const.go
@@ -1,21 +1,7 @@
 package connection_pool
 
-type Mode uint32
-type Role uint32
-type State uint32
-
 /*
-Mode parameter:
-
-- ANY (use any instance) - the request can be executed on any instance (master or replica).
-
-- RW (writeable instance (master)) - the request can only be executed on master.
-
-- RO (read only instance (replica)) - the request can only be executed on replica.
-
-- PREFER_RO (prefer read only instance (replica)) - if there is one, otherwise fallback to a writeable one (master).
-
-- PREFER_RW (prefer write only instance (master)) - if there is one, otherwise fallback to a read only one (replica).
+Default mode for each request table:
 
 	  Request   Default mode
 	---------- --------------
@@ -30,13 +16,17 @@ Mode parameter:
 	| select  | ANY         |
 	| get     | ANY         |
 */
+type Mode uint32
+
 const (
-	ANY = iota
-	RW
-	RO
-	PreferRW
-	PreferRO
+	ANY      Mode = iota // The request can be executed on any instance (master or replica).
+	RW                   // The request can only be executed on master.
+	RO                   // The request can only be executed on replica.
+	PreferRW             // If there is one, otherwise fallback to a writeable one (master).
+	PreferRO             // If there is one, otherwise fallback to a read only one (replica).
 )
+
+type Role uint32
 
 // master/replica role
 const (
@@ -44,6 +34,8 @@ const (
 	master
 	replica
 )
+
+type State uint32
 
 // pool state
 const (

--- a/connection_pool/example_test.go
+++ b/connection_pool/example_test.go
@@ -254,7 +254,7 @@ func ExampleConnectionPool_SelectAsync_err() {
 	fmt.Println("Future", 0, "Error", err)
 
 	// Output:
-	// Future 0 Error Can't find rw instance in pool
+	// Future 0 Error can't find rw instance in pool
 }
 
 func ExampleConnectionPool_Ping() {

--- a/connection_pool/round_robin.go
+++ b/connection_pool/round_robin.go
@@ -60,19 +60,6 @@ func (r *RoundRobinStrategy) IsEmpty() bool {
 	return r.size == 0
 }
 
-func (r *RoundRobinStrategy) CloseConns() []error {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
-	errs := make([]error, len(r.conns))
-
-	for i, conn := range r.conns {
-		errs[i] = conn.Close()
-	}
-
-	return errs
-}
-
 func (r *RoundRobinStrategy) GetNextConnection() *tarantool.Connection {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()

--- a/connection_pool/round_robin_test.go
+++ b/connection_pool/round_robin_test.go
@@ -52,4 +52,20 @@ func TestRoundRobinAddDuplicateDelete(t *testing.T) {
 	}
 }
 
+func TestRoundRobinGetNextConnection(t *testing.T) {
+	rr := NewEmptyRoundRobin(10)
 
+	addrs := []string{validAddr1, validAddr2}
+	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
+
+	for i, addr := range addrs {
+		rr.AddConn(addr, conns[i])
+	}
+
+	expectedConns := []*tarantool.Connection{conns[0], conns[1], conns[0], conns[1]}
+	for i, expected := range expectedConns {
+		if rr.GetNextConnection() != expected {
+			t.Errorf("Unexpected connection on %d call", i)
+		}
+	}
+}

--- a/connection_pool/round_robin_test.go
+++ b/connection_pool/round_robin_test.go
@@ -1,0 +1,55 @@
+package connection_pool_test
+
+import (
+	"testing"
+
+	"github.com/tarantool/go-tarantool"
+	. "github.com/tarantool/go-tarantool/connection_pool"
+)
+
+const (
+	validAddr1 = "x"
+	validAddr2 = "y"
+)
+
+func TestRoundRobinAddDelete(t *testing.T) {
+	rr := NewEmptyRoundRobin(10)
+
+	addrs := []string{validAddr1, validAddr2}
+	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
+
+	for i, addr := range addrs {
+		rr.AddConn(addr, conns[i])
+	}
+
+	for i, addr := range addrs {
+		if conn := rr.DeleteConnByAddr(addr); conn != conns[i] {
+			t.Errorf("Unexpected connection on address %s", addr)
+		}
+	}
+	if !rr.IsEmpty() {
+		t.Errorf("RoundRobin does not empty")
+	}
+}
+
+func TestRoundRobinAddDuplicateDelete(t *testing.T) {
+	rr := NewEmptyRoundRobin(10)
+
+	conn1 := &tarantool.Connection{}
+	conn2 := &tarantool.Connection{}
+
+	rr.AddConn(validAddr1, conn1)
+	rr.AddConn(validAddr1, conn2)
+
+	if rr.DeleteConnByAddr(validAddr1) != conn2 {
+		t.Errorf("Unexpected deleted connection")
+	}
+	if !rr.IsEmpty() {
+		t.Errorf("RoundRobin does not empty")
+	}
+	if rr.DeleteConnByAddr(validAddr1) != nil {
+		t.Errorf("Unexpected value after second deletion")
+	}
+}
+
+

--- a/connection_pool/state.go
+++ b/connection_pool/state.go
@@ -1,0 +1,26 @@
+package connection_pool
+
+import (
+	"sync/atomic"
+)
+
+// pool state
+type state uint32
+
+const (
+	unknownState state = iota
+	connectedState
+	closedState
+)
+
+func (s *state) set(news state) {
+	atomic.StoreUint32((*uint32)(s), uint32(news))
+}
+
+func (s *state) cas(olds, news state) bool {
+	return atomic.CompareAndSwapUint32((*uint32)(s), uint32(olds), uint32(news))
+}
+
+func (s *state) get() state {
+	return state(atomic.LoadUint32((*uint32)(s)))
+}


### PR DESCRIPTION
The patchset contains a number of different fixes for the connection_pool package. I tried to make the changes in small commits so that it would be easier to review them. I recommend to review the changes one by one commit.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)