### PR TITLE
test: fix flaky decimal.TestSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Flaky decimal/TestSelect (#300)
+
 ## [1.12.0] - 2023-06-07
 
 The release introduces the ability to gracefully close Connection

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -19,7 +19,7 @@ var isDecimalSupported = false
 
 var server = "127.0.0.1:3013"
 var opts = Opts{
-	Timeout: 500 * time.Millisecond,
+	Timeout: 5 * time.Second,
 	User:    "test",
 	Pass:    "test",
 }


### PR DESCRIPTION
[See](https://github.com/tarantool/go-tarantool/actions/runs/5197333156/jobs/9372037885):
```
2023-06-07T07:52:34.7468540Z # github.com/tarantool/go-tarantool/decimal.test
...
2023-06-07T07:52:36.3115720Z --- FAIL: TestSelect (0.53s)
2023-06-07T07:52:36.3119070Z     decimal_test.go:503: Decimal insert failed: client timeout for request 10 (0x4003)
```

We forgot to increase the timeout [1] when we fixed tests for macos.

1. https://github.com/tarantool/go-tarantool/commit/521c0c34804e93cd2648c3b5c27bc7194d3870d0

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)