### PR TITLE
api: add context to connection create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   decoded to a varbinary object (#313).
 - Use objects of the Decimal type instead of pointers (#238)
 - Use objects of the Datetime type instead of pointers (#238)
+- `connection.Connect` no longer return non-working 
+  connection objects (#136). This function now does not attempt to reconnect 
+  and tries to establish a connection only once. Function might be canceled 
+  via context. Context accepted as first argument.
+  `pool.Connect` and `pool.Add` now accept context as first argument, which 
+  user may cancel in process. If `pool.Connect` is canceled in progress, an 
+  error will be returned. All created connections will be closed.
 
 ### Deprecated
 

--- a/crud/example_test.go
+++ b/crud/example_test.go
@@ -1,6 +1,7 @@
 package crud_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -21,7 +22,9 @@ var exampleOpts = tarantool.Opts{
 }
 
 func exampleConnect() *tarantool.Connection {
-	conn, err := tarantool.Connect(exampleServer, exampleOpts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := tarantool.Connect(ctx, exampleServer, exampleOpts)
 	if err != nil {
 		panic("Connection is not established: " + err.Error())
 	}

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -108,7 +108,9 @@ var object = crud.MapObject{
 
 func connect(t testing.TB) *tarantool.Connection {
 	for i := 0; i < 10; i++ {
-		conn, err := tarantool.Connect(server, opts)
+		ctx, cancel := test_helpers.GetConnectContext()
+		conn, err := tarantool.Connect(ctx, server, opts)
+		cancel()
 		if err != nil {
 			t.Fatalf("Failed to connect: %s", err)
 		}

--- a/datetime/example_test.go
+++ b/datetime/example_test.go
@@ -9,6 +9,7 @@
 package datetime_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -23,7 +24,9 @@ func Example() {
 		User: "test",
 		Pass: "test",
 	}
-	conn, err := tarantool.Connect("127.0.0.1:3013", opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := tarantool.Connect(ctx, "127.0.0.1:3013", opts)
 	if err != nil {
 		fmt.Printf("Error in connect is %v", err)
 		return

--- a/decimal/example_test.go
+++ b/decimal/example_test.go
@@ -9,6 +9,7 @@
 package decimal_test
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -22,13 +23,13 @@ import (
 func Example() {
 	server := "127.0.0.1:3013"
 	opts := tarantool.Opts{
-		Timeout:       5 * time.Second,
-		Reconnect:     1 * time.Second,
-		MaxReconnects: 3,
-		User:          "test",
-		Pass:          "test",
+		Timeout: 5 * time.Second,
+		User:    "test",
+		Pass:    "test",
 	}
-	client, err := tarantool.Connect(server, opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	client, err := tarantool.Connect(ctx, server, opts)
+	cancel()
 	if err != nil {
 		log.Fatalf("Failed to connect: %s", err.Error())
 	}

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -1,6 +1,7 @@
 package tarantool_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -78,13 +79,13 @@ func Example_customUnpacking() {
 	// Establish a connection.
 	server := "127.0.0.1:3013"
 	opts := tarantool.Opts{
-		Timeout:       500 * time.Millisecond,
-		Reconnect:     1 * time.Second,
-		MaxReconnects: 3,
-		User:          "test",
-		Pass:          "test",
+		Timeout: 500 * time.Millisecond,
+		User:    "test",
+		Pass:    "test",
 	}
-	conn, err := tarantool.Connect(server, opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	conn, err := tarantool.Connect(ctx, server, opts)
+	cancel()
 	if err != nil {
 		log.Fatalf("Failed to connect: %s", err.Error())
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -1,15 +1,16 @@
 package tarantool
 
 import (
+	"context"
 	"net"
 	"time"
 
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-func SslDialTimeout(network, address string, timeout time.Duration,
+func SslDialContext(ctx context.Context, network, address string,
 	opts SslOpts) (connection net.Conn, err error) {
-	return sslDialTimeout(network, address, timeout, opts)
+	return sslDialContext(ctx, network, address, opts)
 }
 
 func SslCreateContext(opts SslOpts) (ctx interface{}, err error) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.7.1
 	github.com/tarantool/go-iproto v0.1.0
-	github.com/tarantool/go-openssl v0.0.8-0.20230801114713-b452431f934a
+	github.com/tarantool/go-openssl v0.0.8-0.20231004103608-336ca939d2ca
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tarantool/go-iproto v0.1.0 h1:zHN9AA8LDawT+JBD0/Nxgr/bIsWkkpDzpcMuaNPSIAQ=
 github.com/tarantool/go-iproto v0.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
-github.com/tarantool/go-openssl v0.0.8-0.20230801114713-b452431f934a h1:eeElglRXJ3xWKkHmDbeXrQWlZyQ4t3Ca1YlZsrfdXFU=
-github.com/tarantool/go-openssl v0.0.8-0.20230801114713-b452431f934a/go.mod h1:M7H4xYSbzqpW/ZRBMyH0eyqQBsnhAMfsYk5mv0yid7A=
+github.com/tarantool/go-openssl v0.0.8-0.20231004103608-336ca939d2ca h1:oOrBh73tDDyooIXajfr+0pfnM+89404ClAhJpTTHI7E=
+github.com/tarantool/go-openssl v0.0.8-0.20231004103608-336ca939d2ca/go.mod h1:M7H4xYSbzqpW/ZRBMyH0eyqQBsnhAMfsYk5mv0yid7A=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -24,7 +24,9 @@ func examplePool(roles []bool, connOpts tarantool.Opts) (*pool.ConnectionPool, e
 	if err != nil {
 		return nil, fmt.Errorf("ConnectionPool is not established")
 	}
-	connPool, err := pool.Connect(servers, connOpts)
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+	connPool, err := pool.Connect(ctx, servers, connOpts)
 	if err != nil || connPool == nil {
 		return nil, fmt.Errorf("ConnectionPool is not established")
 	}

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -1,6 +1,7 @@
 package queue_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -164,7 +165,9 @@ func Example_connectionPool() {
 		CheckTimeout:      5 * time.Second,
 		ConnectionHandler: h,
 	}
-	connPool, err := pool.ConnectWithOpts(servers, connOpts, poolOpts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	connPool, err := pool.ConnectWithOpts(ctx, servers, connOpts, poolOpts)
 	if err != nil {
 		fmt.Printf("Unable to connect to the pool: %s", err)
 		return

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -9,6 +9,7 @@
 package queue_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -55,7 +56,9 @@ func Example_simpleQueueCustomMsgPack() {
 		User:          "test",
 		Pass:          "test",
 	}
-	conn, err := tarantool.Connect("127.0.0.1:3013", opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	conn, err := tarantool.Connect(ctx, "127.0.0.1:3013", opts)
+	cancel()
 	if err != nil {
 		log.Fatalf("connection: %s", err)
 		return

--- a/queue/example_test.go
+++ b/queue/example_test.go
@@ -9,6 +9,7 @@
 package queue_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -31,7 +32,9 @@ func Example_simpleQueue() {
 		Pass:    "test",
 	}
 
-	conn, err := tarantool.Connect("127.0.0.1:3013", opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := tarantool.Connect(ctx, "127.0.0.1:3013", opts)
 	if err != nil {
 		fmt.Printf("error in prepare is %v", err)
 		return

--- a/settings/example_test.go
+++ b/settings/example_test.go
@@ -1,7 +1,9 @@
 package settings_test
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/tarantool/go-tarantool/v2"
 	"github.com/tarantool/go-tarantool/v2/settings"
@@ -9,7 +11,9 @@ import (
 )
 
 func example_connect(opts tarantool.Opts) *tarantool.Connection {
-	conn, err := tarantool.Connect(server, opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	conn, err := tarantool.Connect(ctx, server, opts)
 	if err != nil {
 		panic("Connection is not established: " + err.Error())
 	}

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -460,9 +460,12 @@ func TestGracefulShutdownCloseConcurrent(t *testing.T) {
 		go func(i int) {
 			defer caseWg.Done()
 
+			ctx, cancel := test_helpers.GetConnectContext()
+			defer cancel()
+
 			// Do not wait till Tarantool register out watcher,
 			// test everything is ok even on async.
-			conn, err := Connect(shtdnServer, shtdnClntOpts)
+			conn, err := Connect(ctx, shtdnServer, shtdnClntOpts)
 			if err != nil {
 				t.Errorf("Failed to connect: %s", err)
 			} else {

--- a/ssl.go
+++ b/ssl.go
@@ -5,24 +5,24 @@ package tarantool
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io/ioutil"
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/tarantool/go-openssl"
 )
 
-func sslDialTimeout(network, address string, timeout time.Duration,
+func sslDialContext(ctx context.Context, network, address string,
 	opts SslOpts) (connection net.Conn, err error) {
-	var ctx interface{}
-	if ctx, err = sslCreateContext(opts); err != nil {
+	var sslCtx interface{}
+	if sslCtx, err = sslCreateContext(opts); err != nil {
 		return
 	}
 
-	return openssl.DialTimeout(network, address, timeout, ctx.(*openssl.Ctx), 0)
+	return openssl.DialContext(ctx, network, address, sslCtx.(*openssl.Ctx), 0)
 }
 
 // interface{} is a hack. It helps to avoid dependency of go-openssl in build

--- a/ssl_disable.go
+++ b/ssl_disable.go
@@ -4,12 +4,12 @@
 package tarantool
 
 import (
+	"context"
 	"errors"
 	"net"
-	"time"
 )
 
-func sslDialTimeout(network, address string, timeout time.Duration,
+func sslDialContext(ctx context.Context, network, address string,
 	opts SslOpts) (connection net.Conn, err error) {
 	return nil, errors.New("SSL support is disabled.")
 }

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -11,6 +11,7 @@
 package test_helpers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -97,7 +98,9 @@ func isReady(server string, opts *tarantool.Opts) error {
 	var conn *tarantool.Connection
 	var resp *tarantool.Response
 
-	conn, err = tarantool.Connect(server, *opts)
+	ctx, cancel := GetConnectContext()
+	defer cancel()
+	conn, err = tarantool.Connect(ctx, server, *opts)
 	if err != nil {
 		return err
 	}
@@ -401,4 +404,8 @@ func ConvertUint64(v interface{}) (result uint64, err error) {
 		err = fmt.Errorf("non-number value %T", v)
 	}
 	return
+}
+
+func GetConnectContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 500*time.Millisecond)
 }

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -17,7 +17,9 @@ func ConnectWithValidation(t testing.TB,
 	opts tarantool.Opts) *tarantool.Connection {
 	t.Helper()
 
-	conn, err := tarantool.Connect(server, opts)
+	ctx, cancel := GetConnectContext()
+	defer cancel()
+	conn, err := tarantool.Connect(ctx, server, opts)
 	if err != nil {
 		t.Fatalf("Failed to connect: %s", err.Error())
 	}

--- a/uuid/example_test.go
+++ b/uuid/example_test.go
@@ -9,8 +9,10 @@
 package uuid_test
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/tarantool/go-tarantool/v2"
@@ -25,7 +27,9 @@ func Example() {
 		User: "test",
 		Pass: "test",
 	}
-	client, err := tarantool.Connect("127.0.0.1:3013", opts)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	client, err := tarantool.Connect(ctx, "127.0.0.1:3013", opts)
+	cancel()
 	if err != nil {
 		log.Fatalf("Failed to connect: %s", err.Error())
 	}


### PR DESCRIPTION
`connection.Connect` and `pool.Connect` no longer return non-working connection objects. Those functions now accept context as their first arguments, which user may cancel in process.

`connection.Connect` will block until either the working connection created (and returned), `opts.MaxReconnects` creation attempts were made (returns error) or the context is canceled by user (returns error too).

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Closes #136
