### PR TITLE
api: support iproto feature discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Support iproto feature discovery (#120).
+
 ### Changed
 
 ### Fixed

--- a/connection.go
+++ b/connection.go
@@ -293,6 +293,13 @@ type SslOpts struct {
 	Ciphers string
 }
 
+// Clone returns a copy of the Opts object.
+func (opts Opts) Clone() Opts {
+	optsCopy := opts
+
+	return optsCopy
+}
+
 // Connect creates and configures a new Connection.
 //
 // Address could be specified in following ways:
@@ -319,7 +326,7 @@ func Connect(addr string, opts Opts) (conn *Connection, err error) {
 		contextRequestId: 1,
 		Greeting:         &Greeting{},
 		control:          make(chan struct{}),
-		opts:             opts,
+		opts:             opts.Clone(),
 		dec:              newDecoder(&smallBuf{}),
 	}
 	maxprocs := uint32(runtime.GOMAXPROCS(-1))
@@ -344,9 +351,9 @@ func Connect(addr string, opts Opts) (conn *Connection, err error) {
 		}
 	}
 
-	if opts.RateLimit > 0 {
-		conn.rlimit = make(chan struct{}, opts.RateLimit)
-		if opts.RLimitAction != RLimitDrop && opts.RLimitAction != RLimitWait {
+	if conn.opts.RateLimit > 0 {
+		conn.rlimit = make(chan struct{}, conn.opts.RateLimit)
+		if conn.opts.RLimitAction != RLimitDrop && conn.opts.RLimitAction != RLimitWait {
 			return nil, errors.New("RLimitAction should be specified to RLimitDone nor RLimitWait")
 		}
 	}

--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -125,7 +125,7 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsPool) (co
 
 	connPool = &ConnectionPool{
 		addrs:    make([]string, 0, len(addrs)),
-		connOpts: connOpts,
+		connOpts: connOpts.Clone(),
 		opts:     opts,
 		state:    unknownState,
 		done:     make(chan struct{}),

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,31 @@
+package tarantool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/tarantool/go-tarantool"
+)
+
+func TestOptsClonePreservesRequiredProtocolFeatures(t *testing.T) {
+	original := Opts{
+		RequiredProtocolInfo: ProtocolInfo{
+			Version:  ProtocolVersion(100),
+			Features: []ProtocolFeature{ProtocolFeature(99), ProtocolFeature(100)},
+		},
+	}
+
+	origCopy := original.Clone()
+
+	original.RequiredProtocolInfo.Features[1] = ProtocolFeature(98)
+
+	require.Equal(t,
+		origCopy,
+		Opts{
+			RequiredProtocolInfo: ProtocolInfo{
+				Version:  ProtocolVersion(100),
+				Features: []ProtocolFeature{ProtocolFeature(99), ProtocolFeature(100)},
+			},
+		})
+}

--- a/const.go
+++ b/const.go
@@ -18,6 +18,7 @@ const (
 	RollbackRequestCode  = 16
 	PingRequestCode      = 64
 	SubscribeRequestCode = 66
+	IdRequestCode        = 73
 
 	KeyCode         = 0x00
 	KeySync         = 0x01
@@ -41,6 +42,8 @@ const (
 	KeySQLBind      = 0x41
 	KeySQLInfo      = 0x42
 	KeyStmtID       = 0x43
+	KeyVersion      = 0x54
+	KeyFeatures     = 0x55
 	KeyTimeout      = 0x56
 	KeyTxnIsolation = 0x59
 

--- a/export_test.go
+++ b/export_test.go
@@ -111,6 +111,12 @@ func RefImplRollbackBody(enc *encoder) error {
 	return fillRollback(enc)
 }
 
+// RefImplIdBody is reference implementation for filling of an id
+// request's body.
+func RefImplIdBody(enc *encoder, protocolInfo ProtocolInfo) error {
+	return fillId(enc, protocolInfo)
+}
+
 func NewEncoder(w io.Writer) *encoder {
 	return newEncoder(w)
 }

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -88,7 +88,7 @@ func ConnectWithOpts(addrs []string, connOpts tarantool.Opts, opts OptsMulti) (c
 	connOpts.Notify = notify
 	connMulti = &ConnectionMulti{
 		addrs:    addrs,
-		connOpts: connOpts,
+		connOpts: connOpts.Clone(),
 		opts:     opts,
 		notify:   notify,
 		control:  make(chan struct{}),

--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,139 @@
+package tarantool
+
+import (
+	"context"
+	"fmt"
+)
+
+// ProtocolVersion type stores Tarantool protocol version.
+type ProtocolVersion uint64
+
+// ProtocolVersion type stores a Tarantool protocol feature.
+type ProtocolFeature uint64
+
+// ProtocolInfo type aggregates Tarantool protocol version and features info.
+type ProtocolInfo struct {
+	// Version is the supported protocol version.
+	Version ProtocolVersion
+	// Features are supported protocol features.
+	Features []ProtocolFeature
+}
+
+// Clone returns an exact copy of the ProtocolInfo object.
+// Any changes in copy will not affect the original values.
+func (info ProtocolInfo) Clone() ProtocolInfo {
+	infoCopy := info
+
+	if info.Features != nil {
+		infoCopy.Features = make([]ProtocolFeature, len(info.Features))
+		copy(infoCopy.Features, info.Features)
+	}
+
+	return infoCopy
+}
+
+const (
+	// StreamsFeature represents streams support (supported by connector).
+	StreamsFeature ProtocolFeature = 0
+	// TransactionsFeature represents interactive transactions support.
+	// (supported by connector).
+	TransactionsFeature ProtocolFeature = 1
+	// ErrorExtensionFeature represents support of MP_ERROR objects over MessagePack
+	// (unsupported by connector).
+	ErrorExtensionFeature ProtocolFeature = 2
+	// WatchersFeature represents support of watchers
+	// (unsupported by connector).
+	WatchersFeature ProtocolFeature = 3
+	// PaginationFeature represents support of pagination
+	// (unsupported by connector).
+	PaginationFeature ProtocolFeature = 4
+)
+
+// String returns the name of a Tarantool feature.
+// If value X is not a known feature, returns "Unknown feature (code X)" string.
+func (ftr ProtocolFeature) String() string {
+	switch ftr {
+	case StreamsFeature:
+		return "StreamsFeature"
+	case TransactionsFeature:
+		return "TransactionsFeature"
+	case ErrorExtensionFeature:
+		return "ErrorExtensionFeature"
+	case WatchersFeature:
+		return "WatchersFeature"
+	case PaginationFeature:
+		return "PaginationFeature"
+	default:
+		return fmt.Sprintf("Unknown feature (code %d)", ftr)
+	}
+}
+
+var clientProtocolInfo ProtocolInfo = ProtocolInfo{
+	// Protocol version supported by connector. Version 3
+	// was introduced in Tarantool 2.10.0, version 4 was
+	// introduced in master 948e5cd (possible 2.10.5 or 2.11.0).
+	// Support of protocol version on connector side was introduced in
+	// 1.10.0.
+	Version: ProtocolVersion(4),
+	// Streams and transactions were introduced in protocol version 1
+	// (Tarantool 2.10.0), in connector since 1.7.0.
+	Features: []ProtocolFeature{
+		StreamsFeature,
+		TransactionsFeature,
+	},
+}
+
+// IdRequest informs the server about supported protocol
+// version and protocol features.
+type IdRequest struct {
+	baseRequest
+	protocolInfo ProtocolInfo
+}
+
+func fillId(enc *encoder, protocolInfo ProtocolInfo) error {
+	enc.EncodeMapLen(2)
+
+	encodeUint(enc, KeyVersion)
+	if err := enc.Encode(protocolInfo.Version); err != nil {
+		return err
+	}
+
+	encodeUint(enc, KeyFeatures)
+
+	t := len(protocolInfo.Features)
+	if err := enc.EncodeArrayLen(t); err != nil {
+		return err
+	}
+
+	for _, feature := range protocolInfo.Features {
+		if err := enc.Encode(feature); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// NewIdRequest returns a new IdRequest.
+func NewIdRequest(protocolInfo ProtocolInfo) *IdRequest {
+	req := new(IdRequest)
+	req.requestCode = IdRequestCode
+	req.protocolInfo = protocolInfo.Clone()
+	return req
+}
+
+// Body fills an encoder with the id request body.
+func (req *IdRequest) Body(res SchemaResolver, enc *encoder) error {
+	return fillId(enc, req.protocolInfo)
+}
+
+// Context sets a passed context to the request.
+//
+// Pay attention that when using context with request objects,
+// the timeout option for Connection does not affect the lifetime
+// of the request. For those purposes use context.WithTimeout() as
+// the root context.
+func (req *IdRequest) Context(ctx context.Context) *IdRequest {
+	req.ctx = ctx
+	return req
+}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1,0 +1,37 @@
+package tarantool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	. "github.com/tarantool/go-tarantool"
+)
+
+func TestProtocolInfoClonePreservesFeatures(t *testing.T) {
+	original := ProtocolInfo{
+		Version:  ProtocolVersion(100),
+		Features: []ProtocolFeature{ProtocolFeature(99), ProtocolFeature(100)},
+	}
+
+	origCopy := original.Clone()
+
+	original.Features[1] = ProtocolFeature(98)
+
+	require.Equal(t,
+		origCopy,
+		ProtocolInfo{
+			Version:  ProtocolVersion(100),
+			Features: []ProtocolFeature{ProtocolFeature(99), ProtocolFeature(100)},
+		})
+}
+
+func TestFeatureStringRepresentation(t *testing.T) {
+	require.Equal(t, StreamsFeature.String(), "StreamsFeature")
+	require.Equal(t, TransactionsFeature.String(), "TransactionsFeature")
+	require.Equal(t, ErrorExtensionFeature.String(), "ErrorExtensionFeature")
+	require.Equal(t, WatchersFeature.String(), "WatchersFeature")
+	require.Equal(t, PaginationFeature.String(), "PaginationFeature")
+
+	require.Equal(t, ProtocolFeature(15532).String(), "Unknown feature (code 15532)")
+}

--- a/response.go
+++ b/response.go
@@ -147,8 +147,10 @@ func (resp *Response) decodeBody() (err error) {
 		offset := resp.buf.Offset()
 		defer resp.buf.Seek(offset)
 
-		var l int
+		var l, larr int
 		var stmtID, bindCount uint64
+		var serverProtocolInfo ProtocolInfo
+		var feature ProtocolFeature
 
 		d := newDecoder(&resp.buf)
 
@@ -190,6 +192,22 @@ func (resp *Response) decodeBody() (err error) {
 				if bindCount, err = d.DecodeUint64(); err != nil {
 					return err
 				}
+			case KeyVersion:
+				if err = d.Decode(&serverProtocolInfo.Version); err != nil {
+					return err
+				}
+			case KeyFeatures:
+				if larr, err = d.DecodeArrayLen(); err != nil {
+					return err
+				}
+
+				serverProtocolInfo.Features = make([]ProtocolFeature, larr)
+				for i := 0; i < larr; i++ {
+					if err = d.Decode(&feature); err != nil {
+						return err
+					}
+					serverProtocolInfo.Features[i] = feature
+				}
 			default:
 				if err = d.Skip(); err != nil {
 					return err
@@ -204,6 +222,18 @@ func (resp *Response) decodeBody() (err error) {
 			}
 			resp.Data = []interface{}{stmt}
 		}
+
+		// Tarantool may send only version >= 1
+		if (serverProtocolInfo.Version != ProtocolVersion(0)) || (serverProtocolInfo.Features != nil) {
+			if serverProtocolInfo.Version == ProtocolVersion(0) {
+				return fmt.Errorf("No protocol version provided in Id response")
+			}
+			if serverProtocolInfo.Features == nil {
+				return fmt.Errorf("No features provided in Id response")
+			}
+			resp.Data = []interface{}{serverProtocolInfo}
+		}
+
 		if resp.Code != OkCode && resp.Code != PushCode {
 			resp.Code &^= ErrorCodeBit
 			err = Error{resp.Code, resp.Error}


### PR DESCRIPTION
api: support iproto feature discovery

Since version 2.10.0 Tarantool supports feature discovery [1]. Client
can send client protocol version and supported features and receive
server protocol version and supported features information to tune
its behavior.

After this patch, the request will be sent on `dial`, before
authentication is performed. Connector stores server info in connection
internals. User can also set option RequiredProtocolVersion and
RequiredProtocolFeatures to fast fail on connect if server does
not provide some expected feature, similar to net.box opts [2]. It is
not clear how connector should behave in case if client doesn't support
a protocol feature or protocol version, see [3]. For now we decided not
to check requirements on client side.

Feature check iterates over lists to check if feature is
enabled. It seems that iterating over a small list is way faster than
building a map, see [4]. Benchmark tests show that this check is rather
fast (0.5 ns for both client and server check on HP ProBook 440 G5) so
it is not necessary to cache it in any way.

Traces of IPROTO_FEATURE_GRACEFUL_SHUTDOWN flag and protocol version 4
could be found in Tarantool source code but they were removed in the
following commits before the release and treated like they never
existed. We also ignore them here too. See [5] for more info. In latest
master commit new feature with code 4 and protocol version 4 were
introduced [6].

1. https://github.com/tarantool/tarantool/issues/6253
2. https://www.tarantool.io/en/doc/latest/reference/reference_lua/net_box/#lua-function.net_box.new
3. https://github.com/tarantool/tarantool/issues/7953
4. https://stackoverflow.com/a/52710077/11646599
5. https://github.com/tarantool/tarantool-python/issues/262
6. https://github.com/tarantool/tarantool/commit/948e5cdce18b081a8f7b03ebd43e34a029b7aefe

Closes #120