### PR TITLE
api: support errors extended information and error type in MessagePack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Support iproto feature discovery (#120)
 - Support errors extended information (#209)
+- Error type support in MessagePack (#209)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
-- Support iproto feature discovery (#120).
+- Support iproto feature discovery (#120)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - Support iproto feature discovery (#120)
+- Support errors extended information (#209)
 
 ### Changed
 

--- a/box_error.go
+++ b/box_error.go
@@ -1,0 +1,186 @@
+package tarantool
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const (
+	keyErrorStack   = 0x00
+	keyErrorType    = 0x00
+	keyErrorFile    = 0x01
+	keyErrorLine    = 0x02
+	keyErrorMessage = 0x03
+	keyErrorErrno   = 0x04
+	keyErrorErrcode = 0x05
+	keyErrorFields  = 0x06
+)
+
+// BoxError is a type representing Tarantool `box.error` object: a single
+// MP_ERROR_STACK object with a link to the previous stack error.
+// See https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_error/error/
+//
+// Since 1.10.0
+type BoxError struct {
+	// Type is error type that implies its source (for example, "ClientError").
+	Type string
+	// File is a source code file where the error was caught.
+	File string
+	// Line is a number of line in the source code file where the error was caught.
+	Line uint64
+	// Msg is the text of reason.
+	Msg string
+	// Errno is the ordinal number of the error.
+	Errno uint64
+	// Code is the number of the error as defined in `errcode.h`.
+	Code uint64
+	// Fields are additional fields depending on error type. For example, if
+	// type is "AccessDeniedError", then it will include "object_type",
+	// "object_name", "access_type".
+	Fields map[string]interface{}
+	// Prev is the previous error in stack.
+	Prev *BoxError
+}
+
+// Error converts a BoxError to a string.
+func (e *BoxError) Error() string {
+	s := fmt.Sprintf("%s (%s, code 0x%x), see %s line %d",
+		e.Msg, e.Type, e.Code, e.File, e.Line)
+
+	if e.Prev != nil {
+		return fmt.Sprintf("%s: %s", s, e.Prev)
+	}
+
+	return s
+}
+
+// Depth computes the count of errors in stack, including the current one.
+func (e *BoxError) Depth() int {
+	depth := int(0)
+
+	cur := e
+	for cur != nil {
+		cur = cur.Prev
+		depth++
+	}
+
+	return depth
+}
+
+func decodeBoxError(d *decoder) (*BoxError, error) {
+	var l, larr, l1, l2 int
+	var errorStack []BoxError
+	var err error
+
+	if l, err = d.DecodeMapLen(); err != nil {
+		return nil, err
+	}
+
+	for ; l > 0; l-- {
+		var cd int
+		if cd, err = d.DecodeInt(); err != nil {
+			return nil, err
+		}
+		switch cd {
+		case keyErrorStack:
+			if larr, err = d.DecodeArrayLen(); err != nil {
+				return nil, err
+			}
+
+			errorStack = make([]BoxError, larr)
+
+			for i := 0; i < larr; i++ {
+				if l1, err = d.DecodeMapLen(); err != nil {
+					return nil, err
+				}
+
+				for ; l1 > 0; l1-- {
+					var cd1 int
+					if cd1, err = d.DecodeInt(); err != nil {
+						return nil, err
+					}
+					switch cd1 {
+					case keyErrorType:
+						if errorStack[i].Type, err = d.DecodeString(); err != nil {
+							return nil, err
+						}
+					case keyErrorFile:
+						if errorStack[i].File, err = d.DecodeString(); err != nil {
+							return nil, err
+						}
+					case keyErrorLine:
+						if errorStack[i].Line, err = d.DecodeUint64(); err != nil {
+							return nil, err
+						}
+					case keyErrorMessage:
+						if errorStack[i].Msg, err = d.DecodeString(); err != nil {
+							return nil, err
+						}
+					case keyErrorErrno:
+						if errorStack[i].Errno, err = d.DecodeUint64(); err != nil {
+							return nil, err
+						}
+					case keyErrorErrcode:
+						if errorStack[i].Code, err = d.DecodeUint64(); err != nil {
+							return nil, err
+						}
+					case keyErrorFields:
+						var mapk string
+						var mapv interface{}
+
+						errorStack[i].Fields = make(map[string]interface{})
+
+						if l2, err = d.DecodeMapLen(); err != nil {
+							return nil, err
+						}
+						for ; l2 > 0; l2-- {
+							if mapk, err = d.DecodeString(); err != nil {
+								return nil, err
+							}
+							if mapv, err = d.DecodeInterface(); err != nil {
+								return nil, err
+							}
+							errorStack[i].Fields[mapk] = mapv
+						}
+					default:
+						if err = d.Skip(); err != nil {
+							return nil, err
+						}
+					}
+				}
+
+				if i > 0 {
+					errorStack[i-1].Prev = &errorStack[i]
+				}
+			}
+		default:
+			if err = d.Skip(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(errorStack) == 0 {
+		return nil, fmt.Errorf("msgpack: unexpected empty BoxError stack on decode")
+	}
+
+	return &errorStack[0], nil
+}
+
+// UnmarshalMsgpack deserializes a BoxError value from a MessagePack
+// representation.
+func (e *BoxError) UnmarshalMsgpack(b []byte) error {
+	if e == nil {
+		panic("cannot unmarshal to a nil pointer")
+	}
+
+	buf := bytes.NewBuffer(b)
+	dec := newDecoder(buf)
+
+	if val, err := decodeBoxError(dec); err != nil {
+		return err
+	} else {
+		*e = *val
+		return nil
+	}
+}

--- a/box_error_test.go
+++ b/box_error_test.go
@@ -1,0 +1,200 @@
+package tarantool_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	. "github.com/tarantool/go-tarantool"
+)
+
+var samples = map[string]BoxError{
+	"SimpleError": {
+		Type:  "ClientError",
+		File:  "config.lua",
+		Line:  uint64(202),
+		Msg:   "Unknown error",
+		Errno: uint64(0),
+		Code:  uint64(0),
+	},
+	"AccessDeniedError": {
+		Type:  "AccessDeniedError",
+		File:  "/__w/sdk/sdk/tarantool-2.10/tarantool/src/box/func.c",
+		Line:  uint64(535),
+		Msg:   "Execute access to function 'forbidden_function' is denied for user 'no_grants'",
+		Errno: uint64(0),
+		Code:  uint64(42),
+		Fields: map[string]interface{}{
+			"object_type": "function",
+			"object_name": "forbidden_function",
+			"access_type": "Execute",
+		},
+	},
+	"ChainedError": {
+		Type:  "ClientError",
+		File:  "config.lua",
+		Line:  uint64(205),
+		Msg:   "Timeout exceeded",
+		Errno: uint64(0),
+		Code:  uint64(78),
+		Prev: &BoxError{
+			Type:  "ClientError",
+			File:  "config.lua",
+			Line:  uint64(202),
+			Msg:   "Unknown error",
+			Errno: uint64(0),
+			Code:  uint64(0),
+		},
+	},
+}
+
+var stringCases = map[string]struct {
+	e BoxError
+	s string
+}{
+	"SimpleError": {
+		samples["SimpleError"],
+		"Unknown error (ClientError, code 0x0), see config.lua line 202",
+	},
+	"AccessDeniedError": {
+		samples["AccessDeniedError"],
+		"Execute access to function 'forbidden_function' is denied for user " +
+			"'no_grants' (AccessDeniedError, code 0x2a), see " +
+			"/__w/sdk/sdk/tarantool-2.10/tarantool/src/box/func.c line 535",
+	},
+	"ChainedError": {
+		samples["ChainedError"],
+		"Timeout exceeded (ClientError, code 0x4e), see config.lua line 205: " +
+			"Unknown error (ClientError, code 0x0), see config.lua line 202",
+	},
+}
+
+func TestBoxErrorStringRepr(t *testing.T) {
+	for name, testcase := range stringCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, testcase.s, testcase.e.Error())
+		})
+	}
+}
+
+var mpDecodeSamples = map[string]struct {
+	b   []byte
+	ok  bool
+	err *regexp.Regexp
+}{
+	"OuterMapInvalidLen": {
+		[]byte{0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding map length`),
+	},
+	"OuterMapInvalidKey": {
+		[]byte{0x81, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding int64`),
+	},
+	"OuterMapExtraKey": {
+		[]byte{0x82, 0x00, 0x91, 0x81, 0x02, 0x01, 0x11, 0x00},
+		true,
+		regexp.MustCompile(``),
+	},
+	"OuterMapExtraInvalidKey": {
+		[]byte{0x81, 0x11, 0x81},
+		false,
+		regexp.MustCompile(`EOF`),
+	},
+	"ArrayInvalidLen": {
+		[]byte{0x81, 0x00, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding array length`),
+	},
+	"ArrayZeroLen": {
+		[]byte{0x81, 0x00, 0x90},
+		false,
+		regexp.MustCompile(`msgpack: unexpected empty BoxError stack on decode`),
+	},
+	"InnerMapInvalidLen": {
+		[]byte{0x81, 0x00, 0x91, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding map length`),
+	},
+	"InnerMapInvalidKey": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding int64`),
+	},
+	"InnerMapInvalidErrorType": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x00, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding (?:string\/bytes|bytes) length`),
+	},
+	"InnerMapInvalidErrorFile": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x01, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding (?:string\/bytes|bytes) length`),
+	},
+	"InnerMapInvalidErrorLine": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x02, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding uint64`),
+	},
+	"InnerMapInvalidErrorMessage": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x03, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding (?:string\/bytes|bytes) length`),
+	},
+	"InnerMapInvalidErrorErrno": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x04, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding uint64`),
+	},
+	"InnerMapInvalidErrorErrcode": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x05, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding uint64`),
+	},
+	"InnerMapInvalidErrorFields": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x06, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding map length`),
+	},
+	"InnerMapInvalidErrorFieldsKey": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x06, 0x81, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding (?:string\/bytes|bytes) length`),
+	},
+	"InnerMapInvalidErrorFieldsValue": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x06, 0x81, 0xa3, 0x6b, 0x65, 0x79, 0xc1},
+		false,
+		regexp.MustCompile(`msgpack: (?:unexpected|invalid|unknown) code.c1 decoding interface{}`),
+	},
+	"InnerMapExtraKey": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x21, 0x00},
+		true,
+		regexp.MustCompile(``),
+	},
+	"InnerMapExtraInvalidKey": {
+		[]byte{0x81, 0x00, 0x91, 0x81, 0x21, 0x81},
+		false,
+		regexp.MustCompile(`EOF`),
+	},
+}
+
+func TestMessagePackDecode(t *testing.T) {
+	for name, testcase := range mpDecodeSamples {
+		t.Run(name, func(t *testing.T) {
+			var val *BoxError = &BoxError{}
+			err := val.UnmarshalMsgpack(testcase.b)
+			if testcase.ok {
+				require.Nilf(t, err, "No errors on decode")
+			} else {
+				require.Regexp(t, testcase.err, err.Error())
+			}
+		})
+	}
+}
+
+func TestMessagePackUnmarshalToNil(t *testing.T) {
+	var val *BoxError = nil
+	require.PanicsWithValue(t, "cannot unmarshal to a nil pointer",
+		func() { val.UnmarshalMsgpack(mpDecodeSamples["InnerMapExtraKey"].b) })
+}

--- a/box_error_test.go
+++ b/box_error_test.go
@@ -1,11 +1,13 @@
 package tarantool_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	. "github.com/tarantool/go-tarantool"
+	"github.com/tarantool/go-tarantool/test_helpers"
 )
 
 var samples = map[string]BoxError{
@@ -197,4 +199,295 @@ func TestMessagePackUnmarshalToNil(t *testing.T) {
 	var val *BoxError = nil
 	require.PanicsWithValue(t, "cannot unmarshal to a nil pointer",
 		func() { val.UnmarshalMsgpack(mpDecodeSamples["InnerMapExtraKey"].b) })
+}
+
+func TestMessagePackEncodeNil(t *testing.T) {
+	var val *BoxError
+
+	_, err := val.MarshalMsgpack()
+	require.NotNil(t, err)
+	require.Equal(t, "msgpack: unexpected nil BoxError on encode", err.Error())
+}
+
+var space = "test_error_type"
+var index = "primary"
+
+type TupleBoxError struct {
+	pk  string // BoxError cannot be used as a primary key.
+	val BoxError
+}
+
+func (t *TupleBoxError) EncodeMsgpack(e *encoder) error {
+	if err := e.EncodeArrayLen(2); err != nil {
+		return err
+	}
+
+	if err := e.EncodeString(t.pk); err != nil {
+		return err
+	}
+
+	return e.Encode(&t.val)
+}
+
+func (t *TupleBoxError) DecodeMsgpack(d *decoder) error {
+	var err error
+	var l int
+	if l, err = d.DecodeArrayLen(); err != nil {
+		return err
+	}
+	if l != 2 {
+		return fmt.Errorf("Array length doesn't match: %d", l)
+	}
+
+	if t.pk, err = d.DecodeString(); err != nil {
+		return err
+	}
+
+	return d.Decode(&t.val)
+}
+
+// Raw bytes encoding test is impossible for
+// object with Fields since map iterating is random.
+var tupleCases = map[string]struct {
+	tuple TupleBoxError
+	ttObj string
+}{
+	"SimpleError": {
+		TupleBoxError{
+			"simple_error_pk",
+			samples["SimpleError"],
+		},
+		"simple_error",
+	},
+	"AccessDeniedError": {
+		TupleBoxError{
+			"access_denied_error_pk",
+			samples["AccessDeniedError"],
+		},
+		"access_denied_error",
+	},
+	"ChainedError": {
+		TupleBoxError{
+			"chained_error_pk",
+			samples["ChainedError"],
+		},
+		"chained_error",
+	},
+}
+
+func TestErrorTypeMPEncodeDecode(t *testing.T) {
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			buf, err := marshal(&testcase.tuple)
+			require.Nil(t, err)
+
+			var res TupleBoxError
+			err = unmarshal(buf, &res)
+			require.Nil(t, err)
+
+			require.Equal(t, testcase.tuple, res)
+		})
+	}
+}
+
+func TestErrorTypeEval(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			resp, err := conn.Eval("return ...", []interface{}{&testcase.tuple.val})
+			require.Nil(t, err)
+			require.NotNil(t, resp.Data)
+			require.Equal(t, len(resp.Data), 1)
+			actual, ok := toBoxError(resp.Data[0])
+			require.Truef(t, ok, "Response data has valid type")
+			require.Equal(t, testcase.tuple.val, actual)
+		})
+	}
+}
+
+func TestErrorTypeEvalTyped(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			var res []BoxError
+			err := conn.EvalTyped("return ...", []interface{}{&testcase.tuple.val}, &res)
+			require.Nil(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, len(res), 1)
+			require.Equal(t, testcase.tuple.val, res[0])
+		})
+	}
+}
+
+func TestErrorTypeInsert(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
+	_, err := conn.Eval(truncateEval, []interface{}{})
+	require.Nil(t, err)
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			_, err = conn.Insert(space, &testcase.tuple)
+			require.Nil(t, err)
+
+			checkEval := fmt.Sprintf(`
+				local err = rawget(_G, %q)
+				assert(err ~= nil)
+
+				local tuple = box.space[%q]:get(%q)
+				assert(tuple ~= nil)
+
+				local tuple_err = tuple[2]
+				assert(tuple_err ~= nil)
+
+				return compare_box_errors(err, tuple_err)
+			`, testcase.ttObj, space, testcase.tuple.pk)
+
+			// In fact, compare_box_errors does not check than File and Line
+			// of connector BoxError are equal to the Tarantool ones
+			// since they may differ between different Tarantool versions
+			// and editions.
+			_, err := conn.Eval(checkEval, []interface{}{})
+			require.Nilf(t, err, "Tuple has been successfully inserted")
+		})
+	}
+}
+
+func TestErrorTypeInsertTyped(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
+	_, err := conn.Eval(truncateEval, []interface{}{})
+	require.Nil(t, err)
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			var res []TupleBoxError
+			err = conn.InsertTyped(space, &testcase.tuple, &res)
+			require.Nil(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, len(res), 1)
+			require.Equal(t, testcase.tuple, res[0])
+
+			checkEval := fmt.Sprintf(`
+				local err = rawget(_G, %q)
+				assert(err ~= nil)
+
+				local tuple = box.space[%q]:get(%q)
+				assert(tuple ~= nil)
+
+				local tuple_err = tuple[2]
+				assert(tuple_err ~= nil)
+
+				return compare_box_errors(err, tuple_err)
+			`, testcase.ttObj, space, testcase.tuple.pk)
+
+			// In fact, compare_box_errors does not check than File and Line
+			// of connector BoxError are equal to the Tarantool ones
+			// since they may differ between different Tarantool versions
+			// and editions.
+			_, err := conn.Eval(checkEval, []interface{}{})
+			require.Nilf(t, err, "Tuple has been successfully inserted")
+		})
+	}
+}
+
+func TestErrorTypeSelect(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
+	_, err := conn.Eval(truncateEval, []interface{}{})
+	require.Nil(t, err)
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			insertEval := fmt.Sprintf(`
+				local err = rawget(_G, %q)
+				assert(err ~= nil)
+
+				local tuple = box.space[%q]:insert{%q, err}
+				assert(tuple ~= nil)
+			`, testcase.ttObj, space, testcase.tuple.pk)
+
+			_, err := conn.Eval(insertEval, []interface{}{})
+			require.Nilf(t, err, "Tuple has been successfully inserted")
+
+			var resp *Response
+			var offset uint32 = 0
+			var limit uint32 = 1
+			resp, err = conn.Select(space, index, offset, limit, IterEq, []interface{}{testcase.tuple.pk})
+			require.Nil(t, err)
+			require.NotNil(t, resp.Data)
+			require.Equalf(t, len(resp.Data), 1, "Exactly one tuple had been found")
+			tpl, ok := resp.Data[0].([]interface{})
+			require.Truef(t, ok, "Tuple has valid type")
+			require.Equal(t, testcase.tuple.pk, tpl[0])
+			var actual BoxError
+			actual, ok = toBoxError(tpl[1])
+			require.Truef(t, ok, "BoxError tuple field has valid type")
+			// In fact, CheckEqualBoxErrors does not check than File and Line
+			// of connector BoxError are equal to the Tarantool ones
+			// since they may differ between different Tarantool versions
+			// and editions.
+			test_helpers.CheckEqualBoxErrors(t, testcase.tuple.val, actual)
+		})
+	}
+}
+
+func TestErrorTypeSelectTyped(t *testing.T) {
+	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
+	_, err := conn.Eval(truncateEval, []interface{}{})
+	require.Nil(t, err)
+
+	for name, testcase := range tupleCases {
+		t.Run(name, func(t *testing.T) {
+			insertEval := fmt.Sprintf(`
+				local err = rawget(_G, %q)
+				assert(err ~= nil)
+
+				local tuple = box.space[%q]:insert{%q, err}
+				assert(tuple ~= nil)
+			`, testcase.ttObj, space, testcase.tuple.pk)
+
+			_, err := conn.Eval(insertEval, []interface{}{})
+			require.Nilf(t, err, "Tuple has been successfully inserted")
+
+			var offset uint32 = 0
+			var limit uint32 = 1
+			var resp []TupleBoxError
+			err = conn.SelectTyped(space, index, offset, limit, IterEq, []interface{}{testcase.tuple.pk}, &resp)
+			require.Nil(t, err)
+			require.NotNil(t, resp)
+			require.Equalf(t, len(resp), 1, "Exactly one tuple had been found")
+			require.Equal(t, testcase.tuple.pk, resp[0].pk)
+			// In fact, CheckEqualBoxErrors does not check than File and Line
+			// of connector BoxError are equal to the Tarantool ones
+			// since they may differ between different Tarantool versions
+			// and editions.
+			test_helpers.CheckEqualBoxErrors(t, testcase.tuple.val, resp[0].val)
+		})
+	}
 }

--- a/const.go
+++ b/const.go
@@ -35,7 +35,7 @@ const (
 	KeyExpression   = 0x27
 	KeyDefTuple     = 0x28
 	KeyData         = 0x30
-	KeyError        = 0x31
+	KeyError24      = 0x31
 	KeyMetaData     = 0x32
 	KeyBindCount    = 0x34
 	KeySQLText      = 0x40

--- a/const.go
+++ b/const.go
@@ -35,13 +35,14 @@ const (
 	KeyExpression   = 0x27
 	KeyDefTuple     = 0x28
 	KeyData         = 0x30
-	KeyError24      = 0x31
+	KeyError24      = 0x31 /* Error in pre-2.4 format. */
 	KeyMetaData     = 0x32
 	KeyBindCount    = 0x34
 	KeySQLText      = 0x40
 	KeySQLBind      = 0x41
 	KeySQLInfo      = 0x42
 	KeyStmtID       = 0x43
+	KeyError        = 0x52 /* Extended error in >= 2.4 format. */
 	KeyVersion      = 0x54
 	KeyFeatures     = 0x55
 	KeyTimeout      = 0x56

--- a/errors.go
+++ b/errors.go
@@ -4,12 +4,17 @@ import "fmt"
 
 // Error is wrapper around error returned by Tarantool.
 type Error struct {
-	Code uint32
-	Msg  string
+	Code         uint32
+	Msg          string
+	ExtendedInfo *BoxError
 }
 
 // Error converts an Error to a string.
 func (tnterr Error) Error() string {
+	if tnterr.ExtendedInfo != nil {
+		return tnterr.ExtendedInfo.Error()
+	}
+
 	return fmt.Sprintf("%s (0x%x)", tnterr.Msg, tnterr.Code)
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -329,7 +329,7 @@ func ExampleProtocolVersion() {
 	fmt.Println("Connector client protocol features:", clientProtocolInfo.Features)
 	// Output:
 	// Connector client protocol version: 4
-	// Connector client protocol features: [StreamsFeature TransactionsFeature]
+	// Connector client protocol features: [StreamsFeature TransactionsFeature ErrorExtensionFeature]
 }
 
 func getTestTxnOpts() tarantool.Opts {

--- a/msgpack.go
+++ b/msgpack.go
@@ -48,3 +48,7 @@ func msgpackIsString(code byte) bool {
 	return msgpcode.IsFixedString(code) || code == msgpcode.Str8 ||
 		code == msgpcode.Str16 || code == msgpcode.Str32
 }
+
+func init() {
+	msgpack.RegisterExt(errorExtID, &BoxError{})
+}

--- a/msgpack_helper_test.go
+++ b/msgpack_helper_test.go
@@ -4,6 +4,7 @@
 package tarantool_test
 
 import (
+	"github.com/tarantool/go-tarantool"
 	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
@@ -12,4 +13,17 @@ type decoder = msgpack.Decoder
 
 func encodeUint(e *encoder, v uint64) error {
 	return e.EncodeUint(uint(v))
+}
+
+func toBoxError(i interface{}) (v tarantool.BoxError, ok bool) {
+	v, ok = i.(tarantool.BoxError)
+	return
+}
+
+func marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}
+
+func unmarshal(data []byte, v interface{}) error {
+	return msgpack.Unmarshal(data, v)
 }

--- a/msgpack_v5.go
+++ b/msgpack_v5.go
@@ -52,3 +52,7 @@ func msgpackIsString(code byte) bool {
 	return msgpcode.IsFixedString(code) || code == msgpcode.Str8 ||
 		code == msgpcode.Str16 || code == msgpcode.Str32
 }
+
+func init() {
+	msgpack.RegisterExt(errorExtID, (*BoxError)(nil))
+}

--- a/msgpack_v5_helper_test.go
+++ b/msgpack_v5_helper_test.go
@@ -4,6 +4,7 @@
 package tarantool_test
 
 import (
+	"github.com/tarantool/go-tarantool"
 	"github.com/vmihailenco/msgpack/v5"
 )
 
@@ -12,4 +13,20 @@ type decoder = msgpack.Decoder
 
 func encodeUint(e *encoder, v uint64) error {
 	return e.EncodeUint(v)
+}
+
+func toBoxError(i interface{}) (v tarantool.BoxError, ok bool) {
+	var ptr *tarantool.BoxError
+	if ptr, ok = i.(*tarantool.BoxError); ok {
+		v = *ptr
+	}
+	return
+}
+
+func marshal(v interface{}) ([]byte, error) {
+	return msgpack.Marshal(v)
+}
+
+func unmarshal(data []byte, v interface{}) error {
+	return msgpack.Unmarshal(data, v)
 }

--- a/protocol.go
+++ b/protocol.go
@@ -42,7 +42,7 @@ const (
 	// (unsupported by connector).
 	ErrorExtensionFeature ProtocolFeature = 2
 	// WatchersFeature represents support of watchers
-	// (unsupported by connector).
+	// (supported by connector).
 	WatchersFeature ProtocolFeature = 3
 	// PaginationFeature represents support of pagination
 	// (unsupported by connector).
@@ -76,10 +76,13 @@ var clientProtocolInfo ProtocolInfo = ProtocolInfo{
 	// 1.10.0.
 	Version: ProtocolVersion(4),
 	// Streams and transactions were introduced in protocol version 1
-	// (Tarantool 2.10.0), in connector since 1.7.0.
+	// (Tarantool 2.10.0), in connector since 1.7.0. Error extension
+	// type was introduced in protocol version 2 (Tarantool 2.10.0),
+	// in connector since 1.10.0.
 	Features: []ProtocolFeature{
 		StreamsFeature,
 		TransactionsFeature,
+		ErrorExtensionFeature,
 	},
 }
 

--- a/response.go
+++ b/response.go
@@ -172,7 +172,7 @@ func (resp *Response) decodeBody() (err error) {
 				if resp.Data, ok = res.([]interface{}); !ok {
 					return fmt.Errorf("result is not array: %v", res)
 				}
-			case KeyError:
+			case KeyError24:
 				if resp.Error, err = d.DecodeString(); err != nil {
 					return err
 				}
@@ -262,7 +262,7 @@ func (resp *Response) decodeBodyTyped(res interface{}) (err error) {
 				if err = d.Decode(res); err != nil {
 					return err
 				}
-			case KeyError:
+			case KeyError24:
 				if resp.Error, err = d.DecodeString(); err != nil {
 					return err
 				}

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -2868,8 +2868,12 @@ func TestConnectionProtocolInfoSupported(t *testing.T) {
 	require.Equal(t,
 		clientProtocolInfo,
 		ProtocolInfo{
-			Version:  ProtocolVersion(4),
-			Features: []ProtocolFeature{StreamsFeature, TransactionsFeature},
+			Version: ProtocolVersion(4),
+			Features: []ProtocolFeature{
+				StreamsFeature,
+				TransactionsFeature,
+				ErrorExtensionFeature,
+			},
 		})
 
 	serverProtocolInfo := conn.ServerProtocolInfo()
@@ -2997,8 +3001,12 @@ func TestConnectionProtocolInfoUnsupported(t *testing.T) {
 	require.Equal(t,
 		clientProtocolInfo,
 		ProtocolInfo{
-			Version:  ProtocolVersion(4),
-			Features: []ProtocolFeature{StreamsFeature, TransactionsFeature},
+			Version: ProtocolVersion(4),
+			Features: []ProtocolFeature{
+				StreamsFeature,
+				TransactionsFeature,
+				ErrorExtensionFeature,
+			},
 		})
 
 	serverProtocolInfo := conn.ServerProtocolInfo()

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -176,3 +176,20 @@ func SkipIfErrorExtendedInfoUnsupported(t *testing.T) {
 		t.Skip("Skipping test for Tarantool without error extended info support")
 	}
 }
+
+// SkipIfErrorExtendedInfoUnsupported skips test run if Tarantool without
+// MP_ERROR type over iproto support is used.
+func SkipIfErrorMessagePackTypeUnsupported(t *testing.T) {
+	t.Helper()
+
+	// Tarantool error type over MessagePack supported only since 2.10.0 version.
+	isLess, err := IsTarantoolVersionLess(2, 10, 0)
+	if err != nil {
+		t.Fatalf("Could not check the Tarantool version")
+	}
+
+	if isLess {
+		t.Skip("Skipping test for Tarantool without support of error type over MessagePack")
+		t.Skip("Skipping test for Tarantool without error extended info support")
+	}
+}


### PR DESCRIPTION
Merge after #226

### code health: rename error iproto code

Since 2.4.1 IPROTO_ERROR (0x31) is renamed to IPROTO_ERROR_24 and IPROTO_ERROR name is used for 0x52 constant describing extended error info [1].

1. https://www.tarantool.io/en/doc/latest/dev_guide/internals/msgpack_extensions/#the-error-type

Part of #209

### api: support errors extended information

Since Tarantool 2.4.1, iproto error responses contain extended info with backtrace [1]. After this patch, Error would contain ExtendedInfo field (BoxError object), if it was provided. Error() handle now will print extended info, if possible.

1. https://www.tarantool.io/en/doc/latest/dev_guide/internals/box_protocol/#responses-for-errors

Part of #209

### api: support error type in MessagePack

Tarantool supports error extension type since version 2.4.1 [1], encoding was introduced in Tarantool 2.10.0 [2]. This patch introduces the support of Tarantool error extension type in msgpack decoders and encoders.

Tarantool error extension type objects are decoded to `*tarantool.BoxError` type. `*tarantool.BoxError` may be encoded top Tarantool error extension type objects.

Error extension type internals are the same as errors extended information: the only difference is that extra information is encoded as a separate error dictionary field and error extension type objects are encoded as MessagePack extension type objects.

The only way to receive an error extension type object from Tarantool is to receive an explicitly built `box.error` object: either from
`return box.error.new(...)` or a tuple with it. All errors raised within Tarantool (including those raised with `box.error(...)`) are encoded based on the same rules as simple errors due to backward compatibility.

It is possible to create error extension type objects with Go code, but it not likely to be really useful since most of their fields is
computed on error initialization on the server side (even for custom error types).

This patch also adds ErrorExtensionFeature flag to client protocol features list. Without this flag, all `box.error` object sent over
iproto are encoded to string. We behave like Tarantool `net.box` here: if we support the feature, we provide the feature flag.

Since it may become too complicated to enable/disable feature flag through import, error extension type is available as a part of the base package, in contrary to Decimal, UUID, Datetime and Interval types which are enabled by importing underscore subpackage.

1. tarantool/tarantool#4398
2. tarantool/tarantool#6433

Closes #209

I didn't forget about:

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)
