### PR TITLE
api: add pap-sha256 auth support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -116,13 +116,16 @@ jobs:
       fail-fast: false
       matrix:
         sdk-version:
-          - '1.10.11-0-gf0b0e7ecf-r470'
-          - '2.8.3-21-g7d35cd2be-r470'
+          - 'bundle-1.10.11-0-gf0b0e7ecf-r470'
         coveralls: [false]
         fuzzing: [false]
         ssl: [false]
         include:
-          - sdk-version: '2.10.0-1-gfa775b383-r486-linux-x86_64'
+          - sdk-version: 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64'
+            coveralls: false
+            ssl: true
+          - sdk-path: 'dev/linux/x86_64/master/'
+            sdk-version: 'sdk-gc64-2.11.0-entrypoint-113-g803baaffe-r529.linux.x86_64'
             coveralls: true
             ssl: true
 
@@ -141,8 +144,8 @@ jobs:
 
       - name: Setup Tarantool ${{ matrix.sdk-version }}
         run: |
-          ARCHIVE_NAME=tarantool-enterprise-bundle-${{ matrix.sdk-version }}.tar.gz
-          curl -O -L https://${{ secrets.SDK_DOWNLOAD_TOKEN }}@download.tarantool.io/enterprise/${ARCHIVE_NAME}
+          ARCHIVE_NAME=tarantool-enterprise-${{ matrix.sdk-version }}.tar.gz
+          curl -O -L https://${{ secrets.SDK_DOWNLOAD_TOKEN }}@download.tarantool.io/enterprise/${{ matrix.sdk-path }}${ARCHIVE_NAME}
           tar -xzf ${ARCHIVE_NAME}
           rm -f ${ARCHIVE_NAME}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Error type support in MessagePack (#209)
 - Event subscription support (#119)
 - Session settings support (#215)
+- pap-sha256 authorization method support (Tarantool EE feature) (#243)
 
 ### Changed
 

--- a/auth.go
+++ b/auth.go
@@ -3,7 +3,45 @@ package tarantool
 import (
 	"crypto/sha1"
 	"encoding/base64"
+	"fmt"
 )
+
+const (
+	chapSha1  = "chap-sha1"
+	papSha256 = "pap-sha256"
+)
+
+// Auth is used as a parameter to set up an authentication method.
+type Auth int
+
+const (
+	// AutoAuth does not force any authentication method. A method will be
+	// selected automatically (a value from IPROTO_ID response or
+	// ChapSha1Auth).
+	AutoAuth Auth = iota
+	// ChapSha1Auth forces chap-sha1 authentication method. The method is
+	// available both in the Tarantool Community Edition (CE) and the
+	// Tarantool Enterprise Edition (EE)
+	ChapSha1Auth
+	// PapSha256Auth forces pap-sha256 authentication method. The method is
+	// available only for the Tarantool Enterprise Edition (EE) with
+	// SSL transport.
+	PapSha256Auth
+)
+
+// String returns a string representation of an authentication method.
+func (a Auth) String() string {
+	switch a {
+	case AutoAuth:
+		return "auto"
+	case ChapSha1Auth:
+		return chapSha1
+	case PapSha256Auth:
+		return papSha256
+	default:
+		return fmt.Sprintf("unknown auth type (code %d)", a)
+	}
+}
 
 func scramble(encodedSalt, pass string) (scramble []byte, err error) {
 	/* ==================================================================

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,28 @@
+package tarantool_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	. "github.com/tarantool/go-tarantool"
+)
+
+func TestAuth_String(t *testing.T) {
+	unknownId := int(PapSha256Auth) + 1
+	tests := []struct {
+		auth     Auth
+		expected string
+	}{
+		{AutoAuth, "auto"},
+		{ChapSha1Auth, "chap-sha1"},
+		{PapSha256Auth, "pap-sha256"},
+		{Auth(unknownId), fmt.Sprintf("unknown auth type (code %d)", unknownId)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			assert.Equal(t, tc.auth.String(), tc.expected)
+		})
+	}
+}

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,12 @@
 -- Do not set listen for now so connector won't be
 -- able to send requests until everything is configured.
+local auth_type = os.getenv("TEST_TNT_AUTH_TYPE")
+if auth_type == "auto" then
+    auth_type = nil
+end
+
 box.cfg{
+    auth_type = auth_type,
     work_dir = os.getenv("TEST_TNT_WORK_DIR"),
     memtx_use_mvcc_engine = os.getenv("TEST_TNT_MEMTX_USE_MVCC_ENGINE") == 'true' or nil,
 }
@@ -267,5 +273,6 @@ box.space.test:truncate()
 
 -- Set listen only when every other thing is configured.
 box.cfg{
+    auth_type = auth_type,
     listen = os.getenv("TEST_TNT_LISTEN"),
 }

--- a/const.go
+++ b/const.go
@@ -51,6 +51,7 @@ const (
 	KeyEvent        = 0x57
 	KeyEventData    = 0x58
 	KeyTxnIsolation = 0x59
+	KeyAuthType     = 0x5b
 
 	KeyFieldName               = 0x00
 	KeyFieldType               = 0x01

--- a/protocol.go
+++ b/protocol.go
@@ -13,6 +13,8 @@ type ProtocolFeature uint64
 
 // ProtocolInfo type aggregates Tarantool protocol version and features info.
 type ProtocolInfo struct {
+	// Auth is an authentication method.
+	Auth Auth
 	// Version is the supported protocol version.
 	Version ProtocolVersion
 	// Features are supported protocol features.

--- a/response.go
+++ b/response.go
@@ -213,6 +213,21 @@ func (resp *Response) decodeBody() (err error) {
 					}
 					serverProtocolInfo.Features[i] = feature
 				}
+			case KeyAuthType:
+				var auth string
+				if auth, err = d.DecodeString(); err != nil {
+					return err
+				}
+				found := false
+				for _, a := range [...]Auth{ChapSha1Auth, PapSha256Auth} {
+					if auth == a.String() {
+						serverProtocolInfo.Auth = a
+						found = true
+					}
+				}
+				if !found {
+					return fmt.Errorf("unknown auth type %s", auth)
+				}
 			default:
 				if err = d.Skip(); err != nil {
 					return err

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -726,6 +726,38 @@ func BenchmarkSQLSerial(b *testing.B) {
 	}
 }
 
+func TestOptsAuth_Default(t *testing.T) {
+	defaultOpts := opts
+	defaultOpts.Auth = AutoAuth
+
+	conn := test_helpers.ConnectWithValidation(t, server, defaultOpts)
+	defer conn.Close()
+}
+
+func TestOptsAuth_ChapSha1Auth(t *testing.T) {
+	chapSha1Opts := opts
+	chapSha1Opts.Auth = ChapSha1Auth
+
+	conn := test_helpers.ConnectWithValidation(t, server, chapSha1Opts)
+	defer conn.Close()
+}
+
+func TestOptsAuth_PapSha256AuthForbit(t *testing.T) {
+	papSha256Opts := opts
+	papSha256Opts.Auth = PapSha256Auth
+
+	conn, err := Connect(server, papSha256Opts)
+	if err == nil {
+		t.Error("An error expected.")
+		conn.Close()
+	}
+
+	if err.Error() != "auth: forbidden to use pap-sha256 unless "+
+		"SSL is enabled for the connection" {
+		t.Errorf("An unexpected error: %s", err)
+	}
+}
+
 func TestFutureMultipleGetGetTyped(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer conn.Close()

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -27,6 +27,9 @@ import (
 )
 
 type StartOpts struct {
+	// Auth is an authentication method for a Tarantool instance.
+	Auth tarantool.Auth
+
 	// InitScript is a Lua script for tarantool to run on start.
 	InitScript string
 
@@ -223,6 +226,7 @@ func StartTarantool(startOpts StartOpts) (TarantoolInstance, error) {
 		fmt.Sprintf("TEST_TNT_WORK_DIR=%s", startOpts.WorkDir),
 		fmt.Sprintf("TEST_TNT_LISTEN=%s", startOpts.Listen),
 		fmt.Sprintf("TEST_TNT_MEMTX_USE_MVCC_ENGINE=%t", startOpts.MemtxUseMvccEngine),
+		fmt.Sprintf("TEST_TNT_AUTH_TYPE=%s", startOpts.Auth),
 	)
 
 	// Copy SSL certificates.
@@ -248,6 +252,7 @@ func StartTarantool(startOpts StartOpts) (TarantoolInstance, error) {
 	time.Sleep(startOpts.WaitStart)
 
 	opts := tarantool.Opts{
+		Auth:       startOpts.Auth,
 		Timeout:    500 * time.Millisecond,
 		User:       startOpts.User,
 		Pass:       startOpts.Pass,


### PR DESCRIPTION
The authentication method works only with Tarantool EE [1].

1. https://github.com/tarantool/enterprise_doc/issues/206

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes https://github.com/tarantool/go-tarantool/issues/243