### PR TITLE
datetime: fix interval arithmetic with timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Decimal package use a test function GetNumberLength instead of a
   package-level function getNumberLength (#219)
 - Datetime location after encode + decode is unequal (#217)
+- Wrong interval arithmetic with timezones (#221)
 
 ## [1.8.0] - 2022-08-17
 

--- a/datetime/datetime.go
+++ b/datetime/datetime.go
@@ -220,6 +220,9 @@ func (dtime *Datetime) Sub(ival Interval) (*Datetime, error) {
 func (dtime *Datetime) Interval(next *Datetime) Interval {
 	curIval := intervalFromDatetime(dtime)
 	nextIval := intervalFromDatetime(next)
+	_, curOffset := dtime.time.Zone()
+	_, nextOffset := next.time.Zone()
+	curIval.Min -= int64(curOffset-nextOffset) / 60
 	return nextIval.Sub(curIval)
 }
 


### PR DESCRIPTION
Tarantool used to ignore timezone difference (offset) for a datetime interval calculations due to a bug [1]. We have to fix it too since we relied on the wrong behavior.

1. https://github.com/tarantool/tarantool/issues/7698

 didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)