### PR TITLE
crud: change timeout option type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - `iproto.Feature` type now used instead of `ProtocolFeature` (#337)
 - `iproto.IPROTO_FEATURE_` constants now used instead of local `Feature` 
   constants for `protocol` (#337)
+- Change `crud` operations `Timeout` option type to `crud.OptFloat64`
+  instead of `crud.OptUint` (#342)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ faster than other packages according to public benchmarks.
     * [decimal package](#decimal-package)
     * [multi package](#multi-package)
     * [pool package](#pool-package)
+    * [crud package](#crud-package)
     * [msgpack.v5](#msgpackv5)
     * [Call = Call17](#call--call17)
     * [IPROTO constants](#iproto-constants)
@@ -186,6 +187,11 @@ The subpackage has been deleted. You could use `pool` instead.
   All created connections will be closed.
 * `pool.Add` now accepts context as first argument, which user may cancel in 
   process.
+
+#### crud package
+
+* `crud` operations `Timeout` option has `crud.OptFloat64` type
+  instead of `crud.OptUint`.
 
 #### msgpack.v5
 

--- a/crud/count.go
+++ b/crud/count.go
@@ -15,7 +15,7 @@ type CountResult = NumberResult
 type CountOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString

--- a/crud/get.go
+++ b/crud/get.go
@@ -12,7 +12,7 @@ import (
 type GetOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString

--- a/crud/options.go
+++ b/crud/options.go
@@ -63,6 +63,25 @@ func (opt OptInt) Get() (int, bool) {
 	return opt.value, opt.exist
 }
 
+// OptFloat64 is an optional float64.
+type OptFloat64 struct {
+	value float64
+	exist bool
+}
+
+// MakeOptFloat64 creates an optional float64 from value.
+func MakeOptFloat64(value float64) OptFloat64 {
+	return OptFloat64{
+		value: value,
+		exist: true,
+	}
+}
+
+// Get returns the float64 value or an error if not present.
+func (opt OptFloat64) Get() (float64, bool) {
+	return opt.value, opt.exist
+}
+
 // OptString is an optional string.
 type OptString struct {
 	value string
@@ -120,7 +139,7 @@ func (o *OptTuple) Get() (interface{}, bool) {
 type BaseOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString
@@ -144,7 +163,7 @@ func (opts BaseOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type SimpleOperationOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString
@@ -186,7 +205,7 @@ func (opts SimpleOperationOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type SimpleOperationObjectOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString
@@ -232,7 +251,7 @@ func (opts SimpleOperationObjectOpts) EncodeMsgpack(enc *msgpack.Encoder) error 
 type OperationManyOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString
@@ -280,7 +299,7 @@ func (opts OperationManyOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type OperationObjectManyOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString
@@ -332,7 +351,7 @@ func (opts OperationObjectManyOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type BorderOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString

--- a/crud/request_test.go
+++ b/crud/request_test.go
@@ -137,7 +137,7 @@ func BenchmarkLenRequest(b *testing.B) {
 		buf.Reset()
 		req := crud.MakeLenRequest(spaceName).
 			Opts(crud.LenOpts{
-				Timeout: crud.MakeOptUint(3),
+				Timeout: crud.MakeOptFloat64(3.5),
 			})
 		if err := req.Body(nil, enc); err != nil {
 			b.Error(err)
@@ -156,7 +156,7 @@ func BenchmarkSelectRequest(b *testing.B) {
 		buf.Reset()
 		req := crud.MakeSelectRequest(spaceName).
 			Opts(crud.SelectOpts{
-				Timeout:      crud.MakeOptUint(3),
+				Timeout:      crud.MakeOptFloat64(3.5),
 				VshardRouter: crud.MakeOptString("asd"),
 				Balance:      crud.MakeOptBool(true),
 			})

--- a/crud/select.go
+++ b/crud/select.go
@@ -12,7 +12,7 @@ import (
 type SelectOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptUint
+	Timeout OptFloat64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
 	VshardRouter OptString

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -37,7 +37,7 @@ var startOpts test_helpers.StartOpts = test_helpers.StartOpts{
 	RetryTimeout: 500 * time.Millisecond,
 }
 
-var timeout = uint(1)
+var timeout = float64(1.1)
 
 var operations = []crud.Operation{
 	{
@@ -48,43 +48,43 @@ var operations = []crud.Operation{
 }
 
 var selectOpts = crud.SelectOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var countOpts = crud.CountOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var getOpts = crud.GetOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var minOpts = crud.MinOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var maxOpts = crud.MaxOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var baseOpts = crud.BaseOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var simpleOperationOpts = crud.SimpleOperationOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var simpleOperationObjectOpts = crud.SimpleOperationObjectOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var opManyOpts = crud.OperationManyOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var opObjManyOpts = crud.OperationObjectManyOpts{
-	Timeout: crud.MakeOptUint(timeout),
+	Timeout: crud.MakeOptFloat64(timeout),
 }
 
 var conditions = []crud.Condition{
@@ -815,7 +815,7 @@ func TestGetAdditionalOpts(t *testing.T) {
 	defer conn.Close()
 
 	req := crud.MakeGetRequest(spaceName).Key(key).Opts(crud.GetOpts{
-		Timeout:       crud.MakeOptUint(1),
+		Timeout:       crud.MakeOptFloat64(1.1),
 		Fields:        crud.MakeOptTuple([]interface{}{"name"}),
 		Mode:          crud.MakeOptString("read"),
 		PreferReplica: crud.MakeOptBool(true),


### PR DESCRIPTION
`Timeout` is an option supported for all crud operations using VShard API. In Lua, timeout has `number` type, so float values are allowed. Float timeouts can be useful to set the timeout less than a second. After this patch, `Timeout` will be an optional float64 instead of an optional int.

This is a breaking change.

CRUD allows to use negative timeouts. This approach does not make any sense for an operation: for example, initial schema fetch will fail. Since the module itself does not check for a negative value argument, we do not forbid it here too.

I didn't forget about:

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Closes #342