### PR TITLE
bugfix: flaky TestClientRequestObjectsWithContext 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Decimal package uses a test variable DecimalPrecision instead of a
   package-level variable decimalPrecision (#233)
+- Flaky tests TestClientRequestObjectsWithContext and
+  TestClientIdRequestObjectWithContext (#244)
 
 ## [1.9.0] - 2022-11-02
 

--- a/connection.go
+++ b/connection.go
@@ -1062,22 +1062,18 @@ func (conn *Connection) newFuture(ctx context.Context) (fut *Future) {
 }
 
 // This method removes a future from the internal queue if the context
-// is "done" before the response is come. Such select logic is inspired
-// from this thread: https://groups.google.com/g/golang-dev/c/jX4oQEls3uk
+// is "done" before the response is come.
 func (conn *Connection) contextWatchdog(fut *Future, ctx context.Context) {
 	select {
 	case <-fut.done:
+	case <-ctx.Done():
+	}
+
+	select {
+	case <-fut.done:
+		return
 	default:
-		select {
-		case <-ctx.Done():
-			conn.cancelFuture(fut, fmt.Errorf("context is done"))
-		default:
-			select {
-			case <-fut.done:
-			case <-ctx.Done():
-				conn.cancelFuture(fut, fmt.Errorf("context is done"))
-			}
-		}
+		conn.cancelFuture(fut, fmt.Errorf("context is done"))
 	}
 }
 
@@ -1093,11 +1089,9 @@ func (conn *Connection) send(req Request, streamId uint64) *Future {
 			return fut
 		default:
 		}
-	}
-	conn.putFuture(fut, req, streamId)
-	if req.Ctx() != nil {
 		go conn.contextWatchdog(fut, req.Ctx())
 	}
+	conn.putFuture(fut, req, streamId)
 	return fut
 }
 
@@ -1308,15 +1302,6 @@ func (conn *Connection) Do(req Request) *Future {
 			fut := NewFuture()
 			fut.SetError(fmt.Errorf("the passed connected request doesn't belong to the current connection or connection pool"))
 			return fut
-		}
-	}
-	if req.Ctx() != nil {
-		select {
-		case <-req.Ctx().Done():
-			fut := NewFuture()
-			fut.SetError(fmt.Errorf("context is done"))
-			return fut
-		default:
 		}
 	}
 	return conn.send(req, ignoreStreamId)

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -2973,24 +2973,6 @@ func TestClientIdRequestObjectWithPassedCanceledContext(t *testing.T) {
 	require.Equal(t, err.Error(), "context is done")
 }
 
-func TestClientIdRequestObjectWithContext(t *testing.T) {
-	var err error
-	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	req := NewIdRequest(ProtocolInfo{
-		Version:  ProtocolVersion(1),
-		Features: []ProtocolFeature{StreamsFeature},
-	}).Context(ctx) //nolint
-	fut := conn.Do(req)
-	cancel()
-	resp, err := fut.Get()
-	require.Nilf(t, resp, "Response is empty")
-	require.NotNilf(t, err, "Error is not empty")
-	require.Equal(t, err.Error(), "context is done")
-}
-
 func TestConnectionProtocolInfoUnsupported(t *testing.T) {
 	test_helpers.SkipIfIdSupported(t)
 


### PR DESCRIPTION
The patch makes the test more deterministic. It helps to avoid
canceling a request with an already received response.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #244