### PR TITLE
pool: fix race condition at GetNextConnection()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Fixed
 
 - Flaky decimal/TestSelect (#300)
+- Race condition at roundRobinStrategy.GetNextConnection() (#309)
 
 ## [1.12.0] - 2023-06-07
 

--- a/pool/round_robin.go
+++ b/pool/round_robin.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/tarantool/go-tarantool/v2"
 )
@@ -10,8 +11,8 @@ type roundRobinStrategy struct {
 	conns       []*tarantool.Connection
 	indexByAddr map[string]uint
 	mutex       sync.RWMutex
-	size        uint
-	current     uint
+	size        uint64
+	current     uint64
 }
 
 func newRoundRobinStrategy(size int) *roundRobinStrategy {
@@ -98,13 +99,12 @@ func (r *roundRobinStrategy) AddConn(addr string, conn *tarantool.Connection) {
 		r.conns[idx] = conn
 	} else {
 		r.conns = append(r.conns, conn)
-		r.indexByAddr[addr] = r.size
+		r.indexByAddr[addr] = uint(r.size)
 		r.size += 1
 	}
 }
 
-func (r *roundRobinStrategy) nextIndex() uint {
-	ret := r.current % r.size
-	r.current++
-	return ret
+func (r *roundRobinStrategy) nextIndex() uint64 {
+	next := atomic.AddUint64(&r.current, 1)
+	return (next - 1) % r.size
 }


### PR DESCRIPTION
The `r.current` value can be changed by concurrent threads because the change happens under read-lock. We could use the atomic counter for a current connection number to avoid the race condition.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #309