### PR TITLE
queue: encode UUID argument of `identify()` as string instead of binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - connection_pool renamed to pool (#239)
 - Use msgpack/v5 instead of msgpack.v2 (#236)
 - Call/NewCallRequest = Call17/NewCall17Request (#235)
+- Change encoding of the queue.Identify() UUID argument from binary blob to
+  plain string. Needed for upgrade to Tarantool 3.0, where a binary blob is
+  decoded to a varbinary object (#313).
 
 ### Deprecated
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -239,7 +239,7 @@ func (q *queue) Identify(u *uuid.UUID) (uuid.UUID, error) {
 		if bytes, err := u.MarshalBinary(); err != nil {
 			return uuid.UUID{}, err
 		} else {
-			args = []interface{}{bytes}
+			args = []interface{}{string(bytes)}
 		}
 	}
 


### PR DESCRIPTION
The `identify()` function expects the UUID argument to be a plain string while the go connector encodes it in MsgPack as a binary blob (`MP_BIN`). This works fine for now because Tarantool stores `MP_BIN` data in a string when decoded to Lua but this behavior is going to change soon: we're planning to introduce the new Lua type for binary data and update the MsgPack decoder to store `MP_BIN` data in a varbianry object instead of a plain string.

Let's prepare for that by converting the UUID data to a string before encoding.

Needed for tarantool/tarantool#1629