### PR TITLE
bugfix: flaky multi/TestDisconnectAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   package-level variable decimalPrecision (#233)
 - Flaky tests TestClientRequestObjectsWithContext and
   TestClientIdRequestObjectWithContext (#244)
+- Flaky test multi/TestDisconnectAll (#234)
 
 ## [1.9.0] - 2022-11-02
 


### PR DESCRIPTION
After the fix the test stops tarantool intances to avoid concurrent reconnects by a ConnectionMulti instance.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #234