### PR TITLE
api: unify usage of external types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   plain string. Needed for upgrade to Tarantool 3.0, where a binary blob is
   decoded to a varbinary object (#313).
 - Use objects of the Decimal type instead of pointers (#238)
+- Use objects of the Datetime type instead of pointers (#238)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Change encoding of the queue.Identify() UUID argument from binary blob to
   plain string. Needed for upgrade to Tarantool 3.0, where a binary blob is
   decoded to a varbinary object (#313).
+- Use objects of the Decimal type instead of pointers (#238)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ faster than other packages according to public benchmarks.
   * [API reference](#api-reference)
   * [Walking\-through example](#walking-through-example)
   * [Migration to v2](#migration-to-v2)
+    * [datetime package](#datetime-package)
     * [decimal package](#decimal-package)
     * [multi package](#multi-package)
     * [pool package](#pool-package)
@@ -148,6 +149,12 @@ by `Connect()`.
 ### Migration to v2
 
 The article describes migration from go-tarantool to go-tarantool/v2.
+
+#### datetime package
+
+Now you need to use objects of the Datetime type instead of pointers to it. A
+new constructor `MakeDatetime` returns an object. `NewDatetime` has been
+removed.
 
 #### decimal package
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ faster than other packages according to public benchmarks.
   * [API reference](#api-reference)
   * [Walking\-through example](#walking-through-example)
   * [Migration to v2](#migration-to-v2)
+    * [decimal package](#decimal-package)
     * [multi package](#multi-package)
     * [pool package](#pool-package)
     * [msgpack.v5](#msgpackv5)
@@ -147,6 +148,11 @@ by `Connect()`.
 ### Migration to v2
 
 The article describes migration from go-tarantool to go-tarantool/v2.
+
+#### decimal package
+
+Now you need to use objects of the Decimal type instead of pointers to it. A
+new constructor `MakeDecimal` returns an object. `NewDecimal` has been removed.
 
 #### multi package
 

--- a/datetime/example_test.go
+++ b/datetime/example_test.go
@@ -35,7 +35,7 @@ func Example() {
 		fmt.Printf("Error in time.Parse() is %v", err)
 		return
 	}
-	dt, err := NewDatetime(tm)
+	dt, err := MakeDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -91,13 +91,13 @@ func Example() {
 	fmt.Printf("Data: %v\n", respDt.ToTime())
 }
 
-// ExampleNewDatetime_localUnsupported demonstrates that "Local" location is
+// ExampleMakeDatetime_localUnsupported demonstrates that "Local" location is
 // unsupported.
-func ExampleNewDatetime_localUnsupported() {
+func ExampleMakeDatetime_localUnsupported() {
 	tm := time.Now().Local()
 	loc := tm.Location()
 	fmt.Println("Location:", loc)
-	if _, err := NewDatetime(tm); err != nil {
+	if _, err := MakeDatetime(tm); err != nil {
 		fmt.Printf("Could not create a Datetime with %s location.\n", loc)
 	} else {
 		fmt.Printf("A Datetime with %s location created.\n", loc)
@@ -109,7 +109,7 @@ func ExampleNewDatetime_localUnsupported() {
 
 // Example demonstrates how to create a datetime for Tarantool without UTC
 // timezone in datetime.
-func ExampleNewDatetime_noTimezone() {
+func ExampleMakeDatetime_noTimezone() {
 	var datetime = "2013-10-28T17:51:56.000000009Z"
 	tm, err := time.Parse(time.RFC3339, datetime)
 	if err != nil {
@@ -119,7 +119,7 @@ func ExampleNewDatetime_noTimezone() {
 
 	tm = tm.In(time.FixedZone(NoTimezone, 0))
 
-	dt, err := NewDatetime(tm)
+	dt, err := MakeDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -145,12 +145,12 @@ func ExampleDatetime_Interval() {
 		return
 	}
 
-	dtFirst, err := NewDatetime(tmFirst)
+	dtFirst, err := MakeDatetime(tmFirst)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tmFirst, err)
 		return
 	}
-	dtSecond, err := NewDatetime(tmSecond)
+	dtSecond, err := MakeDatetime(tmSecond)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tmSecond, err)
 		return
@@ -170,7 +170,7 @@ func ExampleDatetime_Add() {
 		fmt.Printf("Error in time.Parse() is %s", err)
 		return
 	}
-	dt, err := NewDatetime(tm)
+	dt, err := MakeDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -201,7 +201,7 @@ func ExampleDatetime_Add_dst() {
 		return
 	}
 	tm := time.Date(2008, 1, 1, 1, 1, 1, 1, loc)
-	dt, err := NewDatetime(tm)
+	dt, err := MakeDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime: %s", err)
 		return
@@ -237,7 +237,7 @@ func ExampleDatetime_Sub() {
 		fmt.Printf("Error in time.Parse() is %s", err)
 		return
 	}
-	dt, err := NewDatetime(tm)
+	dt, err := MakeDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return

--- a/decimal/example_test.go
+++ b/decimal/example_test.go
@@ -35,7 +35,7 @@ func Example() {
 
 	spaceNo := uint32(524)
 
-	number, err := NewDecimalFromString("-22.804")
+	number, err := MakeDecimalFromString("-22.804")
 	if err != nil {
 		log.Fatalf("Failed to prepare test decimal: %s", err)
 	}


### PR DESCRIPTION
After the patch Decimal, Datetime and uuid used in the same way: by a value.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:

Part of #238 