### PR TITLE
api: add ConnectionHandler to the connection_pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - Support queue 1.2.0 (#177)
+- ConnectionHandler interface for handling changes of connections in
+  ConnectionPool (#178)
 
 ### Changed
 


### PR DESCRIPTION
ConnectionHandler provides callbacks for components interested in handling changes of connections in a ConnectionPool.

We have to take into account that user callbacks can take an indefinite amount of time. The simplest solution is to process each connection in a separate goroutine. This should not affect to performance because most of the time these goroutines are blocked.


I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #178

The pull request is based on #208. You need to review **only a last commit** until #208 is not merged.