### PR TITLE
Allow users to update schema without restarting the connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -436,7 +436,7 @@ func Connect(addr string, opts Opts) (conn *Connection, err error) {
 
 	// TODO: reload schema after reconnect.
 	if !conn.opts.SkipSchema {
-		if err = conn.loadSchema(); err != nil {
+		if err = conn.LoadSchema(); err != nil {
 			conn.mutex.Lock()
 			defer conn.mutex.Unlock()
 			conn.closeConnection(err, true)

--- a/schema.go
+++ b/schema.go
@@ -302,7 +302,7 @@ func (indexField *IndexField) DecodeMsgpack(d *decoder) error {
 	return errors.New("unexpected schema format (index fields)")
 }
 
-func (conn *Connection) loadSchema() (err error) {
+func (conn *Connection) LoadSchema() (err error) {
 	schema := new(Schema)
 	schema.SpacesById = make(map[uint32]*Space)
 	schema.Spaces = make(map[string]*Space)


### PR DESCRIPTION
**What has been done? Why? What problem is being solved?**

If new space was created while the program is running, the schema is not updated and hence it's impossible to make queries to new spaces.

Right now if one wants to update the schema, they have to restart the connection completely, which is suboptimal. Making this `loadSchema` method public would allow them to trigger it manually at least. But of course in the future would be nice to update the schema automatically by the response from tarantool, as it's described in #7.
