### PR TITLE
api: add Connection.CloseGraceful() and ConnectionPool.CloseGraceful()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Connection.CloseGraceful() unlike Connection.Close() waits for all
   requests to complete (#257)
+- ConnectionPool.CloseGraceful() unlike ConnectionPool.Close() waits for all
+  requests to complete (#257)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Added
 
+- Connection.CloseGraceful() unlike Connection.Close() waits for all
+  requests to complete (#257)
+
 ### Changed
 
 ### Fixed

--- a/connection.go
+++ b/connection.go
@@ -37,10 +37,10 @@ const (
 	Disconnected
 	// ReconnectFailed signals that attempt to reconnect has failed.
 	ReconnectFailed
-	// Either reconnect attempts exhausted, or explicit Close is called.
-	Closed
 	// Shutdown signals that shutdown callback is processing.
 	Shutdown
+	// Either reconnect attempts exhausted, or explicit Close is called.
+	Closed
 
 	// LogReconnectFailed is logged when reconnect attempt failed.
 	LogReconnectFailed ConnLogKind = iota + 1
@@ -108,6 +108,11 @@ func (d defaultLogger) Report(event ConnLogKind, conn *Connection, v ...interfac
 //
 // - In "Disconnected" state it rejects queries with ClientError{Code:
 // ErrConnectionNotReady}
+//
+// - In "Shutdown" state it rejects queries with ClientError{Code:
+// ErrConnectionShutdown}. The state indicates that a graceful shutdown
+// in progress. The connection waits for all active requests to
+// complete.
 //
 // - In "Closed" state it rejects queries with ClientError{Code:
 // ErrConnectionClosed}. Connection could become "Closed" when

--- a/connection_pool/state.go
+++ b/connection_pool/state.go
@@ -10,6 +10,7 @@ type state uint32
 const (
 	unknownState state = iota
 	connectedState
+	shutdownState
 	closedState
 )
 


### PR DESCRIPTION
CloseGraceful closes Connection gracefully. Unlike Connection.Close() it waits for all requests to complete.
CloseGraceful closes ConnectionPool gracefully. Unlike ConnectionPool.Close() it waits for all requests to complete.

Changes to the connection pool may seem too global, but it will simplify #290 .

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Closes #257 