### PR TITLE
doc: add examples for GetTyped() and custom keys

### DIFF
--- a/client_tools.go
+++ b/client_tools.go
@@ -1,7 +1,7 @@
 package tarantool
 
-// IntKey is utility type for passing integer key to Select*, Update* and Delete*.
-// It serializes to array with single integer element.
+// IntKey is utility type for passing integer key to Select*, Update*,
+// Delete* and GetTyped. It serializes to array with single integer element.
 type IntKey struct {
 	I int
 }
@@ -12,8 +12,9 @@ func (k IntKey) EncodeMsgpack(enc *encoder) error {
 	return nil
 }
 
-// UintKey is utility type for passing unsigned integer key to Select*, Update* and Delete*.
-// It serializes to array with single integer element.
+// UintKey is utility type for passing unsigned integer key to Select*,
+// Update*, Delete* and GetTyped. It serializes to array with single unsigned
+// integer element.
 type UintKey struct {
 	I uint
 }
@@ -24,8 +25,8 @@ func (k UintKey) EncodeMsgpack(enc *encoder) error {
 	return nil
 }
 
-// UintKey is utility type for passing string key to Select*, Update* and Delete*.
-// It serializes to array with single string element.
+// StringKey is utility type for passing string key to Select*, Update*,
+// Delete* and GetTyped. It serializes to array with single string element.
 type StringKey struct {
 	S string
 }
@@ -36,8 +37,8 @@ func (k StringKey) EncodeMsgpack(enc *encoder) error {
 	return nil
 }
 
-// IntIntKey is utility type for passing two integer keys to Select*, Update* and Delete*.
-// It serializes to array with two integer elements.
+// IntIntKey is utility type for passing two integer keys to Select*, Update*,
+// Delete* and GetTyped. It serializes to array with two integer elements.
 type IntIntKey struct {
 	I1, I2 int
 }

--- a/config.lua
+++ b/config.lua
@@ -45,8 +45,28 @@ box.once("init", function()
         if_not_exists = true
     })
 
