### PR TITLE
ci: add tests with data race detector

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -97,16 +97,24 @@ jobs:
         run: make deps
 
       - name: Run regression tests
-        run: make test
+        run: |
+          make test
+          make testrace
 
       - name: Run regression tests with call_17
-        run: make test TAGS="go_tarantool_call_17"
+        run: |
+          make test TAGS="go_tarantool_call_17"
+          make testrace TAGS="go_tarantool_call_17"
 
       - name: Run regression tests with msgpack.v5
-        run: make test TAGS="go_tarantool_msgpack_v5"
+        run: |
+          make test TAGS="go_tarantool_msgpack_v5"
+          make testrace TAGS="go_tarantool_msgpack_v5"
 
       - name: Run regression tests with msgpack.v5 and call_17
-        run: make test TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
+        run: |
+          make test TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
+          make testrace TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
 
       - name: Run fuzzing tests
         if: ${{ matrix.fuzzing }}
@@ -189,6 +197,7 @@ jobs:
         run: |
           source tarantool-enterprise/env.sh
           make test
+          make testrace
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 
@@ -196,6 +205,7 @@ jobs:
         run: |
           source tarantool-enterprise/env.sh
           make test TAGS="go_tarantool_call_17"
+          make testrace TAGS="go_tarantool_call_17"
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 
@@ -203,6 +213,7 @@ jobs:
         run: |
           source tarantool-enterprise/env.sh
           make test TAGS="go_tarantool_msgpack_v5"
+          make testrace TAGS="go_tarantool_msgpack_v5"
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 
@@ -210,6 +221,7 @@ jobs:
         run: |
           source tarantool-enterprise/env.sh
           make test TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
