### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,23 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [1.11.0] - 2023-05-18
+
+The release adds pagination support and wrappers for the
+[crud](https://github.com/tarantool/crud) module.
+
+### Added
+
 - Support pagination (#246)
 - A Makefile target to test with race detector (#218)
 - Support CRUD API (#108)
 - An ability to replace a base network connection to a Tarantool
   instance (#265)
+- Missed iterator constant (#285)
 
 ### Changed
 
@@ -23,6 +35,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - Several non-critical data race issues (#218)
+- Build on Apple M1 with OpenSSL (#260)
 - ConnectionPool does not properly handle disconnection with Opts.Reconnect
   set (#272)
 - Watcher events loss with a small per-request timeout (#284)


### PR DESCRIPTION
## Overview

The release adds pagination support and wrappers for the crud module.

## Breaking changes

There are no breaking changes in the release.

## New features

* Support pagination (#246).
* Support CRUD API (#108).
* An ability to replace a base network connection to a Tarantool instance (#265).
* A Makefile target to test with race detector (#218).
* Missed iterator constant (#285).

## Bugfixes

* Several non-critical data race issues (#218).
* Build on Apple M1 with OpenSSL (#260).
* ConnectionPool does not properly handle disconnection with Opts.Reconnect set (#272).
* Connect() panics on concurrent schema update (#278).
* Wrong Ttr setup by Queue.Cfg() (#278).
* Flaky queue/Example_connectionPool (#278).
* Flaky queue/Example_simpleQueueCustomMsgPack (#277).

## Other

* queue module version bumped to 1.3.0 (#278).