### PR TITLE
bugfix: flaky TestAdd_CloseGraceful_concurrent

### DIFF
--- a/connection_pool/connection_pool.go
+++ b/connection_pool/connection_pool.go
@@ -30,6 +30,7 @@ var (
 	ErrNoRwInstance      = errors.New("can't find rw instance in pool")
 	ErrNoRoInstance      = errors.New("can't find ro instance in pool")
 	ErrNoHealthyInstance = errors.New("can't find healthy instance in pool")
+	ErrExists            = errors.New("endpoint exists")
 	ErrClosed            = errors.New("pool is closed")
 )
 
@@ -233,7 +234,7 @@ func (pool *ConnectionPool) Add(addr string) error {
 	}
 	if _, ok := pool.addrs[addr]; ok {
 		pool.addrsMutex.Unlock()
-		return errors.New("endpoint exist")
+		return ErrExists
 	}
 	pool.addrs[addr] = e
 	pool.addrsMutex.Unlock()

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -282,7 +282,7 @@ func TestAdd_exist(t *testing.T) {
 	defer connPool.Close()
 
 	err = connPool.Add(servers[0])
-	require.ErrorContains(t, err, "endpoint exist")
+	require.Equal(t, connection_pool.ErrExists, err)
 
 	args := test_helpers.CheckStatusesArgs{
 		ConnPool:           connPool,

--- a/connection_pool/connection_pool_test.go
+++ b/connection_pool/connection_pool_test.go
@@ -345,9 +345,9 @@ func TestAdd_Close_concurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		err = connPool.Add(servers[0])
+		err = connPool.Add(servers[1])
 		if err != nil {
-			assert.Equal(t, err, connection_pool.ErrClosed)
+			assert.Equal(t, connection_pool.ErrClosed, err)
 		}
 	}()
 
@@ -366,9 +366,9 @@ func TestAdd_CloseGraceful_concurrent(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		err = connPool.Add(servers[0])
+		err = connPool.Add(servers[1])
 		if err != nil {
-			assert.Equal(t, err, connection_pool.ErrClosed)
+			assert.Equal(t, connection_pool.ErrClosed, err)
 		}
 	}()
 


### PR DESCRIPTION
We need to add non-added endpoint to avoid `endpoint exist` error.

See:

```
2023-06-05T14:18:52.4408505Z === RUN   TestAdd_CloseGraceful_concurrent
2023-06-05T14:18:52.4468977Z     connection_pool_test.go:371: 
2023-06-05T14:18:52.4469460Z         	Error Trace:	connection_pool_test.go:371
2023-06-05T14:18:52.4469950Z         	            				asm_amd64.s:1571
2023-06-05T14:18:52.4470246Z         	Error:      	Not equal: 
2023-06-05T14:18:52.4470864Z         	            	expected: &errors.errorString{s:"endpoint exist"}
2023-06-05T14:18:52.4471538Z         	            	actual  : &errors.errorString{s:"pool is closed"}
2023-06-05T14:18:52.4471864Z         	            	
2023-06-05T14:18:52.4472171Z         	            	Diff:
2023-06-05T14:18:52.4472692Z         	            	--- Expected
2023-06-05T14:18:52.4473050Z         	            	+++ Actual
2023-06-05T14:18:52.4473466Z         	            	@@ -1,3 +1,3 @@
2023-06-05T14:18:52.4473928Z         	            	 (*errors.errorString)({
2023-06-05T14:18:52.4474559Z         	            	- s: (string) (len=14) "endpoint exist"
2023-06-05T14:18:52.4475113Z         	            	+ s: (string) (len=14) "pool is closed"
2023-06-05T14:18:52.4475447Z         	            	 })
2023-06-05T14:18:52.4475821Z         	Test:       	TestAdd_CloseGraceful_concurrent
```

https://github.com/tarantool/go-tarantool/actions/runs/5178095191/jobs/9329091216