-    local s = box.schema.space.create('SQL_TEST', {
+    local s = box.schema.space.create('teststring', {
         id = 518,
+        if_not_exists = true,
+    })
+    s:create_index('primary', {
+        type = 'tree',
+        parts = {1, 'string'},
+        if_not_exists = true
+    })
+
+    local s = box.schema.space.create('testintint', {
+        id = 519,
+        if_not_exists = true,
+    })
+    s:create_index('primary', {
+        type = 'tree',
+        parts = {1, 'int', 2, 'int'},
+        if_not_exists = true
+    })
+
+    local s = box.schema.space.create('SQL_TEST', {
+        id = 520,
         if_not_exists = true,
         format = {
             {name = "NAME0", type = "unsigned"},
@@ -62,7 +82,7 @@ box.once("init", function()
     s:insert{1, "test", "test"}
 
     local s = box.schema.space.create('test_perf', {
-        id = 519,
+        id = 521,
         temporary = true,
         if_not_exists = true,
         field_count = 3,

--- a/config.lua
+++ b/config.lua
@@ -6,24 +6,6 @@ box.cfg{
 }
 
 box.once("init", function()
-    local s = box.schema.space.create('test', {
-        id = 517,
-        if_not_exists = true,
-    })
-    s:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
-
-    local sp = box.schema.space.create('SQL_TEST', {
-        id = 519,
-        if_not_exists = true,
-        format = {
-            {name = "NAME0", type = "unsigned"},
-            {name = "NAME1", type = "string"},
-            {name = "NAME2", type = "string"},
-        }
-    })
-    sp:create_index('primary', {type = 'tree', parts = {1, 'uint'}, if_not_exists = true})
-    sp:insert{1, "test", "test"}
-
     local st = box.schema.space.create('schematest', {
         id = 516,
         temporary = true,
@@ -53,8 +35,34 @@ box.once("init", function()
     })
     st:truncate()
 
-    local s2 = box.schema.space.create('test_perf', {
-        id = 520,
+    local s = box.schema.space.create('test', {
+        id = 517,
+        if_not_exists = true,
+    })
+    s:create_index('primary', {
+        type = 'tree',
+        parts = {1, 'uint'},
+        if_not_exists = true
+    })
+
+    local s = box.schema.space.create('SQL_TEST', {
+        id = 518,
+        if_not_exists = true,
+        format = {
+            {name = "NAME0", type = "unsigned"},
+            {name = "NAME1", type = "string"},
+            {name = "NAME2", type = "string"},
+        }
+    })
+    s:create_index('primary', {
+        type = 'tree',
+        parts = {1, 'uint'},
+        if_not_exists = true
+    })
+    s:insert{1, "test", "test"}
+
+    local s = box.schema.space.create('test_perf', {
+        id = 519,
         temporary = true,
         if_not_exists = true,
         field_count = 3,
@@ -64,14 +72,24 @@ box.once("init", function()
             {name = "arr1", type = "array"},
         },
     })
-    s2:create_index('primary', {type = 'tree', unique = true, parts = {1, 'unsigned'}, if_not_exists = true})
-    s2:create_index('secondary', {id = 5, type = 'tree', unique = false, parts = {2, 'string'}, if_not_exists = true})
+    s:create_index('primary', {
+        type = 'tree',
+        unique = true,
+        parts = {1, 'unsigned'},
+        if_not_exists = true
+    })
+    s:create_index('secondary', {
+        id = 5, type = 'tree',
+        unique = false,
+        parts = {2, 'string'},
+        if_not_exists = true
+    })
     local arr_data = {}
     for i = 1,100 do
         arr_data[i] = i
     end
     for i = 1,1000 do
-        s2:insert{
+        s:insert{
             i,
             'test_name',
             arr_data,

--- a/example_test.go
+++ b/example_test.go
@@ -127,6 +127,98 @@ func ExampleConnection_SelectAsync() {
 	// Future 2 Data [[18 val 18 bla]]
 }
 
+func ExampleConnection_GetTyped() {
+	conn := example_connect()
+	defer conn.Close()
+
+	const space = "test"
+	const index = "primary"
+	conn.Replace(space, []interface{}{uint(1111), "hello", "world"})
+
+	var t Tuple
+	err := conn.GetTyped(space, index, []interface{}{1111}, &t)
+	fmt.Println("Error", err)
+	fmt.Println("Data", t)
+	// Output:
+	// Error <nil>
+	// Data {{} 1111 hello world}
+}
+
+func ExampleIntKey() {
+	conn := example_connect()
+	defer conn.Close()
+
+	const space = "test"
+	const index = "primary"
+	conn.Replace(space, []interface{}{int(1111), "hello", "world"})
+
+	var t Tuple
+	err := conn.GetTyped(space, index, tarantool.IntKey{1111}, &t)
+	fmt.Println("Error", err)
+	fmt.Println("Data", t)
+	// Output:
+	// Error <nil>
+	// Data {{} 1111 hello world}
+}
+
+func ExampleUintKey() {
+	conn := example_connect()
+	defer conn.Close()
+
+	const space = "test"
+	const index = "primary"
+	conn.Replace(space, []interface{}{uint(1111), "hello", "world"})
+
+	var t Tuple
+	err := conn.GetTyped(space, index, tarantool.UintKey{1111}, &t)
+	fmt.Println("Error", err)
+	fmt.Println("Data", t)
+	// Output:
+	// Error <nil>
+	// Data {{} 1111 hello world}
+}
+
+func ExampleStringKey() {
+	conn := example_connect()
+	defer conn.Close()
+
+	const space = "teststring"
+	const index = "primary"
+	conn.Replace(space, []interface{}{"any", []byte{0x01, 0x02}})
+
+	t := struct {
+		Key   string
+		Value []byte
+	}{}
+	err := conn.GetTyped(space, index, tarantool.StringKey{"any"}, &t)
+	fmt.Println("Error", err)
+	fmt.Println("Data", t)
+	// Output:
+	// Error <nil>
+	// Data {any [1 2]}
+}
+
+func ExampleIntIntKey() {
+	conn := example_connect()
+	defer conn.Close()
+
+	const space = "testintint"
+	const index = "primary"
+	conn.Replace(space, []interface{}{1, 2, "foo"})
+
+	t := struct {
+		Key1  int
+		Key2  int
+		Value string
+	}{}
+	err := conn.GetTyped(space, index, tarantool.IntIntKey{1, 2}, &t)
+	fmt.Println("Error", err)
+	fmt.Println("Data", t)
+	// Output:
+	// Error <nil>
+	// Data {1 2 foo}
+}
+
 func ExampleSelectRequest() {
 	conn := example_connect()
 	defer conn.Close()

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -205,8 +205,7 @@ func BenchmarkClientSerialSQL(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
-	spaceNo := 519
-	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
+	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
 		b.Errorf("Failed to replace: %s", err)
 	}
@@ -227,8 +226,7 @@ func BenchmarkClientSerialSQLPrepared(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
-	spaceNo := 519
-	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
+	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
 		b.Errorf("Failed to replace: %s", err)
 	}
@@ -601,7 +599,6 @@ func BenchmarkClientParallelMassiveUntyped(b *testing.B) {
 func BenchmarkClientReplaceParallel(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
-	spaceNo = 520
 
 	rSpaceNo, _, err := conn.Schema.ResolveSpaceIndex("test_perf", "secondary")
 	if err != nil {
@@ -647,8 +644,7 @@ func BenchmarkClientParallelSQL(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
-	spaceNo := 519
-	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
+	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
 		b.Errorf("No connection available")
 	}
@@ -671,8 +667,7 @@ func BenchmarkClientParallelSQLPrepared(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
-	spaceNo := 519
-	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
+	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
 		b.Errorf("No connection available")
 	}
@@ -706,8 +701,7 @@ func BenchmarkSQLSerial(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
 	defer conn.Close()
 
-	spaceNo := 519
-	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
+	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
 		b.Errorf("Failed to replace: %s", err)
 	}


### PR DESCRIPTION
The patch adds examples for:

* Connection.GetTyped() method
* IntKey type
* UintKey type
* StringKey type
* IntIntKey type

I didn't forget about (remove if it is not applicable):

- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #196