### PR TITLE
ci: improve golangci-lint output

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,7 +37,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
+        continue-on-error: true
         with:
           # The suppression of the rule `errcheck` may be removed after adding
           # errors check in all methods calling EncodeXxx inside.
@@ -47,7 +48,16 @@ jobs:
           # The `//nolint` workaround was not the acceptable way of warnings suppression,
           # cause those comments get rendered in documentation by godoc.
           # See https://github.com/tarantool/go-tarantool/pull/160#discussion_r858608221
+          #
+          # The first run is for GitHub Actions error format.
           args: -E goimports -D errcheck
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # The second run is for human-readable error format with a file name
+          # and a line number.
+          args: --out-${NO_FUTURE}format colored-line-number -E goimports -D errcheck
 
   codespell:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The patch adds a second golangci-lint run that prints errors in human-readable format [1].

1. https://github.com/golangci/golangci-lint-action/issues/119

Closes #231

The first run of golangci-lint prints errors in GitHub Actions format:
![1](https://user-images.githubusercontent.com/29621138/209658199-5df92d72-d3cb-4b2c-be5a-d90877a0b2a8.png)

The second run in human-readable format:

![2](https://user-images.githubusercontent.com/29621138/209658254-5c03460a-34f8-42a3-ab44-b9cba8d276b7.png)

Unfortunately, it doesn't work in one run and we need two different ones.