### PR TITLE
bugfix: watcher events loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Several non-critical data race issues (#218)
 - ConnectionPool does not properly handle disconnection with Opts.Reconnect
   set (#272)
+- Watcher events loss with a small per-request timeout (#284)
 
 ## [1.10.0] - 2022-12-31
 

--- a/connection.go
+++ b/connection.go
@@ -1066,6 +1066,10 @@ func (conn *Connection) putFuture(fut *Future, req Request, streamId uint64) {
 	}
 	shard.bufmut.Unlock()
 
+	if firstWritten {
+		conn.dirtyShard <- shardn
+	}
+
 	if req.Async() {
 		if fut = conn.fetchFuture(reqid); fut != nil {
 			resp := &Response{
@@ -1075,10 +1079,6 @@ func (conn *Connection) putFuture(fut *Future, req Request, streamId uint64) {
 			fut.SetResponse(resp)
 			conn.markDone(fut)
 		}
-	}
-
-	if firstWritten {
-		conn.dirtyShard <- shardn
 	}
 }
 


### PR DESCRIPTION
Watchers may behave incorrectly if a request timeout is too small. A
re-IPROTO_WATCH request may be not send to a server. It could lead to
loss of events stream.

It also could lead to a lost IPROTO_UNREGISTER request, but a user
won't see the problem.

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #284