### PR TITLE
pool: handle disconnection with Opts.Reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - Several non-critical data race issues (#218)
+- ConnectionPool does not properly handle disconnection with Opts.Reconnect
+  set (#272)
 
 ## [1.10.0] - 2022-12-31
 


### PR DESCRIPTION
The ConnectionPool didn't close a connection if it couldn't get a role when checking the connection.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #272