### PR TITLE
bugfix: decimal use a test function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - A connection is still opened after ConnectionPool.Close() (#208)
 - Future.GetTyped() after Future.Get() does not decode response
   correctly (#213)
+- Decimal package use a test function GetNumberLength instead of a
+  package-level function getNumberLength (#219)
 
 ## [1.8.0] - 2022-08-17
 

--- a/decimal/bcd.go
+++ b/decimal/bcd.go
@@ -117,7 +117,7 @@ func encodeStringToBCD(buf string) ([]byte, error) {
 	// number of digits. Therefore highNibble is false when decimal number
 	// is even.
 	highNibble := true
-	l := GetNumberLength(buf)
+	l := getNumberLength(buf)
 	if l%2 == 0 {
 		highNibble = false
 	}


### PR DESCRIPTION
The patch replaces usage of a test function GetNumberLength by a package-level function getNumberLength in the decimal package code.

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)