### PR TITLE
api: add events subscription support

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Setup Tarantool
-      uses: tarantool/setup-tarantool@v1
+      uses: tarantool/setup-tarantool@v2
       with:
         tarantool-version: '2.8'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,7 +21,9 @@ jobs:
         github.event.pull_request.head.repo.full_name != github.repository) ||
       (github.event_name == 'workflow_dispatch')
 
-    runs-on: ubuntu-latest
+    # We could replace it with ubuntu-latest after fixing the bug:
+    # https://github.com/tarantool/setup-tarantool/issues/37
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup Tarantool ${{ matrix.tarantool }}
         if: matrix.tarantool != '2.x-latest'
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: ${{ matrix.tarantool }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support iproto feature discovery (#120)
 - Support errors extended information (#209)
 - Error type support in MessagePack (#209)
+- Event subscription support (#119)
 
 ### Changed
 

--- a/connection.go
+++ b/connection.go
@@ -77,10 +77,10 @@ func (d defaultLogger) Report(event ConnLogKind, conn *Connection, v ...interfac
 	case LogReconnectFailed:
 		reconnects := v[0].(uint)
 		err := v[1].(error)
-		log.Printf("tarantool: reconnect (%d/%d) to %s failed: %s\n", reconnects, conn.opts.MaxReconnects, conn.addr, err.Error())
+		log.Printf("tarantool: reconnect (%d/%d) to %s failed: %s", reconnects, conn.opts.MaxReconnects, conn.addr, err)
 	case LogLastReconnectFailed:
 		err := v[0].(error)
-		log.Printf("tarantool: last reconnect to %s failed: %s, giving it up.\n", conn.addr, err.Error())
+		log.Printf("tarantool: last reconnect to %s failed: %s, giving it up", conn.addr, err)
 	case LogUnexpectedResultId:
 		resp := v[0].(*Response)
 		log.Printf("tarantool: connection %s got unexpected resultId (%d) in response", conn.addr, resp.RequestId)

--- a/connection_pool/connector.go
+++ b/connection_pool/connector.go
@@ -299,6 +299,14 @@ func (c *ConnectorAdapter) NewStream() (*tarantool.Stream, error) {
 	return c.pool.NewStream(c.mode)
 }
 
+// NewWatcher creates new Watcher object for the pool
+//
+// Since 1.10.0
+func (c *ConnectorAdapter) NewWatcher(key string,
+	callback tarantool.WatchCallback) (tarantool.Watcher, error) {
+	return c.pool.NewWatcher(key, callback, c.mode)
+}
+
 // Do performs a request asynchronously on the connection.
 func (c *ConnectorAdapter) Do(req tarantool.Request) *tarantool.Future {
 	return c.pool.Do(req, c.mode)

--- a/connection_pool/pooler.go
+++ b/connection_pool/pooler.go
@@ -84,6 +84,8 @@ type Pooler interface {
 
 	NewPrepared(expr string, mode Mode) (*tarantool.Prepared, error)
 	NewStream(mode Mode) (*tarantool.Stream, error)
+	NewWatcher(key string, callback tarantool.WatchCallback,
+		mode Mode) (tarantool.Watcher, error)
 
 	Do(req tarantool.Request, mode Mode) (fut *tarantool.Future)
 }

--- a/connection_pool/round_robin_test.go
+++ b/connection_pool/round_robin_test.go
@@ -69,3 +69,22 @@ func TestRoundRobinGetNextConnection(t *testing.T) {
 		}
 	}
 }
+
+func TestRoundRobinStrategy_GetConnections(t *testing.T) {
+	rr := NewEmptyRoundRobin(10)
+
+	addrs := []string{validAddr1, validAddr2}
+	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
+
+	for i, addr := range addrs {
+		rr.AddConn(addr, conns[i])
+	}
+
+	rr.GetConnections()[1] = conns[0] // GetConnections() returns a copy.
+	rrConns := rr.GetConnections()
+	for i, expected := range conns {
+		if expected != rrConns[i] {
+			t.Errorf("Unexpected connection on %d call", i)
+		}
+	}
+}

--- a/connection_pool/watcher.go
+++ b/connection_pool/watcher.go
@@ -1,0 +1,133 @@
+package connection_pool
+
+import (
+	"sync"
+
+	"github.com/tarantool/go-tarantool"
+)
+
+// watcherContainer is a very simple implementation of a thread-safe container
+// for watchers. It is not expected that there will be too many watchers and
+// they will registered/unregistered too frequently.
+//
+// Otherwise, the implementation will need to be optimized.
+type watcherContainer struct {
+	head  *poolWatcher
+	mutex sync.RWMutex
+}
+
+// add adds a watcher to the container.
+func (c *watcherContainer) add(watcher *poolWatcher) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	watcher.next = c.head
+	c.head = watcher
+}
+
+// remove removes a watcher from the container.
+func (c *watcherContainer) remove(watcher *poolWatcher) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if watcher == c.head {
+		c.head = watcher.next
+	} else {
+		cur := c.head
+		for cur.next != nil {
+			if cur.next == watcher {
+				cur.next = watcher.next
+				break
+			}
+			cur = cur.next
+		}
+	}
+}
+
+// foreach iterates over the container to the end or until the call returns
+// false.
+func (c *watcherContainer) foreach(call func(watcher *poolWatcher) error) error {
+	cur := c.head
+	for cur != nil {
+		if err := call(cur); err != nil {
+			return err
+		}
+		cur = cur.next
+	}
+	return nil
+}
+
+// poolWatcher is an internal implementation of the tarantool.Watcher interface.
+type poolWatcher struct {
+	// The watcher container data. We can split the structure into two parts
+	// in the future: a watcher data and a watcher container data, but it looks
+	// simple at now.
+
+	// next item in the watcher container.
+	next *poolWatcher
+	// container is the container for all active poolWatcher objects.
+	container *watcherContainer
+
+	// The watcher data.
+	// mode of the watcher.
+	mode     Mode
+	key      string
+	callback tarantool.WatchCallback
+	// watchers is a map connection -> connection watcher.
+	watchers map[string]tarantool.Watcher
+	// unregistered is true if the watcher already unregistered.
+	unregistered bool
+	// mutex for the pool watcher.
+	mutex sync.Mutex
+}
+
+// Unregister unregisters the pool watcher.
+func (w *poolWatcher) Unregister() {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if !w.unregistered {
+		w.container.remove(w)
+		w.unregistered = true
+		for _, watcher := range w.watchers {
+			watcher.Unregister()
+		}
+	}
+}
+
+// watch adds a watcher for the connection.
+func (w *poolWatcher) watch(conn *tarantool.Connection) error {
+	addr := conn.Addr()
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if !w.unregistered {
+		if _, ok := w.watchers[addr]; ok {
+			return nil
+		}
+
+		if watcher, err := conn.NewWatcher(w.key, w.callback); err == nil {
+			w.watchers[addr] = watcher
+			return nil
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+// unwatch removes a watcher for the connection.
+func (w *poolWatcher) unwatch(conn *tarantool.Connection) {
+	addr := conn.Addr()
+
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if !w.unregistered {
+		if watcher, ok := w.watchers[addr]; ok {
+			watcher.Unregister()
+			delete(w.watchers, addr)
+		}
+	}
+}

--- a/connector.go
+++ b/connector.go
@@ -46,6 +46,7 @@ type Connector interface {
 
 	NewPrepared(expr string) (*Prepared, error)
 	NewStream() (*Stream, error)
+	NewWatcher(key string, callback WatchCallback) (Watcher, error)
 
 	Do(req Request) (fut *Future)
 }

--- a/const.go
+++ b/const.go
@@ -19,6 +19,8 @@ const (
 	PingRequestCode      = 64
 	SubscribeRequestCode = 66
 	IdRequestCode        = 73
+	WatchRequestCode     = 74
+	UnwatchRequestCode   = 75
 
 	KeyCode         = 0x00
 	KeySync         = 0x01
@@ -46,6 +48,8 @@ const (
 	KeyVersion      = 0x54
 	KeyFeatures     = 0x55
 	KeyTimeout      = 0x56
+	KeyEvent        = 0x57
+	KeyEventData    = 0x58
 	KeyTxnIsolation = 0x59
 
 	KeyFieldName               = 0x00
@@ -74,6 +78,7 @@ const (
 	RLimitWait = 2
 
 	OkCode            = uint32(0)
+	EventCode         = uint32(0x4c)
 	PushCode          = uint32(0x80)
 	ErrorCodeBit      = 0x8000
 	PacketLengthBytes = 5

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -507,6 +507,16 @@ func (connMulti *ConnectionMulti) NewStream() (*tarantool.Stream, error) {
 	return connMulti.getCurrentConnection().NewStream()
 }
 
+// NewWatcher does not supported by the ConnectionMulti. The ConnectionMulti is
+// deprecated: use ConnectionPool instead.
+//
+// Since 1.10.0
+func (connMulti *ConnectionMulti) NewWatcher(key string,
+	callback tarantool.WatchCallback) (tarantool.Watcher, error) {
+	return nil, errors.New("ConnectionMulti is deprecated " +
+		"use ConnectionPool")
+}
+
 // Do sends the request and returns a future.
 func (connMulti *ConnectionMulti) Do(req tarantool.Request) *tarantool.Future {
 	if connectedReq, ok := req.(tarantool.ConnectedRequest); ok {

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -548,6 +548,30 @@ func TestStream_Rollback(t *testing.T) {
 	}
 }
 
+func TestConnectionMulti_NewWatcher(t *testing.T) {
+	test_helpers.SkipIfStreamsUnsupported(t)
+
+	multiConn, err := Connect([]string{server1, server2}, connOpts)
+	if err != nil {
+		t.Fatalf("Failed to connect: %s", err.Error())
+	}
+	if multiConn == nil {
+		t.Fatalf("conn is nil after Connect")
+	}
+	defer multiConn.Close()
+
+	watcher, err := multiConn.NewWatcher("foo", func(event tarantool.WatchEvent) {})
+	if watcher != nil {
+		t.Errorf("Unexpected watcher")
+	}
+	if err == nil {
+		t.Fatalf("Unexpected success")
+	}
+	if err.Error() != "ConnectionMulti is deprecated use ConnectionPool" {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
 // runTestMain is a body of TestMain function
 // (see https://pkg.go.dev/testing#hdr-Main).
 // Using defer + os.Exit is not works so TestMain body

--- a/protocol.go
+++ b/protocol.go
@@ -76,13 +76,16 @@ var clientProtocolInfo ProtocolInfo = ProtocolInfo{
 	// 1.10.0.
 	Version: ProtocolVersion(4),
 	// Streams and transactions were introduced in protocol version 1
-	// (Tarantool 2.10.0), in connector since 1.7.0. Error extension
-	// type was introduced in protocol version 2 (Tarantool 2.10.0),
-	// in connector since 1.10.0.
+	// (Tarantool 2.10.0), in connector since 1.7.0.
+	// Error extension type was introduced in protocol
+	// version 2 (Tarantool 2.10.0), in connector since 1.10.0.
+	// Watchers were introduced in protocol version 3 (Tarantool 2.10.0), in
+	// connector since 1.10.0.
 	Features: []ProtocolFeature{
 		StreamsFeature,
 		TransactionsFeature,
 		ErrorExtensionFeature,
+		WatchersFeature,
 	},
 }
 

--- a/request.go
+++ b/request.go
@@ -538,6 +538,8 @@ type Request interface {
 	Body(resolver SchemaResolver, enc *encoder) error
 	// Ctx returns a context of the request.
 	Ctx() context.Context
+	// Async returns true if the request does not expect response.
+	Async() bool
 }
 
 // ConnectedRequest is an interface that provides the info about a Connection
@@ -550,12 +552,18 @@ type ConnectedRequest interface {
 
 type baseRequest struct {
 	requestCode int32
+	async       bool
 	ctx         context.Context
 }
 
 // Code returns a IPROTO code for the request.
 func (req *baseRequest) Code() int32 {
 	return req.requestCode
+}
+
+// Async returns true if the request does not require a response.
+func (req *baseRequest) Async() bool {
+	return req.async
 }
 
 // Ctx returns a context of the request.

--- a/test_helpers/request_mock.go
+++ b/test_helpers/request_mock.go
@@ -17,6 +17,10 @@ func (sr *StrangerRequest) Code() int32 {
 	return 0
 }
 
+func (sr *StrangerRequest) Async() bool {
+	return false
+}
+
 func (sr *StrangerRequest) Body(resolver tarantool.SchemaResolver, enc *encoder) error {
 	return nil
 }

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -75,18 +75,54 @@ func SkipIfSQLUnsupported(t testing.TB) {
 	}
 }
 
-func SkipIfStreamsUnsupported(t *testing.T) {
+func skipIfLess(t *testing.T, feature string, major, minor, patch uint64) {
 	t.Helper()
 
-	// Tarantool supports streams and interactive transactions since version 2.10.0
-	isLess, err := IsTarantoolVersionLess(2, 10, 0)
+	isLess, err := IsTarantoolVersionLess(major, minor, patch)
 	if err != nil {
 		t.Fatalf("Could not check the Tarantool version")
 	}
 
 	if isLess {
-		t.Skip("Skipping test for Tarantool without streams support")
+		t.Skipf("Skipping test for Tarantool without %s support", feature)
 	}
+}
+
+func skipIfGreaterOrEqual(t *testing.T, feature string, major, minor, patch uint64) {
+	t.Helper()
+
+	isLess, err := IsTarantoolVersionLess(major, minor, patch)
+	if err != nil {
+		t.Fatalf("Could not check the Tarantool version")
+	}
+
+	if !isLess {
+		t.Skipf("Skipping test for Tarantool with %s support", feature)
+	}
+}
+
+// SkipOfStreamsUnsupported skips test run if Tarantool without streams
+// support is used.
+func SkipIfStreamsUnsupported(t *testing.T) {
+	t.Helper()
+
+	skipIfLess(t, "streams", 2, 10, 0)
+}
+
+// SkipOfStreamsUnsupported skips test run if Tarantool without watchers
+// support is used.
+func SkipIfWatchersUnsupported(t *testing.T) {
+	t.Helper()
+
+	skipIfLess(t, "watchers", 2, 10, 0)
+}
+
+// SkipIfWatchersSupported skips test run if Tarantool with watchers
+// support is used.
+func SkipIfWatchersSupported(t *testing.T) {
+	t.Helper()
+
+	skipIfGreaterOrEqual(t, "watchers", 2, 10, 0)
 }
 
 // SkipIfIdUnsupported skips test run if Tarantool without
@@ -94,15 +130,7 @@ func SkipIfStreamsUnsupported(t *testing.T) {
 func SkipIfIdUnsupported(t *testing.T) {
 	t.Helper()
 
-	// Tarantool supports Id requests since version 2.10.0
-	isLess, err := IsTarantoolVersionLess(2, 10, 0)
-	if err != nil {
-		t.Fatalf("Could not check the Tarantool version")
-	}
-
-	if isLess {
-		t.Skip("Skipping test for Tarantool without id requests support")
-	}
+	skipIfLess(t, "id requests", 2, 10, 0)
 }
 
 // SkipIfIdSupported skips test run if Tarantool with
@@ -111,15 +139,7 @@ func SkipIfIdUnsupported(t *testing.T) {
 func SkipIfIdSupported(t *testing.T) {
 	t.Helper()
 
-	// Tarantool supports Id requests since version 2.10.0
-	isLess, err := IsTarantoolVersionLess(2, 10, 0)
-	if err != nil {
-		t.Fatalf("Could not check the Tarantool version")
-	}
-
-	if !isLess {
-		t.Skip("Skipping test for Tarantool with non-zero protocol version and features")
-	}
+	skipIfGreaterOrEqual(t, "id requests", 2, 10, 0)
 }
 
 // CheckEqualBoxErrors checks equivalence of tarantool.BoxError objects.

--- a/watch.go
+++ b/watch.go
@@ -1,0 +1,138 @@
+package tarantool
+
+import (
+	"context"
+)
+
+// BroadcastRequest helps to send broadcast messages. See:
+// https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_events/broadcast/
+type BroadcastRequest struct {
+	call *CallRequest
+	key  string
+}
+
+// NewBroadcastRequest returns a new broadcast request for a specified key.
+func NewBroadcastRequest(key string) *BroadcastRequest {
+	req := new(BroadcastRequest)
+	req.key = key
+	req.call = NewCallRequest("box.broadcast").Args([]interface{}{key})
+	return req
+}
+
+// Value sets the value for the broadcast request.
+// Note: default value is nil.
+func (req *BroadcastRequest) Value(value interface{}) *BroadcastRequest {
+	req.call = req.call.Args([]interface{}{req.key, value})
+	return req
+}
+
+// Context sets a passed context to the broadcast request.
+func (req *BroadcastRequest) Context(ctx context.Context) *BroadcastRequest {
+	req.call = req.call.Context(ctx)
+	return req
+}
+
+// Code returns IPROTO code for the broadcast request.
+func (req *BroadcastRequest) Code() int32 {
+	return req.call.Code()
+}
+
+// Body fills an encoder with the broadcast request body.
+func (req *BroadcastRequest) Body(res SchemaResolver, enc *encoder) error {
+	return req.call.Body(res, enc)
+}
+
+// Ctx returns a context of the broadcast request.
+func (req *BroadcastRequest) Ctx() context.Context {
+	return req.call.Ctx()
+}
+
+// Async returns is the broadcast request expects a response.
+func (req *BroadcastRequest) Async() bool {
+	return req.call.Async()
+}
+
+// watchRequest subscribes to the updates of a specified key defined on the
+// server. After receiving the notification, you should send a new
+// watchRequest to acknowledge the notification.
+type watchRequest struct {
+	baseRequest
+	key string
+	ctx context.Context
+}
+
+// newWatchRequest returns a new watchRequest.
+func newWatchRequest(key string) *watchRequest {
+	req := new(watchRequest)
+	req.requestCode = WatchRequestCode
+	req.async = true
+	req.key = key
+	return req
+}
+
+// Body fills an encoder with the watch request body.
+func (req *watchRequest) Body(res SchemaResolver, enc *encoder) error {
+	if err := enc.EncodeMapLen(1); err != nil {
+		return err
+	}
+	if err := encodeUint(enc, KeyEvent); err != nil {
+		return err
+	}
+	return enc.EncodeString(req.key)
+}
+
+// Context sets a passed context to the request.
+func (req *watchRequest) Context(ctx context.Context) *watchRequest {
+	req.ctx = ctx
+	return req
+}
+
+// unwatchRequest unregisters a watcher subscribed to the given notification
+// key.
+type unwatchRequest struct {
+	baseRequest
+	key string
+	ctx context.Context
+}
+
+// newUnwatchRequest returns a new unwatchRequest.
+func newUnwatchRequest(key string) *unwatchRequest {
+	req := new(unwatchRequest)
+	req.requestCode = UnwatchRequestCode
+	req.async = true
+	req.key = key
+	return req
+}
+
+// Body fills an encoder with the unwatch request body.
+func (req *unwatchRequest) Body(res SchemaResolver, enc *encoder) error {
+	if err := enc.EncodeMapLen(1); err != nil {
+		return err
+	}
+	if err := encodeUint(enc, KeyEvent); err != nil {
+		return err
+	}
+	return enc.EncodeString(req.key)
+}
+
+// Context sets a passed context to the request.
+func (req *unwatchRequest) Context(ctx context.Context) *unwatchRequest {
+	req.ctx = ctx
+	return req
+}
+
+// WatchEvent is a watch notification event received from a server.
+type WatchEvent struct {
+	Conn  *Connection // A source connection.
+	Key   string      // A key.
+	Value interface{} // A value.
+}
+
+// Watcher is a subscription to broadcast events.
+type Watcher interface {
+	// Unregister unregisters the watcher.
+	Unregister()
+}
+
+// WatchCallback is a callback to invoke when the key value is updated.
+type WatchCallback func(event WatchEvent)


### PR DESCRIPTION
A user can create watcher by the Connection.NewWatcher() call:

```Go
    watcher = conn.NewWatcker("key", func(event WatchEvent) {
        // The callback code.
    })
```

After that, the watcher callback is invoked for the first time. In this case, the callback is triggered whether or not the key has already been broadcast. All subsequent invocations are triggered with box.broadcast() called on the remote host. If a watcher is subscribed for a key that has not been broadcast yet, the callback is triggered only once, after the registration of the watcher.

If the key is updated while the watcher callback is running, the callback will be invoked again with the latest value as soon as it returns.

Multiple watchers can be created for one key.

If you don’t need the watcher anymore, you can unregister it using the Unregister method:

```Go
    watcher.Unregister()
```

The api is similar to net.box implementation [1].

It also adds a BroadcastRequest to make it easier to send broadcast messages.

1. https://www.tarantool.io/en/doc/latest/reference/reference_lua/net_box/#conn-watch

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #119