### PR TITLE
queue: fix flaky Example_connectionPool 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Datetime location after encode + decode is unequal (#217)
 - Wrong interval arithmetic with timezones (#221)
 - Invalid MsgPack if STREAM_ID > 127 (#224)
+- queue.Take() returns an invalid task (#222)
 
 ## [1.8.0] - 2022-08-17
 

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -337,7 +337,7 @@ func TestConnectionHandlerOpenUpdateClose(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		// Wait for read_only update, it should report about close connection
 		// with old role.
-		if h.deactivated >= 1 {
+		if h.discovered >= 3 {
 			break
 		}
 		time.Sleep(poolOpts.CheckTimeout)

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -467,6 +467,14 @@ func (qd *queueData) DecodeMsgpack(d *decoder) error {
 	}
 
 	qd.task = &Task{data: qd.result, q: qd.q}
-	d.Decode(&qd.task)
+	if err = d.Decode(&qd.task); err != nil {
+		return err
+	}
+
+	if qd.task.Data() == nil {
+		// It may happen if the decoder has a code.Nil value inside. As a
+		// result, the task will not be decoded.
+		qd.task = nil
+	}
 	return nil
 }

--- a/queue/task.go
+++ b/queue/task.go
@@ -29,13 +29,9 @@ func (t *Task) DecodeMsgpack(d *decoder) error {
 		return err
 	}
 	if t.data != nil {
-		if err = d.Decode(t.data); err != nil {
-			return fmt.Errorf("fffuuuu: %s", err)
-		}
-	} else {
-		if t.data, err = d.DecodeInterface(); err != nil {
-			return err
-		}
+		d.Decode(t.data)
+	} else if t.data, err = d.DecodeInterface(); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
The flaky test output:

```
=== RUN   Example_connectionPool
--- FAIL: Example_connectionPool (1.01s)
got:
Master 127.0.0.1:3014 is ready to work!
A Queue object is ready to work.
Send data: test_data
Master 127.0.0.1:3015 is ready to work!
task.Data() == nil
want:
Master 127.0.0.1:3014 is ready to work!
A Queue object is ready to work.
Send data: test_data
Master 127.0.0.1:3015 is ready to work!
Got data: test_data
```

We get a nil task if a ConnectionPool does not yet detect master->replica role switch. We need to add additional check for the case to make the test output deterministic.