### PR TITLE
crud: support `operation_data` field in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - More linters on CI (#310)
 - Meaningful description for read/write socket errors (#129)
 - Support password and password file to decrypt private SSL key file (#319)
+- Support `operation_data` in `crud.Error` (#330) 
 
 ### Changed
 

--- a/crud/example_test.go
+++ b/crud/example_test.go
@@ -78,6 +78,92 @@ func ExampleResult_rowsCustomType() {
 	// [{{} 2010 45 bla}]
 }
 
+// ExampleResult_operationData demonstrates how to obtain information
+// about erroneous objects from crud.Error using `OperationData` field.
+func ExampleResult_operationData() {
+	conn := exampleConnect()
+	req := crud.MakeInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
+		crud.MapObject{
+			"id":        2,
+			"bucket_id": 3,
+			"name":      "Makar",
+		},
+		crud.MapObject{
+			"id":        2,
+			"bucket_id": 3,
+			"name":      "Vasya",
+		},
+		crud.MapObject{
+			"id":        3,
+			"bucket_id": 5,
+		},
+	})
+
+	ret := crud.Result{}
+	if err := conn.Do(req).GetTyped(&ret); err != nil {
+		crudErrs := err.(crud.ErrorMany)
+		fmt.Println("Erroneous data:")
+		for _, crudErr := range crudErrs.Errors {
+			fmt.Println(crudErr.OperationData)
+		}
+	} else {
+		fmt.Println(ret.Metadata)
+		fmt.Println(ret.Rows)
+	}
+
+	// Output:
+	// Erroneous data:
+	// [2 3 Vasya]
+	// map[bucket_id:5 id:3]
+}
+
+// ExampleResult_operationDataCustomType demonstrates the ability
+// to cast `OperationData` field, extracted from a CRUD error during decoding
+// using crud.Result, to a custom type.
+// The type of `OperationData` is determined as the crud.Result row type.
+func ExampleResult_operationDataCustomType() {
+	conn := exampleConnect()
+	req := crud.MakeInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
+		crud.MapObject{
+			"id":        1,
+			"bucket_id": 3,
+			"name":      "Makar",
+		},
+		crud.MapObject{
+			"id":        1,
+			"bucket_id": 3,
+			"name":      "Vasya",
+		},
+		crud.MapObject{
+			"id":        3,
+			"bucket_id": 5,
+		},
+	})
+
+	type Tuple struct {
+		Id       uint64 `msgpack:"id,omitempty"`
+		BucketId uint64 `msgpack:"bucket_id,omitempty"`
+		Name     string `msgpack:"name,omitempty"`
+	}
+
+	ret := crud.MakeResult(reflect.TypeOf(Tuple{}))
+	if err := conn.Do(req).GetTyped(&ret); err != nil {
+		crudErrs := err.(crud.ErrorMany)
+		fmt.Println("Erroneous data:")
+		for _, crudErr := range crudErrs.Errors {
+			operationData := crudErr.OperationData.(Tuple)
+			fmt.Println(operationData)
+		}
+	} else {
+		fmt.Println(ret.Metadata)
+		fmt.Println(ret.Rows)
+	}
+	// Output:
+	// Erroneous data:
+	// {1 3 Vasya}
+	// {3 5 }
+}
+
 // ExampleResult_many demonstrates that there is no difference in a
 // response from *ManyRequest.
 func ExampleResult_many() {

--- a/crud/result.go
+++ b/crud/result.go
@@ -137,20 +137,20 @@ func (r *Result) DecodeMsgpack(d *msgpack.Decoder) error {
 
 	var retErr error
 	if msgpackIsArray(code) {
-		var crudErr *ErrorMany
+		crudErr := newErrorMany(r.rowType)
 		if err := d.Decode(&crudErr); err != nil {
 			return err
 		}
-		if crudErr != nil {
-			retErr = *crudErr
+		retErr = *crudErr
+	} else if code != msgpcode.Nil {
+		crudErr := newError(r.rowType)
+		if err := d.Decode(&crudErr); err != nil {
+			return err
 		}
+		retErr = *crudErr
 	} else {
-		var crudErr *Error
-		if err := d.Decode(&crudErr); err != nil {
+		if err := d.DecodeNil(); err != nil {
 			return err
-		}
-		if crudErr != nil {
-			retErr = *crudErr
 		}
 	}
 

--- a/crud/result_test.go
+++ b/crud/result_test.go
@@ -1,0 +1,33 @@
+package crud_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-tarantool/v2/crud"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+func TestResult_DecodeMsgpack(t *testing.T) {
+	sampleCrudResponse := []interface{}{
+		map[string]interface{}{
+			"rows": []interface{}{"1", "2", "3"},
+		},
+		nil,
+	}
+	responses := []interface{}{sampleCrudResponse, sampleCrudResponse}
+
+	b := bytes.NewBuffer([]byte{})
+	enc := msgpack.NewEncoder(b)
+	err := enc.Encode(responses)
+	require.NoError(t, err)
+
+	var results []crud.Result
+	decoder := msgpack.NewDecoder(b)
+	err = decoder.DecodeValue(reflect.ValueOf(&results))
+	require.NoError(t, err)
+	require.Equal(t, results[0].Rows, []interface{}{"1", "2", "3"})
+	require.Equal(t, results[1].Rows, []interface{}{"1", "2", "3"})
+}


### PR DESCRIPTION
This patch adds `operation_data` decoding for the `crud.Error`.

The `operation_data` type is determined as `rowType` in `crud.Result`.

Also, according to [1], an error can contain one of the following:
- an error
- an array of errors
- nil

So the error decoding logic has been modified to consider each case, in order to avoid comparing an error to nil.

1. https://github.com/tarantool/crud/tree/master#api

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Closes #330
