### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,24 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
-- Support queue 1.2.0 (#177)
+### Changed
+
+### Fixed
+
+## [1.9.0] - 2022-11-02
+
+The release adds support for the latest version of the
+[queue package](https://github.com/tarantool/queue) with master-replica
+switching.
+
+### Added
+
+- Support the queue 1.2.1 (#177)
 - ConnectionHandler interface for handling changes of connections in
   ConnectionPool (#178)
 - Execute, ExecuteTyped and ExecuteAsync methods to ConnectionPool (#176)
 - ConnectorAdapter type to use ConnectionPool as Connector interface (#176)
 - An example how to use queue and connection_pool subpackages together (#176)
-
-### Changed
-
-- Bump queue package version to 1.2.1 (#176)
 
 ### Fixed
 


### PR DESCRIPTION
## Overview

The release adds support for the latest version of the [queue package](https://github.com/tarantool/queue/) with master-replica switching.

## Breaking changes

There are no breaking changes in the release.

## New features

* Support the queue 1.2.1 (#177).
* ConnectionHandler interface for handling changes of connections in ConnectionPool (#178).
* Execute, ExecuteTyped and ExecuteAsync methods to ConnectionPool (#176).
* ConnectorAdapter type to use ConnectionPool as Connector interface (#176).
* An example how to use queue and connection_pool subpackages together (#176).

## Bugfixes

* Mode type description in the connection_pool subpackage (#208).
* Missed Role type constants in the connection_pool subpackage (#208).
* ConnectionPool does not close UnknownRole connections (#208).
* Segmentation faults in ConnectionPool requests after disconnect (#208).
* Addresses in ConnectionPool may be changed from an external code (#208).
* ConnectionPool recreates connections too often (#208).
* A connection is still opened after ConnectionPool.Close() (#208).
* Future.GetTyped() after Future.Get() does not decode response  correctly (#213).
* Decimal package use a test function GetNumberLength instead of a package-level function getNumberLength (#219).
* Datetime location after encode + decode is unequal (#217).
* Wrong interval arithmetic with timezones (#221).
* Invalid MsgPack if STREAM_ID > 127 (#224).
* queue.Take() returns an invalid task (#222).