### PR TITLE
crud: fix options for SelectRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Flaky decimal/TestSelect (#300)
 - Race condition at roundRobinStrategy.GetNextConnection() (#309)
 - Incorrect decoding of an MP_DECIMAL when the `scale` value is negative (#314)
+- Incorrect options (`after`, `batch_size` and `force_map_call`) setup for
+  crud.SelectRequest (#320)
 
 ## [1.12.0] - 2023-06-07
 

--- a/crud/example_test.go
+++ b/crud/example_test.go
@@ -148,3 +148,41 @@ func ExampleResult_errorMany() {
 	// Output:
 	// Failed to execute request: CallError:
 }
+
+func ExampleSelectRequest_pagination() {
+	conn := exampleConnect()
+
+	const (
+		fromTuple = 5
+		allTuples = 10
+	)
+	var tuple interface{}
+	for i := 0; i < allTuples; i++ {
+		req := crud.MakeReplaceRequest(exampleSpace).
+			Tuple([]interface{}{uint(3000 + i), nil, "bla"})
+		ret := crud.Result{}
+		if err := conn.Do(req).GetTyped(&ret); err != nil {
+			fmt.Printf("Failed to initialize the example: %s\n", err)
+			return
+		}
+		if i == fromTuple {
+			tuple = ret.Rows.([]interface{})[0]
+		}
+	}
+
+	req := crud.MakeSelectRequest(exampleSpace).
+		Opts(crud.SelectOpts{
+			First: crud.MakeOptInt(2),
+			After: crud.MakeOptTuple(tuple),
+		})
+	ret := crud.Result{}
+	if err := conn.Do(req).GetTyped(&ret); err != nil {
+		fmt.Printf("Failed to execute request: %s", err)
+		return
+	}
+	fmt.Println(ret.Metadata)
+	fmt.Println(ret.Rows)
+	// Output:
+	// [{id unsigned false} {bucket_id unsigned true} {name string false}]
+	// [[3006 32 bla] [3007 33 bla]]
+}

--- a/crud/select.go
+++ b/crud/select.go
@@ -63,9 +63,9 @@ func (opts SelectOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 	values[6], exists[6] = opts.Balance.Get()
 	values[7], exists[7] = opts.First.Get()
 	values[8], exists[8] = opts.After.Get()
-	values[8], exists[8] = opts.BatchSize.Get()
-	values[8], exists[8] = opts.ForceMapCall.Get()
-	values[8], exists[8] = opts.Fullscan.Get()
+	values[9], exists[9] = opts.BatchSize.Get()
+	values[10], exists[10] = opts.ForceMapCall.Get()
+	values[11], exists[11] = opts.Fullscan.Get()
 
 	return encodeOptions(enc, names[:], values[:], exists[:])
 }


### PR DESCRIPTION
The patch fixes a typo that made it impossible to setup `SelectOpts.After`, `SelectOpts.BatchSize` and `SelectOpts.ForceMapCall`.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Part of #320 