### PR TITLE
bugfix: decimal uses a test variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Decimal package uses a test variable DecimalPrecision instead of a
+  package-level variable decimalPrecision (#233)
+
 ## [1.9.0] - 2022-11-02
 
 The release adds support for the latest version of the
@@ -40,7 +43,7 @@ switching.
 - A connection is still opened after ConnectionPool.Close() (#208)
 - Future.GetTyped() after Future.Get() does not decode response
   correctly (#213)
-- Decimal package use a test function GetNumberLength instead of a
+- Decimal package uses a test function GetNumberLength instead of a
   package-level function getNumberLength (#219)
 - Datetime location after encode + decode is unequal (#217)
 - Wrong interval arithmetic with timezones (#221)

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -58,13 +58,13 @@ func NewDecimalFromString(src string) (result *Decimal, err error) {
 // MarshalMsgpack serializes the Decimal into a MessagePack representation.
 func (decNum *Decimal) MarshalMsgpack() ([]byte, error) {
 	one := decimal.NewFromInt(1)
-	maxSupportedDecimal := decimal.New(1, DecimalPrecision).Sub(one) // 10^DecimalPrecision - 1
-	minSupportedDecimal := maxSupportedDecimal.Neg().Sub(one)        // -10^DecimalPrecision - 1
+	maxSupportedDecimal := decimal.New(1, decimalPrecision).Sub(one) // 10^decimalPrecision - 1
+	minSupportedDecimal := maxSupportedDecimal.Neg().Sub(one)        // -10^decimalPrecision - 1
 	if decNum.GreaterThan(maxSupportedDecimal) {
-		return nil, fmt.Errorf("msgpack: decimal number is bigger than maximum supported number (10^%d - 1)", DecimalPrecision)
+		return nil, fmt.Errorf("msgpack: decimal number is bigger than maximum supported number (10^%d - 1)", decimalPrecision)
 	}
 	if decNum.LessThan(minSupportedDecimal) {
-		return nil, fmt.Errorf("msgpack: decimal number is lesser than minimum supported number (-10^%d - 1)", DecimalPrecision)
+		return nil, fmt.Errorf("msgpack: decimal number is lesser than minimum supported number (-10^%d - 1)", decimalPrecision)
 	}
 
 	strBuf := decNum.String()


### PR DESCRIPTION
The patch replaces usage of a test variable DecimalPrecision by a package-level variable decimalPrecision in the decimal package code.

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

See:

1. https://github.com/tarantool/go-tarantool/blob/48cf0c75b3869e54fc47881f0a1323612c3694fe/decimal/decimal.go#L36
2. https://github.com/tarantool/go-tarantool/blob/48cf0c75b3869e54fc47881f0a1323612c3694fe/decimal/export_test.go#L16