### PR TITLE
decimal: incorrect MP_DECIMAL decoding with scale < 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 - Flaky decimal/TestSelect (#300)
 - Race condition at roundRobinStrategy.GetNextConnection() (#309)
+- Incorrect decoding of an MP_DECIMAL when the `scale` value is negative (#314)
 
 ## [1.12.0] - 2023-06-07
 

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -98,16 +98,20 @@ func (decNum *Decimal) UnmarshalMsgpack(b []byte) error {
 	//  +--------+-------------------+------------+===============+
 	//  | MP_EXT | length (optional) | MP_DECIMAL | PackedDecimal |
 	//  +--------+-------------------+------------+===============+
-	digits, err := decodeStringFromBCD(b)
+	digits, exp, err := decodeStringFromBCD(b)
 	if err != nil {
 		return fmt.Errorf("msgpack: can't decode string from BCD buffer (%x): %w", b, err)
 	}
+
 	dec, err := decimal.NewFromString(digits)
-	*decNum = *NewDecimal(dec)
 	if err != nil {
 		return fmt.Errorf("msgpack: can't encode string (%s) to a decimal number: %w", digits, err)
 	}
 
+	if exp != 0 {
+		dec = dec.Shift(int32(exp))
+	}
+	*decNum = *NewDecimal(dec)
 	return nil
 }
 

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -121,6 +121,18 @@ var correctnessSamples = []struct {
 		"c7150113012345678912345678900987654321987654321d", false},
 }
 
+var correctnessDecodeSamples = []struct {
+	numString string
+	mpBuf     string
+	fixExt    bool
+}{
+	{"1e2", "d501fe1c", true},
+	{"1e33", "c70301d0df1c", false},
+	{"1.1e31", "c70301e2011c", false},
+	{"13e-2", "c7030102013c", false},
+	{"-1e3", "d501fd1d", true},
+}
+
 // There is a difference between encoding result from a raw string and from
 // decimal.Decimal. It's expected because decimal.Decimal simplifies decimals:
 // 0.00010000 -> 0.0001
@@ -397,18 +409,22 @@ func TestEncodeStringToBCD(t *testing.T) {
 
 func TestDecodeStringFromBCD(t *testing.T) {
 	samples := correctnessSamples
+	samples = append(samples, correctnessDecodeSamples...)
 	samples = append(samples, rawSamples...)
 	samples = append(samples, benchmarkSamples...)
 	for _, testcase := range samples {
 		t.Run(testcase.numString, func(t *testing.T) {
 			b, _ := hex.DecodeString(testcase.mpBuf)
 			bcdBuf := trimMPHeader(b, testcase.fixExt)
-			s, err := DecodeStringFromBCD(bcdBuf)
+			s, exp, err := DecodeStringFromBCD(bcdBuf)
 			if err != nil {
 				t.Fatalf("Failed to decode BCD '%x' to decimal: %s", bcdBuf, err)
 			}
 
 			decActual, err := decimal.NewFromString(s)
+			if exp != 0 {
+				decActual = decActual.Shift(int32(exp))
+			}
 			if err != nil {
 				t.Fatalf("Failed to msgpack.Encoder string ('%s') to decimal", s)
 			}
@@ -549,6 +565,37 @@ func TestSelect(t *testing.T) {
 		t.Fatalf("Decimal delete failed: %s", err)
 	}
 	tupleValueIsDecimal(t, resp.Data, number)
+}
+
+func TestUnmarshal_from_decimal_new(t *testing.T) {
+	skipIfDecimalUnsupported(t)
+
+	conn := test_helpers.ConnectWithValidation(t, server, opts)
+	defer conn.Close()
+
+	samples := correctnessSamples
+	samples = append(samples, correctnessDecodeSamples...)
+	samples = append(samples, benchmarkSamples...)
+	for _, testcase := range samples {
+		str := testcase.numString
+		t.Run(str, func(t *testing.T) {
+			number, err := decimal.NewFromString(str)
+			if err != nil {
+				t.Fatalf("Failed to prepare test decimal: %s", err)
+			}
+
+			call := NewEvalRequest("return require('decimal').new(...)").
+				Args([]interface{}{str})
+			resp, err := conn.Do(call).Get()
+			if err != nil {
+				t.Fatalf("Decimal create failed: %s", err)
+			}
+			if resp == nil {
+				t.Fatalf("Response is nil after Call")
+			}
+			tupleValueIsDecimal(t, []interface{}{resp.Data}, number)
+		})
+	}
 }
 
 func assertInsert(t *testing.T, conn *Connection, numString string) {

--- a/decimal/export_test.go
+++ b/decimal/export_test.go
@@ -4,7 +4,7 @@ func EncodeStringToBCD(buf string) ([]byte, error) {
 	return encodeStringToBCD(buf)
 }
 
-func DecodeStringFromBCD(bcdBuf []byte) (string, error) {
+func DecodeStringFromBCD(bcdBuf []byte) (string, int, error) {
 	return decodeStringFromBCD(bcdBuf)
 }
 

--- a/decimal/fuzzing_test.go
+++ b/decimal/fuzzing_test.go
@@ -10,10 +10,13 @@ import (
 	. "github.com/tarantool/go-tarantool/v2/decimal"
 )
 
-func strToDecimal(t *testing.T, buf string) decimal.Decimal {
+func strToDecimal(t *testing.T, buf string, exp int) decimal.Decimal {
 	decNum, err := decimal.NewFromString(buf)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if exp != 0 {
+		decNum = decNum.Shift(int32(exp))
 	}
 	return decNum
 }
@@ -33,13 +36,13 @@ func FuzzEncodeDecodeBCD(f *testing.F) {
 		if err != nil {
 			t.Skip("Only correct requests are interesting: %w", err)
 		}
-		var dec string
-		dec, err = DecodeStringFromBCD(bcdBuf)
+
+		dec, exp, err := DecodeStringFromBCD(bcdBuf)
 		if err != nil {
 			t.Fatalf("Failed to decode encoded value ('%s')", orig)
 		}
 
-		if !strToDecimal(t, dec).Equal(strToDecimal(t, orig)) {
+		if !strToDecimal(t, dec, exp).Equal(strToDecimal(t, orig, 0)) {
 			t.Fatal("Decimal numbers are not equal")
 		}
 	})


### PR DESCRIPTION
The `scale` value in `MP_DECIMAL` may be negative [1]. We need to handle the case.

1. https://www.tarantool.io/en/doc/latest/dev_guide/internals/msgpack_extensions/#the-decimal-type

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)