### PR TITLE
readme: support Tarantool 1.10+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 # Client in Go for Tarantool
 
 The package `go-tarantool` contains everything you need to connect to
-[Tarantool 1.6+][tarantool-site].
+[Tarantool 1.10+][tarantool-site].
 
 The advantage of integrating Go with Tarantool, which is an application server
 plus a DBMS, is that Go programmers can handle databases and perform on-the-fly
@@ -32,7 +32,7 @@ faster than other packages according to public benchmarks.
 
 ## Installation
 
-We assume that you have Tarantool version 1.6+ and a modern Linux or BSD
+We assume that you have Tarantool version 1.10+ and a modern Linux or BSD
 operating system.
 
 You need a current version of `go`, version 1.13 or later (use `go version` to

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -945,21 +945,19 @@ func TestClient(t *testing.T) {
 	}
 
 	// Upsert
-	if strings.Compare(conn.Greeting.Version, "Tarantool 1.6.7") >= 0 {
-		resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
-		if err != nil {
-			t.Fatalf("Failed to Upsert (insert): %s", err.Error())
-		}
-		if resp == nil {
-			t.Errorf("Response is nil after Upsert (insert)")
-		}
-		resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
-		if err != nil {
-			t.Fatalf("Failed to Upsert (update): %s", err.Error())
-		}
-		if resp == nil {
-			t.Errorf("Response is nil after Upsert (update)")
-		}
+	resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
+	if err != nil {
+		t.Fatalf("Failed to Upsert (insert): %s", err.Error())
+	}
+	if resp == nil {
+		t.Errorf("Response is nil after Upsert (insert)")
+	}
+	resp, err = conn.Upsert(spaceNo, []interface{}{uint(3), 1}, []interface{}{[]interface{}{"+", 1, 1}})
+	if err != nil {
+		t.Fatalf("Failed to Upsert (update): %s", err.Error())
+	}
+	if resp == nil {
+		t.Errorf("Response is nil after Upsert (update)")
 	}
 
 	// Select
@@ -1977,21 +1975,19 @@ func TestClientNamed(t *testing.T) {
 	}
 
 	// Upsert
-	if strings.Compare(conn.Greeting.Version, "Tarantool 1.6.7") >= 0 {
-		resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
-		if err != nil {
-			t.Fatalf("Failed to Upsert (insert): %s", err.Error())
-		}
-		if resp == nil {
-			t.Errorf("Response is nil after Upsert (insert)")
-		}
-		resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
-		if err != nil {
-			t.Fatalf("Failed to Upsert (update): %s", err.Error())
-		}
-		if resp == nil {
-			t.Errorf("Response is nil after Upsert (update)")
-		}
+	resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
+	if err != nil {
+		t.Fatalf("Failed to Upsert (insert): %s", err.Error())
+	}
+	if resp == nil {
+		t.Errorf("Response is nil after Upsert (insert)")
+	}
+	resp, err = conn.Upsert(spaceName, []interface{}{uint(1003), 1}, []interface{}{[]interface{}{"+", 1, 1}})
+	if err != nil {
+		t.Fatalf("Failed to Upsert (update): %s", err.Error())
+	}
+	if resp == nil {
+		t.Errorf("Response is nil after Upsert (update)")
 	}
 
 	// Select


### PR DESCRIPTION
Technically, the connector can now work with Tarantool 1.6+. But we decided to simplify our CI and do not declare support for older versions [1].

1. https://github.com/tarantool/go-tarantool/pull/198
