### PR TITLE
api: merge Close() and CloseGraceful()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - connection_pool renamed to pool (#239)
 - Use msgpack/v5 instead of msgpack.v2 (#236)
 - Call/NewCallRequest = Call17/NewCall17Request (#235)
+- The Close() and CloseGraceful() methods have been merged into a single
+  method Close(force bool) (#307)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ faster than other packages according to public benchmarks.
     * [Call = Call17](#call--call17)
     * [IPROTO constants](#iproto-constants)
     * [Request interface](#request-interface)
+    * [Single Close() method](#single-close-method)
 * [Contributing](#contributing)
 * [Alternative connectors](#alternative-connectors)
 
@@ -113,6 +114,8 @@ func main() {
 	if err != nil {
 		fmt.Println("Connection refused:", err)
 	}
+	defer conn.Close(true)
+
 	resp, err := conn.Do(tarantool.NewInsertRequest(999).
 		Tuple([]interface{}{99999, "BB"}),
 	).Get()
@@ -140,7 +143,10 @@ starting a session. There are two parameters:
 **Observation 4:** The `err` structure will be `nil` if there is no error,
 otherwise it will have a description which can be retrieved with `err.Error()`.
 
-**Observation 5:** The `Insert` request, like almost all requests, is preceded
+**Observation 5:** The `defer conn.Close(true)` closes the connection at the
+end of the example.
+
+**Observation 6:** The `Insert` request, like almost all requests, is preceded
 by the method `Do` of object `conn` which is the object that was returned
 by `Connect()`.
 
@@ -158,6 +164,9 @@ The logic has not changed, but there are a few renames:
 
 * The `connection_pool` subpackage has been renamed to `pool`.
 * The type `PoolOpts` has been renamed to `Opts`.
+* ConnectionPool.Close(true) should be used instead of ConnectionPool.Close()
+* ConnectionPool.Close(false) should be used instead of
+  ConnectionPool.CloseGraceful()
 
 #### msgpack.v5
 
@@ -198,6 +207,11 @@ IPROTO constants have been moved to a separate package [go-iproto](https://githu
 #### Request interface
 
 * The method `Code() uint32` replaced by the `Type() iproto.Type`.
+
+#### Single Close() method
+
+* Connection.Close(true) should be used instead of Connection.Close()
+* Connection.Close(false) should be used instead of Connection.CloseGraceful()
 
 ## Contributing
 

--- a/box_error_test.go
+++ b/box_error_test.go
@@ -296,7 +296,7 @@ func TestErrorTypeEval(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for name, testcase := range tupleCases {
 		t.Run(name, func(t *testing.T) {
@@ -315,7 +315,7 @@ func TestErrorTypeEvalTyped(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for name, testcase := range tupleCases {
 		t.Run(name, func(t *testing.T) {
@@ -333,7 +333,7 @@ func TestErrorTypeInsert(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
 	_, err := conn.Eval(truncateEval, []interface{}{})
@@ -371,7 +371,7 @@ func TestErrorTypeInsertTyped(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
 	_, err := conn.Eval(truncateEval, []interface{}{})
@@ -413,7 +413,7 @@ func TestErrorTypeSelect(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
 	_, err := conn.Eval(truncateEval, []interface{}{})
@@ -457,7 +457,7 @@ func TestErrorTypeSelectTyped(t *testing.T) {
 	test_helpers.SkipIfErrorMessagePackTypeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	truncateEval := fmt.Sprintf("box.space[%q]:truncate()", space)
 	_, err := conn.Eval(truncateEval, []interface{}{})

--- a/connection.go
+++ b/connection.go
@@ -464,19 +464,16 @@ func (conn *Connection) ClosedNow() bool {
 	return atomic.LoadUint32(&conn.state) == connClosed
 }
 
-// Close closes Connection.
+// Close closes Connection. It waits for all requests to complete
+// if force == false.
 // After this method called, there is no way to reopen this Connection.
-func (conn *Connection) Close() error {
-	err := ClientError{ErrConnectionClosed, "connection closed by client"}
-	conn.mutex.Lock()
-	defer conn.mutex.Unlock()
-	return conn.closeConnection(err, true)
-}
-
-// CloseGraceful closes Connection gracefully. It waits for all requests to
-// complete.
-// After this method called, there is no way to reopen this Connection.
-func (conn *Connection) CloseGraceful() error {
+func (conn *Connection) Close(force bool) error {
+	if force {
+		err := ClientError{ErrConnectionClosed, "connection closed by client"}
+		conn.mutex.Lock()
+		defer conn.mutex.Unlock()
+		return conn.closeConnection(err, true)
+	}
 	return conn.shutdown(true)
 }
 

--- a/connector.go
+++ b/connector.go
@@ -4,7 +4,7 @@ import "time"
 
 type Connector interface {
 	ConnectedNow() bool
-	Close() error
+	Close(force bool) error
 	ConfiguredTimeout() time.Duration
 	NewPrepared(expr string) (*Prepared, error)
 	NewStream() (*Stream, error)

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -484,7 +484,7 @@ func testCrudRequestCheck(t *testing.T, req tarantool.Request,
 
 func TestCrudGenerateData(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for _, testCase := range testGenerateDataCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -511,7 +511,7 @@ func TestCrudGenerateData(t *testing.T) {
 
 func TestCrudProcessData(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for _, testCase := range testProcessDataCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -563,7 +563,7 @@ func TestUnflattenRows(t *testing.T) {
 	)
 
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Do `replace`.
 	req := crud.MakeReplaceRequest(spaceName).
@@ -622,7 +622,7 @@ func TestUnflattenRows(t *testing.T) {
 
 func TestResultWithErr(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for _, testCase := range testResultWithErrCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -637,7 +637,7 @@ func TestResultWithErr(t *testing.T) {
 
 func TestBoolResult(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := crud.MakeTruncateRequest(spaceName).Opts(baseOpts)
 	resp := crud.TruncateResult{}
@@ -662,7 +662,7 @@ func TestBoolResult(t *testing.T) {
 
 func TestNumberResult(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := crud.MakeCountRequest(spaceName).Opts(countOpts)
 	resp := crud.CountResult{}
@@ -705,7 +705,7 @@ func TestBaseResult(t *testing.T) {
 	}
 
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := crud.MakeSelectRequest(spaceName).Opts(selectOpts)
 	resp := crud.Result{}
@@ -750,7 +750,7 @@ func TestManyResult(t *testing.T) {
 	}
 
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := crud.MakeReplaceManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts)
 	resp := crud.Result{}
@@ -777,7 +777,7 @@ func TestManyResult(t *testing.T) {
 
 func TestStorageInfoResult(t *testing.T) {
 	conn := connect(t)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := crud.MakeStorageInfoRequest().Opts(baseOpts)
 	resp := crud.StorageInfoResult{}

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -371,7 +371,7 @@ func TestDatetimeTarantoolInterval(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	dates := []string{
 		// We could return tests with timezones after a release with a fix of
@@ -511,7 +511,7 @@ func TestInvalidOffset(t *testing.T) {
 			}
 			if testcase.ok && isDatetimeSupported {
 				conn := test_helpers.ConnectWithValidation(t, server, opts)
-				defer conn.Close()
+				defer conn.Close(true)
 
 				tupleInsertSelectDelete(t, conn, tm)
 			}
@@ -523,7 +523,7 @@ func TestCustomTimezone(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	customZone := "Europe/Moscow"
 	customOffset := 180 * 60
@@ -683,7 +683,7 @@ func TestDatetimeInsertSelectDelete(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for _, testcase := range datetimeSample {
 		t.Run(testcase.dt, func(t *testing.T) {
@@ -712,7 +712,7 @@ func TestDatetimeBoundaryRange(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for _, tm := range append(lesserBoundaryTimes, boundaryTimes...) {
 		t.Run(tm.String(), func(t *testing.T) {
@@ -738,7 +738,7 @@ func TestDatetimeReplace(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tm, err := time.Parse(time.RFC3339, "2007-01-02T15:04:05Z")
 	if err != nil {
@@ -903,7 +903,7 @@ func TestCustomEncodeDecodeTuple1(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tm1, _ := time.Parse(time.RFC3339, "2010-05-24T17:51:56.000000009Z")
 	tm2, _ := time.Parse(time.RFC3339, "2022-05-24T17:51:56.000000009Z")
@@ -973,7 +973,7 @@ func TestCustomDecodeFunction(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Call function 'call_datetime_testdata' returning a custom tuples.
 	var tuple [][]Tuple2
@@ -1017,7 +1017,7 @@ func TestCustomEncodeDecodeTuple5(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tm := time.Unix(500, 1000).In(time.FixedZone(NoTimezone, 0))
 	dt, err := NewDatetime(tm)

--- a/datetime/interval_test.go
+++ b/datetime/interval_test.go
@@ -106,7 +106,7 @@ func TestIntervalTarantoolEncoding(t *testing.T) {
 	skipIfDatetimeUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	cases := []Interval{
 		{},

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -495,7 +495,7 @@ func TestSelect(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	number, err := decimal.NewFromString("-12.34")
 	if err != nil {
@@ -565,7 +565,7 @@ func TestInsert(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	samples := append(correctnessSamples, benchmarkSamples...)
 	for _, testcase := range samples {
@@ -579,7 +579,7 @@ func TestReplace(t *testing.T) {
 	skipIfDecimalUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	number, err := decimal.NewFromString("-12.34")
 	if err != nil {

--- a/dial_test.go
+++ b/dial_test.go
@@ -216,7 +216,7 @@ func dialIo(t *testing.T,
 
 func TestConn_Close(t *testing.T) {
 	conn, dialer := dialIo(t, nil)
-	conn.Close()
+	conn.Close(true)
 
 	assert.Equal(t, 1, dialer.conn.closeCnt)
 
@@ -241,7 +241,7 @@ func TestConn_LocalAddr(t *testing.T) {
 	defer func() {
 		dialer.conn.readWg.Done()
 		dialer.conn.writeWg.Done()
-		conn.Close()
+		conn.Close(true)
 	}()
 
 	assert.Equal(t, addr, conn.LocalAddr())
@@ -256,7 +256,7 @@ func TestConn_RemoteAddr(t *testing.T) {
 	defer func() {
 		dialer.conn.readWg.Done()
 		dialer.conn.writeWg.Done()
-		conn.Close()
+		conn.Close(true)
 	}()
 
 	assert.Equal(t, addr, conn.RemoteAddr())
@@ -273,7 +273,7 @@ func TestConn_Greeting(t *testing.T) {
 	defer func() {
 		dialer.conn.readWg.Done()
 		dialer.conn.writeWg.Done()
-		conn.Close()
+		conn.Close(true)
 	}()
 
 	assert.Equal(t, &greeting, conn.Greeting)
@@ -294,7 +294,7 @@ func TestConn_ProtocolInfo(t *testing.T) {
 	defer func() {
 		dialer.conn.readWg.Done()
 		dialer.conn.writeWg.Done()
-		conn.Close()
+		conn.Close(true)
 	}()
 
 	assert.Equal(t, info, conn.ServerProtocolInfo())

--- a/example_test.go
+++ b/example_test.go
@@ -46,7 +46,7 @@ func ExampleSslOpts() {
 
 func ExampleIntKey() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	const space = "test"
 	const index = "primary"
@@ -68,7 +68,7 @@ func ExampleIntKey() {
 
 func ExampleUintKey() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	const space = "test"
 	const index = "primary"
@@ -90,7 +90,7 @@ func ExampleUintKey() {
 
 func ExampleStringKey() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	const space = "teststring"
 	const index = "primary"
@@ -115,7 +115,7 @@ func ExampleStringKey() {
 
 func ExampleIntIntKey() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	const space = "testintint"
 	const index = "primary"
@@ -141,7 +141,7 @@ func ExampleIntIntKey() {
 
 func ExamplePingRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Ping a Tarantool instance to check connection.
 	resp, err := conn.Do(tarantool.NewPingRequest()).Get()
@@ -161,7 +161,7 @@ func ExamplePingRequest() {
 // the root context.
 func ExamplePingRequest_Context() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	timeout := time.Nanosecond
 
@@ -186,7 +186,7 @@ func ExamplePingRequest_Context() {
 
 func ExampleSelectRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for i := 1111; i <= 1112; i++ {
 		conn.Do(tarantool.NewReplaceRequest(spaceNo).
@@ -227,7 +227,7 @@ func ExampleSelectRequest() {
 
 func ExampleInsertRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Insert a new tuple { 31, 1 }.
 	resp, err := conn.Do(tarantool.NewInsertRequest(spaceNo).
@@ -269,7 +269,7 @@ func ExampleInsertRequest() {
 
 func ExampleDeleteRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Insert a new tuple { 35, 1 }.
 	conn.Do(tarantool.NewInsertRequest(spaceNo).
@@ -312,7 +312,7 @@ func ExampleDeleteRequest() {
 
 func ExampleReplaceRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Insert a new tuple { 13, 1 }.
 	conn.Do(tarantool.NewInsertRequest(spaceNo).
@@ -371,7 +371,7 @@ func ExampleReplaceRequest() {
 
 func ExampleUpdateRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for i := 1111; i <= 1112; i++ {
 		conn.Do(tarantool.NewReplaceRequest(spaceNo).
@@ -407,7 +407,7 @@ func ExampleUpdateRequest() {
 
 func ExampleUpsertRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	var req tarantool.Request
 	req = tarantool.NewUpsertRequest(617).
@@ -448,7 +448,7 @@ func ExampleUpsertRequest() {
 
 func ExampleCallRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Call a function 'simple_concat' with arguments.
 	resp, err := conn.Do(tarantool.NewCallRequest("simple_concat").
@@ -467,7 +467,7 @@ func ExampleCallRequest() {
 
 func ExampleEvalRequest() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Run raw Lua code.
 	resp, err := conn.Do(tarantool.NewEvalRequest("return 1 + 2")).Get()
@@ -495,7 +495,7 @@ func ExampleExecuteRequest() {
 	}
 
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := tarantool.NewExecuteRequest(
 		"CREATE TABLE SQL_TEST (id INTEGER PRIMARY KEY, name STRING)")
@@ -614,7 +614,7 @@ func ExampleExecuteRequest() {
 
 func ExampleProtocolVersion() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	clientProtocolInfo := conn.ClientProtocolInfo()
 	fmt.Println("Connector client protocol version:", clientProtocolInfo.Version)
@@ -652,7 +652,7 @@ func ExampleCommitRequest() {
 
 	txnOpts := getTestTxnOpts()
 	conn := exampleConnect(txnOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -729,7 +729,7 @@ func ExampleRollbackRequest() {
 
 	txnOpts := getTestTxnOpts()
 	conn := exampleConnect(txnOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -806,7 +806,7 @@ func ExampleBeginRequest_TxnIsolation() {
 
 	txnOpts := getTestTxnOpts()
 	conn := exampleConnect(txnOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -874,7 +874,7 @@ func ExampleBeginRequest_TxnIsolation() {
 
 func ExampleFuture_GetIterator() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	const timeout = 3 * time.Second
 	fut := conn.Do(tarantool.NewCallRequest("push_func").
@@ -917,7 +917,7 @@ func ExampleConnect() {
 		fmt.Println("No connection available")
 		return
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 	if conn != nil {
 		fmt.Println("Connection is ready")
 	}
@@ -928,7 +928,7 @@ func ExampleConnect() {
 // Example demonstrates how to retrieve information with space schema.
 func ExampleSchema() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	schema := conn.Schema
 	if schema.SpacesById == nil {
@@ -950,7 +950,7 @@ func ExampleSchema() {
 // Example demonstrates how to retrieve information with space schema.
 func ExampleSpace() {
 	conn := exampleConnect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Save Schema to a local variable to avoid races
 	schema := conn.Schema
@@ -1057,7 +1057,7 @@ func ExampleConnection_NewWatcher() {
 		fmt.Printf("Failed to connect: %s\n", err)
 		return
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 
 	callback := func(event tarantool.WatchEvent) {
 		fmt.Printf("event connection: %s\n", event.Conn.Addr())
@@ -1075,9 +1075,9 @@ func ExampleConnection_NewWatcher() {
 	time.Sleep(time.Second)
 }
 
-// ExampleConnection_CloseGraceful_force demonstrates how to force close
+// ExampleConnection_Close_graceful_force demonstrates how to force close
 // a connection with graceful close in progress after a while.
-func ExampleConnection_CloseGraceful_force() {
+func ExampleConnection_Close_graceful_force() {
 	conn := exampleConnect(opts)
 
 	eval := `local fiber = require('fiber')
@@ -1089,24 +1089,24 @@ func ExampleConnection_CloseGraceful_force() {
 
 	done := make(chan struct{})
 	go func() {
-		conn.CloseGraceful()
-		fmt.Println("Connection.CloseGraceful() done!")
+		conn.Close(false)
+		fmt.Println("Connection.Close(false) done!")
 		close(done)
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		fmt.Println("Force Connection.Close()!")
-		conn.Close()
+		fmt.Println("Force Connection.Close(true)!")
+		conn.Close(true)
 	}
 	<-done
 
 	fmt.Println("Result:")
 	fmt.Println(fut.Get())
 	// Output:
-	// Force Connection.Close()!
-	// Connection.CloseGraceful() done!
+	// Force Connection.Close(true)!
+	// Connection.Close(false) done!
 	// Result:
 	// <nil> connection closed by client (0x4001)
 }

--- a/pool/connector.go
+++ b/pool/connector.go
@@ -1,8 +1,6 @@
 package pool
 
 import (
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/tarantool/go-tarantool/v2"
@@ -32,19 +30,9 @@ func (c *ConnectorAdapter) ConnectedNow() bool {
 	return ret
 }
 
-// ClosedNow reports if the connector is closed by user or all connections
-// in the specified mode closed.
+// Close closes all connections and the object.
 func (c *ConnectorAdapter) Close() error {
-	errs := c.pool.Close()
-	if len(errs) == 0 {
-		return nil
-	}
-
-	err := errors.New("failed to close connection pool")
-	for _, e := range errs {
-		err = fmt.Errorf("%s: %w", err.Error(), e)
-	}
-	return err
+	return c.pool.Close()
 }
 
 // ConfiguredTimeout returns a timeout from connections config.

--- a/pool/connector.go
+++ b/pool/connector.go
@@ -31,8 +31,8 @@ func (c *ConnectorAdapter) ConnectedNow() bool {
 }
 
 // Close closes all connections and the object.
-func (c *ConnectorAdapter) Close() error {
-	return c.pool.Close()
+func (c *ConnectorAdapter) Close(force bool) error {
+	return c.pool.Close(force)
 }
 
 // ConfiguredTimeout returns a timeout from connections config.

--- a/pool/connector_test.go
+++ b/pool/connector_test.go
@@ -56,10 +56,10 @@ type closeMock struct {
 	retErr bool
 }
 
-func (m *closeMock) Close() []error {
+func (m *closeMock) Close() error {
 	m.called++
 	if m.retErr {
-		return []error{errors.New("err1"), errors.New("err2")}
+		return errors.New("err1")
 	}
 	return nil
 }
@@ -79,7 +79,7 @@ func TestConnectorCloseWithError(t *testing.T) {
 	err := c.Close()
 	require.NotNilf(t, err, "unexpected result")
 	require.Equalf(t, 1, m.called, "should be called only once")
-	require.Equal(t, "failed to close connection pool: err1: err2", err.Error())
+	require.Equal(t, "err1", err.Error())
 }
 
 type configuredTimeoutMock struct {

--- a/pool/connector_test.go
+++ b/pool/connector_test.go
@@ -56,7 +56,7 @@ type closeMock struct {
 	retErr bool
 }
 
-func (m *closeMock) Close() error {
+func (m *closeMock) Close(force bool) error {
 	m.called++
 	if m.retErr {
 		return errors.New("err1")
@@ -68,7 +68,7 @@ func TestConnectorClose(t *testing.T) {
 	m := &closeMock{retErr: false}
 	c := NewConnectorAdapter(m, testMode)
 
-	require.Nilf(t, c.Close(), "unexpected result")
+	require.Nilf(t, c.Close(true), "unexpected result")
 	require.Equalf(t, 1, m.called, "should be called only once")
 }
 
@@ -76,7 +76,7 @@ func TestConnectorCloseWithError(t *testing.T) {
 	m := &closeMock{retErr: true}
 	c := NewConnectorAdapter(m, testMode)
 
-	err := c.Close()
+	err := c.Close(true)
 	require.NotNilf(t, err, "unexpected result")
 	require.Equalf(t, 1, m.called, "should be called only once")
 	require.Equal(t, "err1", err.Error())

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -37,7 +37,7 @@ func ExampleConnectionPool_Do() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	modes := []pool.Mode{
 		pool.ANY,
@@ -65,7 +65,7 @@ func ExampleConnectionPool_NewPrepared() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	stmt, err := connPool.NewPrepared("SELECT 1", pool.ANY)
 	if err != nil {
@@ -98,7 +98,7 @@ func ExampleConnectionPool_NewWatcher() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	callback := func(event tarantool.WatchEvent) {
 		fmt.Printf("event connection: %s\n", event.Conn.Addr())
@@ -127,7 +127,7 @@ func ExampleConnectionPool_NewWatcher_noWatchersFeature() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	callback := func(event tarantool.WatchEvent) {}
 	watcher, err := connPool.NewWatcher(key, callback, pool.ANY)
@@ -170,7 +170,7 @@ func ExampleCommitRequest() {
 		fmt.Println(err)
 		return
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	// example pool has only one rw instance
 	stream, err := connPool.NewStream(pool.RW)
@@ -258,7 +258,7 @@ func ExampleRollbackRequest() {
 		fmt.Println(err)
 		return
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	stream, err := connPool.NewStream(pool.RW)
 	if err != nil {
@@ -345,7 +345,7 @@ func ExampleBeginRequest_TxnIsolation() {
 		fmt.Println(err)
 		return
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	stream, err := connPool.NewStream(pool.RW)
 	if err != nil {
@@ -421,7 +421,7 @@ func ExampleConnectorAdapter() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	adapter := pool.NewConnectorAdapter(connPool, pool.RW)
 	var connector tarantool.Connector = adapter
@@ -437,9 +437,9 @@ func ExampleConnectorAdapter() {
 	// Ping Error <nil>
 }
 
-// ExampleConnectionPool_CloseGraceful_force demonstrates how to force close
+// ExampleConnectionPool_Close_graceful_force demonstrates how to force close
 // a connection pool with graceful close in progress after a while.
-func ExampleConnectionPool_CloseGraceful_force() {
+func ExampleConnectionPool_Close_graceful_force() {
 	connPool, err := examplePool(testRoles, connOpts)
 	if err != nil {
 		fmt.Println(err)
@@ -455,24 +455,24 @@ func ExampleConnectionPool_CloseGraceful_force() {
 
 	done := make(chan struct{})
 	go func() {
-		connPool.CloseGraceful()
-		fmt.Println("ConnectionPool.CloseGraceful() done!")
+		connPool.Close(false)
+		fmt.Println("ConnectionPool.Close(false) done!")
 		close(done)
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		fmt.Println("Force ConnectionPool.Close()!")
-		connPool.Close()
+		fmt.Println("Force ConnectionPool.Close(true)!")
+		connPool.Close(true)
 	}
 	<-done
 
 	fmt.Println("Result:")
 	fmt.Println(fut.Get())
 	// Output:
-	// Force ConnectionPool.Close()!
-	// ConnectionPool.CloseGraceful() done!
+	// Force ConnectionPool.Close(true)!
+	// ConnectionPool.Close(false) done!
 	// Result:
 	// <nil> connection closed by client (0x4001)
 }

--- a/pool/pooler.go
+++ b/pool/pooler.go
@@ -9,7 +9,7 @@ import (
 // Pooler is the interface that must be implemented by a connection pool.
 type Pooler interface {
 	ConnectedNow(mode Mode) (bool, error)
-	Close() error
+	Close(force bool) error
 	ConfiguredTimeout(mode Mode) (time.Duration, error)
 	NewPrepared(expr string, mode Mode) (*tarantool.Prepared, error)
 	NewStream(mode Mode) (*tarantool.Stream, error)

--- a/pool/pooler.go
+++ b/pool/pooler.go
@@ -9,7 +9,7 @@ import (
 // Pooler is the interface that must be implemented by a connection pool.
 type Pooler interface {
 	ConnectedNow(mode Mode) (bool, error)
-	Close() []error
+	Close() error
 	ConfiguredTimeout(mode Mode) (time.Duration, error)
 	NewPrepared(expr string, mode Mode) (*tarantool.Prepared, error)
 	NewStream(mode Mode) (*tarantool.Stream, error)

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -169,7 +169,7 @@ func Example_connectionPool() {
 		fmt.Printf("Unable to connect to the pool: %s", err)
 		return
 	}
-	defer connPool.Close()
+	defer connPool.Close(true)
 
 	// Wait for a queue initialization and master instance identification in
 	// the queue.

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -60,7 +60,7 @@ func Example_simpleQueueCustomMsgPack() {
 		log.Fatalf("connection: %s", err)
 		return
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 
 	cfg := queue.Cfg{
 		Temporary:   true,

--- a/queue/example_test.go
+++ b/queue/example_test.go
@@ -36,7 +36,7 @@ func Example_simpleQueue() {
 		fmt.Printf("error in prepare is %v", err)
 		return
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 
 	q := queue.New(conn, "test_queue")
 	if err := q.Create(cfg); err != nil {

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -54,7 +54,7 @@ func dropQueue(t *testing.T, q queue.Queue) {
 
 func TestFifoQueue(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -63,7 +63,7 @@ func TestFifoQueue(t *testing.T) {
 
 func TestQueue_Cfg(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -77,7 +77,7 @@ func TestQueue_Cfg(t *testing.T) {
 
 func TestQueue_Identify(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -102,7 +102,7 @@ func TestQueue_ReIdentify(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
 	defer func() {
 		if conn != nil {
-			conn.Close()
+			conn.Close(true)
 		}
 	}()
 
@@ -133,7 +133,7 @@ func TestQueue_ReIdentify(t *testing.T) {
 	putData := "put_data"
 	task, err := q.Put(putData)
 	if err != nil {
-		conn.Close()
+		conn.Close(true)
 		t.Fatalf("Failed put to queue: %s", err)
 	} else if err == nil && task == nil {
 		t.Fatalf("Task is nil after put")
@@ -151,7 +151,7 @@ func TestQueue_ReIdentify(t *testing.T) {
 		t.Fatalf("Task is nil after take")
 	}
 
-	conn.Close()
+	conn.Close(true)
 	conn = nil
 
 	conn = test_helpers.ConnectWithValidation(t, server, opts)
@@ -185,7 +185,7 @@ func TestQueue_ReIdentify(t *testing.T) {
 
 func TestQueue_State(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -202,7 +202,7 @@ func TestQueue_State(t *testing.T) {
 
 func TestFifoQueue_GetExist_Statistic(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -232,7 +232,7 @@ func TestFifoQueue_GetExist_Statistic(t *testing.T) {
 
 func TestFifoQueue_Put(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -254,7 +254,7 @@ func TestFifoQueue_Put(t *testing.T) {
 
 func TestFifoQueue_Take(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -329,7 +329,7 @@ func (c *customData) EncodeMsgpack(e *msgpack.Encoder) error {
 
 func TestFifoQueue_TakeTyped(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -385,7 +385,7 @@ func TestFifoQueue_TakeTyped(t *testing.T) {
 
 func TestFifoQueue_Peek(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -423,7 +423,7 @@ func TestFifoQueue_Peek(t *testing.T) {
 
 func TestFifoQueue_Bury_Kick(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -486,7 +486,7 @@ func TestFifoQueue_Delete(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -538,7 +538,7 @@ func TestFifoQueue_Delete(t *testing.T) {
 
 func TestFifoQueue_Release(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -600,7 +600,7 @@ func TestFifoQueue_Release(t *testing.T) {
 
 func TestQueue_ReleaseAll(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	q := createQueue(t, conn, name, queue.Cfg{Temporary: true, Kind: queue.FIFO})
@@ -666,7 +666,7 @@ func TestQueue_ReleaseAll(t *testing.T) {
 
 func TestTtlQueue(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	cfg := queue.Cfg{
@@ -702,7 +702,7 @@ func TestTtlQueue(t *testing.T) {
 
 func TestTtlQueue_Put(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_queue"
 	cfg := queue.Cfg{
@@ -753,7 +753,7 @@ func TestTtlQueue_Put(t *testing.T) {
 
 func TestUtube_Put(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	name := "test_utube"
 	cfg := queue.Cfg{
@@ -825,7 +825,7 @@ func TestUtube_Put(t *testing.T) {
 
 func TestTask_Touch(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tests := []struct {
 		name string

--- a/settings/example_test.go
+++ b/settings/example_test.go
@@ -22,7 +22,7 @@ func Example_sqlFullColumnNames() {
 	var isLess bool
 
 	conn := example_connect(opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Tarantool supports session settings since version 2.3.1
 	isLess, err = test_helpers.IsTarantoolVersionLess(2, 3, 1)

--- a/settings/tarantool_test.go
+++ b/settings/tarantool_test.go
@@ -53,7 +53,7 @@ func TestErrorMarshalingEnabledSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Disable receiving box.error as MP_EXT 3.
 	resp, err = conn.Do(NewErrorMarshalingEnabledSetRequest(false)).Get()
@@ -102,7 +102,7 @@ func TestSQLDefaultEngineSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Set default SQL "CREATE TABLE" engine to "vinyl".
 	resp, err = conn.Do(NewSQLDefaultEngineSetRequest("vinyl")).Get()
@@ -165,7 +165,7 @@ func TestSQLDeferForeignKeysSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Create a parent space.
 	exec := tarantool.NewExecuteRequest("CREATE TABLE parent(id INT PRIMARY KEY, y INT UNIQUE);")
@@ -237,7 +237,7 @@ func TestSQLFullColumnNamesSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Create a space.
 	exec := tarantool.NewExecuteRequest("CREATE TABLE fkname(id INT PRIMARY KEY, x INT);")
@@ -299,7 +299,7 @@ func TestSQLFullMetadataSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Create a space.
 	exec := tarantool.NewExecuteRequest("CREATE TABLE fmt(id INT PRIMARY KEY, x INT);")
@@ -360,7 +360,7 @@ func TestSQLParserDebugSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Disable parser debug mode.
 	resp, err = conn.Do(NewSQLParserDebugSetRequest(false)).Get()
@@ -398,7 +398,7 @@ func TestSQLRecursiveTriggersSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Create a space.
 	exec := tarantool.NewExecuteRequest("CREATE TABLE rec(id INTEGER PRIMARY KEY, a INT, b INT);")
@@ -469,7 +469,7 @@ func TestSQLReverseUnorderedSelectsSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Create a space.
 	exec := tarantool.NewExecuteRequest("CREATE TABLE data(id STRING PRIMARY KEY);")
@@ -544,7 +544,7 @@ func TestSQLSelectDebugSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Disable select debug mode.
 	resp, err = conn.Do(NewSQLSelectDebugSetRequest(false)).Get()
@@ -581,7 +581,7 @@ func TestSQLVDBEDebugSetting(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Disable VDBE debug mode.
 	resp, err = conn.Do(NewSQLVDBEDebugSetRequest(false)).Get()
@@ -618,7 +618,7 @@ func TestSessionSettings(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Set some settings values.
 	resp, err = conn.Do(NewSQLDefaultEngineSetRequest("memtx")).Get()

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -496,9 +496,9 @@ func TestOpts_PapSha256Auth(t *testing.T) {
 	clientOpts.Ssl = sslOpts
 	clientOpts.Auth = PapSha256Auth
 	conn := test_helpers.ConnectWithValidation(t, tntHost, clientOpts)
-	conn.Close()
+	conn.Close(true)
 
 	clientOpts.Auth = AutoAuth
 	conn = test_helpers.ConnectWithValidation(t, tntHost, clientOpts)
-	conn.Close()
+	conn.Close(true)
 }

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -90,7 +90,7 @@ func BenchmarkClientSerial(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -110,7 +110,7 @@ func BenchmarkClientSerialRequestObject(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -137,7 +137,7 @@ func BenchmarkClientSerialRequestObjectWithContext(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -166,7 +166,7 @@ func BenchmarkClientSerialTyped(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -187,7 +187,7 @@ func BenchmarkClientSerialSQL(b *testing.B) {
 	test_helpers.SkipIfSQLUnsupported(b)
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -208,7 +208,7 @@ func BenchmarkClientSerialSQLPrepared(b *testing.B) {
 	test_helpers.SkipIfSQLUnsupported(b)
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -240,7 +240,7 @@ func BenchmarkClientFuture(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -267,7 +267,7 @@ func BenchmarkClientFutureTyped(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -297,7 +297,7 @@ func BenchmarkClientFutureParallel(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -330,7 +330,7 @@ func BenchmarkClientFutureParallelTyped(b *testing.B) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err = conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -366,7 +366,7 @@ func BenchmarkClientFutureParallelTyped(b *testing.B) {
 
 func BenchmarkClientParallel(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -387,7 +387,7 @@ func BenchmarkClientParallel(b *testing.B) {
 
 func benchmarkClientParallelRequestObject(multiplier int, b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -415,7 +415,7 @@ func benchmarkClientParallelRequestObject(multiplier int, b *testing.B) {
 
 func benchmarkClientParallelRequestObjectWithContext(multiplier int, b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -447,7 +447,7 @@ func benchmarkClientParallelRequestObjectWithContext(multiplier int, b *testing.
 
 func benchmarkClientParallelRequestObjectMixed(multiplier int, b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -486,7 +486,7 @@ func benchmarkClientParallelRequestObjectMixed(multiplier int, b *testing.B) {
 func BenchmarkClientParallelRequestObject(b *testing.B) {
 	multipliers := []int{10, 50, 500, 1000}
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -512,7 +512,7 @@ func BenchmarkClientParallelRequestObject(b *testing.B) {
 
 func BenchmarkClientParallelMassive(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -547,7 +547,7 @@ func BenchmarkClientParallelMassive(b *testing.B) {
 
 func BenchmarkClientParallelMassiveUntyped(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace(spaceNo, []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -582,7 +582,7 @@ func BenchmarkClientParallelMassiveUntyped(b *testing.B) {
 
 func BenchmarkClientReplaceParallel(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	rSpaceNo, _, err := conn.Schema.ResolveSpaceIndex("test_perf", "secondary")
 	if err != nil {
@@ -602,7 +602,7 @@ func BenchmarkClientReplaceParallel(b *testing.B) {
 
 func BenchmarkClientLargeSelectParallel(b *testing.B) {
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	schema := conn.Schema
 	rSpaceNo, rIndexNo, err := schema.ResolveSpaceIndex("test_perf", "secondary")
@@ -626,7 +626,7 @@ func BenchmarkClientParallelSQL(b *testing.B) {
 	test_helpers.SkipIfSQLUnsupported(b)
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -649,7 +649,7 @@ func BenchmarkClientParallelSQLPrepared(b *testing.B) {
 	test_helpers.SkipIfSQLUnsupported(b)
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -683,7 +683,7 @@ func BenchmarkSQLSerial(b *testing.B) {
 	test_helpers.SkipIfSQLUnsupported(b)
 
 	conn := test_helpers.ConnectWithValidation(b, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Replace("SQL_TEST", []interface{}{uint(1111), "hello", "world"})
 	if err != nil {
@@ -748,7 +748,7 @@ func TestTtDialer_worksWithConnection(t *testing.T) {
 	defaultOpts.Dialer = TtDialer{}
 
 	conn := test_helpers.ConnectWithValidation(t, server, defaultOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Do(NewPingRequest()).Get()
 	assert.Nil(t, err)
@@ -759,7 +759,7 @@ func TestOptsAuth_Default(t *testing.T) {
 	defaultOpts.Auth = AutoAuth
 
 	conn := test_helpers.ConnectWithValidation(t, server, defaultOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 }
 
 func TestOptsAuth_ChapSha1Auth(t *testing.T) {
@@ -767,7 +767,7 @@ func TestOptsAuth_ChapSha1Auth(t *testing.T) {
 	chapSha1Opts.Auth = ChapSha1Auth
 
 	conn := test_helpers.ConnectWithValidation(t, server, chapSha1Opts)
-	defer conn.Close()
+	defer conn.Close(true)
 }
 
 func TestOptsAuth_PapSha256AuthForbit(t *testing.T) {
@@ -777,7 +777,7 @@ func TestOptsAuth_PapSha256AuthForbit(t *testing.T) {
 	conn, err := Connect(server, papSha256Opts)
 	if err == nil {
 		t.Error("An error expected.")
-		conn.Close()
+		conn.Close(true)
 	}
 
 	if err.Error() != "failed to authenticate: forbidden to use pap-sha256"+
@@ -788,7 +788,7 @@ func TestOptsAuth_PapSha256AuthForbit(t *testing.T) {
 
 func TestFutureMultipleGetGetTyped(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	fut := conn.Call17Async("simple_concat", []interface{}{"1"})
 
@@ -826,7 +826,7 @@ func TestFutureMultipleGetGetTyped(t *testing.T) {
 
 func TestFutureMultipleGetWithError(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	fut := conn.Call17Async("non_exist", []interface{}{"1"})
 
@@ -839,7 +839,7 @@ func TestFutureMultipleGetWithError(t *testing.T) {
 
 func TestFutureMultipleGetTypedWithError(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	fut := conn.Call17Async("simple_concat", []interface{}{"1"})
 
@@ -868,7 +868,7 @@ func TestClient(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Ping
 	resp, err = conn.Ping()
@@ -1210,7 +1210,7 @@ func TestClient(t *testing.T) {
 
 func TestClientSessionPush(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	var it ResponseIterator
 	const pushMax = 3
@@ -1504,7 +1504,7 @@ func TestSQL(t *testing.T) {
 	}
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for i, test := range testCases {
 		resp, err := conn.Execute(test.Query, test.Args)
@@ -1531,7 +1531,7 @@ func TestSQLTyped(t *testing.T) {
 	test_helpers.SkipIfSQLUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	mem := []Member{}
 	info, meta, err := conn.ExecuteTyped(selectTypedQuery, []interface{}{1}, &mem)
@@ -1560,7 +1560,7 @@ func TestSQLBindings(t *testing.T) {
 	var resp *Response
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// test all types of supported bindings
 	// prepare named sql bind
@@ -1662,7 +1662,7 @@ func TestStressSQL(t *testing.T) {
 	var resp *Response
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	resp, err := conn.Execute(createTableQuery, []interface{}{})
 	if err != nil {
@@ -1759,7 +1759,7 @@ func TestNewPrepared(t *testing.T) {
 	test_helpers.SkipIfSQLUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stmt, err := conn.NewPrepared(selectNamedQuery2)
 	if err != nil {
@@ -1875,7 +1875,7 @@ func TestSchema(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Schema
 	schema := conn.Schema
@@ -2047,7 +2047,7 @@ func TestSchema(t *testing.T) {
 
 func TestSchema_IsNullable(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	schema := conn.Schema
 	if schema.Spaces == nil {
@@ -2083,7 +2083,7 @@ func TestClientNamed(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Insert
 	resp, err = conn.Insert(spaceName, []interface{}{uint(1001), "hello2", "world2"})
@@ -2174,7 +2174,7 @@ func TestClientRequestObjects(t *testing.T) {
 	)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Ping
 	req = NewPingRequest()
@@ -2568,7 +2568,7 @@ func testConnectionDoSelectRequestCheck(t *testing.T,
 
 func TestConnectionDoSelectRequest(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	testConnectionDoSelectRequestPrepare(t, conn)
 
@@ -2586,7 +2586,7 @@ func TestConnectionDoSelectRequest_fetch_pos(t *testing.T) {
 	test_helpers.SkipIfPaginationUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	testConnectionDoSelectRequestPrepare(t, conn)
 
@@ -2605,7 +2605,7 @@ func TestConnectDoSelectRequest_after_tuple(t *testing.T) {
 	test_helpers.SkipIfPaginationUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	testConnectionDoSelectRequestPrepare(t, conn)
 
@@ -2625,7 +2625,7 @@ func TestConnectionDoSelectRequest_pagination_pos(t *testing.T) {
 	test_helpers.SkipIfPaginationUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	testConnectionDoSelectRequestPrepare(t, conn)
 
@@ -2649,7 +2649,7 @@ func TestConnection_Call(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	resp, err = conn.Call("simple_concat", []interface{}{"1"})
 	if err != nil {
@@ -2665,7 +2665,7 @@ func TestCallRequest(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := NewCallRequest("simple_concat").Args([]interface{}{"1"})
 	resp, err = conn.Do(req).Get()
@@ -2679,7 +2679,7 @@ func TestCallRequest(t *testing.T) {
 
 func TestClientRequestObjectsWithNilContext(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 	req := NewPingRequest().Context(nil) //nolint
 	resp, err := conn.Do(req).Get()
 	if err != nil {
@@ -2695,7 +2695,7 @@ func TestClientRequestObjectsWithNilContext(t *testing.T) {
 
 func TestClientRequestObjectsWithPassedCanceledContext(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := NewPingRequest().Context(ctx)
@@ -2737,7 +2737,7 @@ func (req *waitCtxRequest) Async() bool {
 func TestClientRequestObjectsWithContext(t *testing.T) {
 	var err error
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := &waitCtxRequest{ctx: ctx}
@@ -2776,7 +2776,7 @@ func TestComplexStructs(t *testing.T) {
 	var err error
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tuple := Tuple2{Cid: 777, Orig: "orig", Members: []Member{{"lol", "", 1}, {"wut", "", 3}}}
 	_, err = conn.Replace(spaceNo, &tuple)
@@ -2805,7 +2805,7 @@ func TestStream_IdValues(t *testing.T) {
 	test_helpers.SkipIfStreamsUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	cases := []uint64{
 		1,
@@ -2842,7 +2842,7 @@ func TestStream_Commit(t *testing.T) {
 	test_helpers.SkipIfStreamsUnsupported(t)
 
 	conn = test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -2957,7 +2957,7 @@ func TestStream_Rollback(t *testing.T) {
 	test_helpers.SkipIfStreamsUnsupported(t)
 
 	conn = test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -3078,7 +3078,7 @@ func TestStream_TxnIsolationLevel(t *testing.T) {
 	test_helpers.SkipIfStreamsUnsupported(t)
 
 	conn = test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	stream, _ := conn.NewStream()
 
@@ -3181,7 +3181,7 @@ func TestStream_DoWithClosedConn(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
 
 	stream, _ := conn.NewStream()
-	conn.Close()
+	conn.Close(true)
 
 	// Begin transaction
 	req := NewBeginRequest()
@@ -3198,7 +3198,7 @@ func TestConnectionProtocolInfoSupported(t *testing.T) {
 	test_helpers.SkipIfIdUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// First Tarantool protocol version (1, StreamsFeature and TransactionsFeature)
 	// was introduced between 2.10.0-beta1 and 2.10.0-beta2.
@@ -3244,7 +3244,7 @@ func TestClientIdRequestObject(t *testing.T) {
 	test_helpers.SkipIfIdUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tarantool210ProtocolInfo := ProtocolInfo{
 		Version: ProtocolVersion(3),
@@ -3280,7 +3280,7 @@ func TestClientIdRequestObjectWithNilContext(t *testing.T) {
 	test_helpers.SkipIfIdUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	tarantool210ProtocolInfo := ProtocolInfo{
 		Version: ProtocolVersion(3),
@@ -3314,7 +3314,7 @@ func TestClientIdRequestObjectWithNilContext(t *testing.T) {
 
 func TestClientIdRequestObjectWithPassedCanceledContext(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := NewIdRequest(ProtocolInfo{
@@ -3332,7 +3332,7 @@ func TestConnectionProtocolInfoUnsupported(t *testing.T) {
 	test_helpers.SkipIfIdSupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	clientProtocolInfo := conn.ClientProtocolInfo()
 	require.Equal(t,
@@ -3354,7 +3354,7 @@ func TestConnectionProtocolInfoUnsupported(t *testing.T) {
 
 func TestConnectionClientFeaturesUmmutable(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	info := conn.ClientProtocolInfo()
 	infoOrig := info.Clone()
@@ -3368,7 +3368,7 @@ func TestConnectionServerFeaturesUmmutable(t *testing.T) {
 	test_helpers.SkipIfIdUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	info := conn.ServerProtocolInfo()
 	infoOrig := info.Clone()
@@ -3391,7 +3391,7 @@ func TestConnectionProtocolVersionRequirementSuccess(t *testing.T) {
 	require.Nilf(t, err, "No errors on connect")
 	require.NotNilf(t, conn, "Connect success")
 
-	conn.Close()
+	conn.Close(true)
 }
 
 func TestConnectionProtocolVersionRequirementFail(t *testing.T) {
@@ -3422,7 +3422,7 @@ func TestConnectionProtocolFeatureRequirementSuccess(t *testing.T) {
 	require.NotNilf(t, conn, "Connect success")
 	require.Nilf(t, err, "No errors on connect")
 
-	conn.Close()
+	conn.Close(true)
 }
 
 func TestConnectionProtocolFeatureRequirementFail(t *testing.T) {
@@ -3481,7 +3481,7 @@ func TestConnectionFeatureOptsImmutable(t *testing.T) {
 
 	// Connect with valid opts
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	// Change opts outside
 	connOpts.RequiredProtocolInfo.Features[0] = ProtocolFeature(15532)
@@ -3499,7 +3499,7 @@ func TestErrorExtendedInfoBasic(t *testing.T) {
 	test_helpers.SkipIfErrorExtendedInfoUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Eval("not a Lua code", []interface{}{})
 	require.NotNilf(t, err, "expected error on invalid Lua code")
@@ -3527,7 +3527,7 @@ func TestErrorExtendedInfoStack(t *testing.T) {
 	test_helpers.SkipIfErrorExtendedInfoUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Eval("error(chained_error)", []interface{}{})
 	require.NotNilf(t, err, "expected error on explicit error raise")
@@ -3563,7 +3563,7 @@ func TestErrorExtendedInfoFields(t *testing.T) {
 	test_helpers.SkipIfErrorExtendedInfoUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	_, err := conn.Eval("error(access_denied_error)", []interface{}{})
 	require.NotNilf(t, err, "expected error on forbidden action")
@@ -3601,7 +3601,7 @@ func TestConnection_NewWatcher(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	events := make(chan WatchEvent)
 	defer close(events)
@@ -3635,7 +3635,7 @@ func TestConnection_NewWatcher_noWatchersFeature(t *testing.T) {
 	connOpts := opts.Clone()
 	connOpts.RequiredProtocolInfo.Features = []ProtocolFeature{}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	watcher, err := conn.NewWatcher(key, func(event WatchEvent) {})
 	require.Nilf(t, watcher, "watcher must not be created")
@@ -3672,7 +3672,7 @@ func TestConnection_NewWatcher_reconnect(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, reconnectOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	events := make(chan WatchEvent)
 	defer close(events)
@@ -3710,7 +3710,7 @@ func TestBroadcastRequest(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	resp, err := conn.Do(NewBroadcastRequest(key).Value(value)).Get()
 	if err != nil {
@@ -3760,7 +3760,7 @@ func TestBroadcastRequest_multi(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	events := make(chan WatchEvent)
 	defer close(events)
@@ -3808,7 +3808,7 @@ func TestConnection_NewWatcher_multiOnKey(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	events := []chan WatchEvent{
 		make(chan WatchEvent),
@@ -3871,7 +3871,7 @@ func TestWatcher_Unregister(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	events := make(chan WatchEvent)
 	defer close(events)
@@ -3907,7 +3907,7 @@ func TestConnection_NewWatcher_concurrent(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	var wg sync.WaitGroup
 	wg.Add(testConcurrency)
@@ -3952,7 +3952,7 @@ func TestWatcher_Unregister_concurrent(t *testing.T) {
 		WatchersFeature,
 	}
 	conn := test_helpers.ConnectWithValidation(t, server, connOpts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	watcher, err := conn.NewWatcher(key, func(event WatchEvent) {})
 	if err != nil {
@@ -3973,7 +3973,7 @@ func TestWatcher_Unregister_concurrent(t *testing.T) {
 
 func TestConnect_schema_update(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	for i := 0; i < 100; i++ {
 		fut := conn.Do(NewCallRequest("create_spaces"))
@@ -3985,7 +3985,7 @@ func TestConnect_schema_update(t *testing.T) {
 		} else if conn == nil {
 			t.Errorf("conn is nil")
 		} else {
-			conn.Close()
+			conn.Close(true)
 		}
 
 		if _, err := fut.Get(); err != nil {

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -104,7 +104,7 @@ func isReady(server string, opts *tarantool.Opts) error {
 	if conn == nil {
 		return errors.New("Conn is nil after connect")
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 
 	resp, err = conn.Do(tarantool.NewPingRequest()).Get()
 	if err != nil {

--- a/test_helpers/pool_helper.go
+++ b/test_helpers/pool_helper.go
@@ -137,7 +137,7 @@ func InsertOnInstance(server string, connOpts tarantool.Opts, space interface{},
 	if conn == nil {
 		return fmt.Errorf("conn is nil after Connect")
 	}
-	defer conn.Close()
+	defer conn.Close(true)
 
 	resp, err := conn.Do(tarantool.NewInsertRequest(space).Tuple(tuple)).Get()
 	if err != nil {
@@ -194,7 +194,7 @@ func SetInstanceRO(server string, connOpts tarantool.Opts, isReplica bool) error
 		return err
 	}
 
-	defer conn.Close()
+	defer conn.Close(true)
 
 	req := tarantool.NewCallRequest("box.cfg").
 		Args([]interface{}{map[string]bool{"read_only": isReplica}})

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -74,7 +74,7 @@ func TestSelect(t *testing.T) {
 	}
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	id, uuidErr := uuid.Parse("c8f0fa1f-da29-438c-a040-393f1126ad39")
 	if uuidErr != nil {
@@ -114,7 +114,7 @@ func TestReplace(t *testing.T) {
 	}
 
 	conn := test_helpers.ConnectWithValidation(t, server, opts)
-	defer conn.Close()
+	defer conn.Close(true)
 
 	id, uuidErr := uuid.Parse("64d22e4d-ac92-4a23-899a-e59f34af5479")
 	if uuidErr != nil {


### PR DESCRIPTION
The Close() and CloseGraceful() methods have been merged into a single
method Close(force bool) to simplify the interface.

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)