+          make testrace TAGS="go_tarantool_msgpack_v5,go_tarantool_call_17"
         env:
           TEST_TNT_SSL: ${{matrix.ssl}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - Support pagination (#246)
+- A Makefile target to test with race detector (#218)
 
 ### Changed
 
 ### Fixed
+
+- Several non-critical data race issues (#218)
 
 ## [1.10.0] - 2022-12-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,18 @@ To run tests for the main package and each subpackage:
 make test
 ```
 
+To run tests for the main package and each subpackage with race detector:
+```bash
+make testrace
+```
+
 The tests set up all required `tarantool` processes before run and clean up
 afterwards.
 
 If you want to run the tests with specific build tags:
 ```bash
 make test TAGS=go_tarantool_ssl_disable,go_tarantool_msgpack_v5
+make testrace TAGS=go_tarantool_ssl_disable,go_tarantool_msgpack_v5
 ```
 
 If you have Tarantool Enterprise Edition 2.10 or newer, you can run additional
@@ -39,6 +45,7 @@ SSL tests. To do this, you need to set an environment variable 'TEST_TNT_SSL':
 
 ```bash
 TEST_TNT_SSL=true make test
+TEST_TNT_SSL=true make testrace
 ```
 
 If you want to run the tests for a specific package:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,13 @@ ${BENCH_PATH} bench-deps:
 	rm -rf ${BENCH_PATH}
 	mkdir ${BENCH_PATH}
 	go clean -testcache
-	cd ${BENCH_PATH} && git clone https://go.googlesource.com/perf && cd perf && go install ./cmd/benchstat
+	# It is unable to build a latest version of benchstat with go 1.13. So
+	# we need to switch to an old commit.
+	cd ${BENCH_PATH} && \
+		git clone https://go.googlesource.com/perf && \
+		cd perf && \
+		git checkout 91a04616dc65ba76dbe9e5cf746b923b1402d303 && \
+		go install ./cmd/benchstat
 	rm -rf ${BENCH_PATH}/perf
 
 .PHONY: bench

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ test:
 testdata:
 	(cd ./testdata; ./generate.sh)
 
+.PHONY: testrace
+testrace:
+	@echo "Running all packages tests with data race detector"
+	go clean -testcache
+	go test -race -tags "$(TAGS)" ./... -v -p 1
+
 .PHONY: test-connection-pool
 test-connection-pool:
 	@echo "Running tests in connection_pool package"

--- a/connection.go
+++ b/connection.go
@@ -702,7 +702,7 @@ func pack(h *smallWBuf, enc *encoder, reqid uint32,
 
 func (conn *Connection) writeRequest(w *bufio.Writer, req Request) error {
 	var packet smallWBuf
-	err := pack(&packet, newEncoder(&packet), 0, req, ignoreStreamId, conn.Schema)
+	err := pack(&packet, newEncoder(&packet), 0, req, ignoreStreamId, nil)
 
 	if err != nil {
 		return fmt.Errorf("pack error: %w", err)

--- a/connection.go
+++ b/connection.go
@@ -1368,6 +1368,9 @@ func (conn *Connection) OverrideSchema(s *Schema) {
 	if s != nil {
 		conn.mutex.Lock()
 		defer conn.mutex.Unlock()
+		conn.lockShards()
+		defer conn.unlockShards()
+
 		conn.Schema = s
 	}
 }

--- a/connection_pool/watcher.go
+++ b/connection_pool/watcher.go
@@ -33,7 +33,7 @@ func (c *watcherContainer) remove(watcher *poolWatcher) bool {
 	if watcher == c.head {
 		c.head = watcher.next
 		return true
-	} else {
+	} else if c.head != nil {
 		cur := c.head
 		for cur.next != nil {
 			if cur.next == watcher {
@@ -85,7 +85,11 @@ type poolWatcher struct {
 
 // Unregister unregisters the pool watcher.
 func (w *poolWatcher) Unregister() {
-	if !w.unregistered && w.container.remove(w) {
+	w.mutex.Lock()
+	unregistered := w.unregistered
+	w.mutex.Unlock()
+
+	if !unregistered && w.container.remove(w) {
 		w.mutex.Lock()
 		w.unregistered = true
 		for _, watcher := range w.watchers {

--- a/future_test.go
+++ b/future_test.go
@@ -237,13 +237,13 @@ func TestFutureGetIteratorError(t *testing.T) {
 func TestFutureSetStateRaceCondition(t *testing.T) {
 	err := errors.New("any error")
 	resp := &Response{}
-	respAppend := &Response{}
 
 	for i := 0; i < 1000; i++ {
 		fut := NewFuture()
 		for j := 0; j < 9; j++ {
 			go func(opt int) {
 				if opt%3 == 0 {
+					respAppend := &Response{}
 					fut.AppendPush(respAppend)
 				} else if opt%3 == 1 {
 					fut.SetError(err)

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -263,7 +263,7 @@ func (connMulti *ConnectionMulti) Close() (err error) {
 	defer connMulti.mutex.Unlock()
 
 	close(connMulti.control)
-	connMulti.state = connClosed
+	atomic.StoreUint32(&connMulti.state, connClosed)
 
 	for _, conn := range connMulti.pool {
 		if err == nil {

--- a/multi/multi.go
+++ b/multi/multi.go
@@ -212,7 +212,9 @@ func (connMulti *ConnectionMulti) checker() {
 						connMulti.deleteConnectionFromPool(v)
 					}
 				}
+				connMulti.mutex.Lock()
 				connMulti.addrs = addrs
+				connMulti.mutex.Unlock()
 			}
 		case <-timer.C:
 			for _, addr := range connMulti.addrs {

--- a/multi/multi_test.go
+++ b/multi/multi_test.go
@@ -200,13 +200,18 @@ func TestRefresh(t *testing.T) {
 		t.Errorf("conn is nil after Connect")
 		return
 	}
+
+	multiConn.mutex.RLock()
 	curAddr := multiConn.addrs[0]
+	multiConn.mutex.RUnlock()
 
 	// Wait for refresh timer.
 	// Scenario 1 nodeload, 1 refresh, 1 nodeload.
 	time.Sleep(10 * time.Second)
 
+	multiConn.mutex.RLock()
 	newAddr := multiConn.addrs[0]
+	multiConn.mutex.RUnlock()
 
 	if curAddr == newAddr {
 		t.Errorf("Expect address refresh")

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -89,8 +89,8 @@ func (h *QueueConnectionHandler) Discovered(conn *tarantool.Connection,
 		}
 	}
 
-	atomic.AddInt32(&h.masterCnt, 1)
 	fmt.Printf("Master %s is ready to work!\n", conn.Addr())
+	atomic.AddInt32(&h.masterCnt, 1)
 
 	return nil
 }
@@ -185,8 +185,12 @@ func Example_connectionPool() {
 
 	// Wait for a new master instance re-identification.
 	<-h.masterUpdated
-	if h.err != nil {
-		fmt.Printf("Unable to re-identify in the pool: %s", h.err)
+	h.mutex.Lock()
+	err = h.err
+	h.mutex.Unlock()
+
+	if err != nil {
+		fmt.Printf("Unable to re-identify in the pool: %s", err)
 		return
 	}
 

--- a/schema.go
+++ b/schema.go
@@ -329,7 +329,10 @@ func (conn *Connection) loadSchema() (err error) {
 		schema.SpacesById[index.SpaceId].Indexes[index.Name] = index
 	}
 
+	conn.lockShards()
 	conn.Schema = schema
+	conn.unlockShards()
+
 	return nil
 }
 


### PR DESCRIPTION
The patchset adds tests with race detector. It also fixes founded problems.

You could review commits one by one with the command:

```bash
$ go test -race -v ./...
```

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #218 