### PR TITLE
add missing iterator constant

### DIFF
--- a/const.go
+++ b/const.go
@@ -68,16 +68,18 @@ const (
 
 	// https://github.com/fl00r/go-tarantool-1.6/issues/2
 
-	IterEq            = uint32(0) // key == x ASC order
-	IterReq           = uint32(1) // key == x DESC order
-	IterAll           = uint32(2) // all tuples
-	IterLt            = uint32(3) // key < x
-	IterLe            = uint32(4) // key <= x
-	IterGe            = uint32(5) // key >= x
-	IterGt            = uint32(6) // key > x
-	IterBitsAllSet    = uint32(7) // all bits from x are set in key
-	IterBitsAnySet    = uint32(8) // at least one x's bit is set
-	IterBitsAllNotSet = uint32(9) // all bits are not set
+	IterEq            = uint32(0)  // key == x ASC order
+	IterReq           = uint32(1)  // key == x DESC order
+	IterAll           = uint32(2)  // all tuples
+	IterLt            = uint32(3)  // key < x
+	IterLe            = uint32(4)  // key <= x
+	IterGe            = uint32(5)  // key >= x
+	IterGt            = uint32(6)  // key > x
+	IterBitsAllSet    = uint32(7)  // all bits from x are set in key
+	IterBitsAnySet    = uint32(8)  // at least one x's bit is set
+	IterBitsAllNotSet = uint32(9)  // all bits are not set
+	IterOverlaps      = uint32(10) // key overlaps x
+	IterNeighbor      = uint32(11) // tuples in distance ascending order from specified point
 
 	RLimitDrop = 1
 	RLimitWait = 2


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

add missing constant from https://github.com/tarantool/tarantool/blob/680990a082374e4790539215f69d9e9ee39c3307/src/box/iterator_type.h

Related issues:

fixes https://github.com/tarantool/go-tarantool/issues/285
