### PR TITLE
test: fix compatibility with Tarantool master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - crud tests with Tarantool 3.0 (#293)
+- SQL tests with Tarantool 3.0 (#295)
 
 ## [1.11.0] - 2023-05-18
 

--- a/settings/tarantool_test.go
+++ b/settings/tarantool_test.go
@@ -481,7 +481,14 @@ func TestSQLReverseUnorderedSelectsSetting(t *testing.T) {
 	require.Equal(t, []interface{}{[]interface{}{"sql_reverse_unordered_selects", false}}, resp.Data)
 
 	// Select multiple records.
-	resp, err = conn.Execute("SELECT * FROM data;", []interface{}{})
+	query := "SELECT * FROM seqscan data;"
+	if isSeqScanOld, err := test_helpers.IsTarantoolVersionLess(3, 0, 0); err != nil {
+		t.Fatal("Could not check the Tarantool version")
+	} else if isSeqScanOld {
+		query = "SELECT * FROM data;"
+	}
+
+	resp, err = conn.Execute(query, []interface{}{})
 	require.Nil(t, err)
 	require.NotNil(t, resp)
 	require.EqualValues(t, []interface{}{"1"}, resp.Data[0])
@@ -500,7 +507,7 @@ func TestSQLReverseUnorderedSelectsSetting(t *testing.T) {
 	require.Equal(t, []interface{}{[]interface{}{"sql_reverse_unordered_selects", true}}, resp.Data)
 
 	// Select multiple records.
-	resp, err = conn.Execute("SELECT * FROM data;", []interface{}{})
+	resp, err = conn.Execute(query, []interface{}{})
 	require.Nil(t, err)
 	require.NotNil(t, resp)
 	require.EqualValues(t, []interface{}{"2"}, resp.Data[0])


### PR DESCRIPTION
New behavior: SELECT scan queries are only allowed if the SEQSCAN keyword is used correctly[1].

1. https://www.tarantool.io/en/doc/latest/reference/reference_lua/compat/sql_seq_scan_default/

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

https://github.com/tarantool/tarantool/pull/8602