### PR TITLE
api: support `IPROTO_FEATURE_SPACE_AND_INDEX_NAMES`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -138,17 +138,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        sdk-path:
+          - 'release/linux/x86_64/1.10/'
         sdk-version:
-          - 'bundle-1.10.11-0-gf0b0e7ecf-r470'
+          - 'sdk-1.10.15-0-r598'
         coveralls: [false]
         fuzzing: [false]
         ssl: [false]
         include:
-          - sdk-version: 'bundle-2.10.0-1-gfa775b383-r486-linux-x86_64'
+          - sdk-path: 'release/linux/x86_64/2.10/'
+            sdk-version: 'sdk-gc64-2.10.8-0-r598.linux.x86_64'
             coveralls: false
             ssl: true
           - sdk-path: 'release/linux/x86_64/2.11/'
-            sdk-version: 'sdk-gc64-2.11.0-0-r577.linux.x86_64'
+            sdk-version: 'sdk-gc64-2.11.1-0-r598.linux.x86_64'
             coveralls: true
             ssl: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support `IPROTO_WATCH_ONCE` request type for Tarantool 
   version >= 3.0.0-alpha1 (#337)
 - Support `yield_every` option for crud select requests (#350)
+- Support `IPROTO_FEATURE_SPACE_AND_INDEX_NAMES` for Tarantool
+  version >= 3.0.0-alpha1 (#338). It allows to use space and index names 
+  in requests instead of their IDs.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ and user may cancel it in process.
 * `iproto.Feature` type used instead of `ProtocolFeature`.
 * `iproto.IPROTO_FEATURE_` constants used instead of local ones.
 
+#### Schema changes
+
+* `ResolveSpaceIndex` function for `SchemaResolver` interface split into two: 
+`ResolveSpace` and `ResolveIndex`. `NamesUseSupported` function added into the 
+interface to get information if the usage of space and index names in requests 
+is supported.
+* `Schema` structure no longer implements `SchemaResolver` interface.
+
 ## Contributing
 
 See [the contributing guide](CONTRIBUTING.md) for detailed instructions on how

--- a/example_test.go
+++ b/example_test.go
@@ -231,6 +231,21 @@ func ExampleSelectRequest() {
 	// response is [{{} 1111 hello world}]
 }
 
+func ExampleSelectRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewSelectRequest(spaceName)
+	req.Index(indexName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
+}
+
 func ExampleInsertRequest() {
 	conn := exampleConnect(opts)
 	defer conn.Close()
@@ -271,6 +286,20 @@ func ExampleInsertRequest() {
 	// Error <nil>
 	// Code 0
 	// Data [[32 test one]]
+}
+
+func ExampleInsertRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewInsertRequest(spaceName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
 }
 
 func ExampleDeleteRequest() {
@@ -314,6 +343,21 @@ func ExampleDeleteRequest() {
 	// Error <nil>
 	// Code 0
 	// Data [[36 test one]]
+}
+
+func ExampleDeleteRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewDeleteRequest(spaceName)
+	req.Index(indexName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
 }
 
 func ExampleReplaceRequest() {
@@ -375,6 +419,20 @@ func ExampleReplaceRequest() {
 	// Data [[13 test twelve]]
 }
 
+func ExampleReplaceRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewReplaceRequest(spaceName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
+}
+
 func ExampleUpdateRequest() {
 	conn := exampleConnect(opts)
 	defer conn.Close()
@@ -409,6 +467,21 @@ func ExampleUpdateRequest() {
 	// Output:
 	// response is []interface {}{[]interface {}{0x457, "bye", "world"}}
 	// response is []interface {}{[]interface {}{0x457, "hello", "world"}}
+}
+
+func ExampleUpdateRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewUpdateRequest(spaceName)
+	req.Index(indexName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
 }
 
 func ExampleUpsertRequest() {
@@ -450,6 +523,20 @@ func ExampleUpsertRequest() {
 	// response is []interface {}{}
 	// response is []interface {}{}
 	// response is []interface {}{[]interface {}{0x459, "first", "updated"}}
+}
+
+func ExampleUpsertRequest_spaceAndIndexNames() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	req := tarantool.NewUpsertRequest(spaceName)
+	resp, err := conn.Do(req).Get()
+
+	if err != nil {
+		fmt.Printf("Failed to execute the request: %s\n", err)
+	} else {
+		fmt.Println(resp.Data)
+	}
 }
 
 func ExampleCallRequest() {
@@ -634,6 +721,7 @@ func ExampleProtocolVersion() {
 	// Connector client protocol feature: IPROTO_FEATURE_ERROR_EXTENSION
 	// Connector client protocol feature: IPROTO_FEATURE_WATCHERS
 	// Connector client protocol feature: IPROTO_FEATURE_PAGINATION
+	// Connector client protocol feature: IPROTO_FEATURE_SPACE_AND_INDEX_NAMES
 	// Connector client protocol feature: IPROTO_FEATURE_WATCH_ONCE
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -25,39 +25,80 @@ func RefImplPingBody(enc *msgpack.Encoder) error {
 
 // RefImplSelectBody is reference implementation for filling of a select
 // request's body.
-func RefImplSelectBody(enc *msgpack.Encoder, space, index, offset, limit uint32, iterator Iter,
-	key, after interface{}, fetchPos bool) error {
-	return fillSelect(enc, space, index, offset, limit, iterator, key, after, fetchPos)
+func RefImplSelectBody(enc *msgpack.Encoder, res SchemaResolver, space, index interface{},
+	offset, limit uint32, iterator Iter, key, after interface{}, fetchPos bool) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	indexEnc, err := newIndexEncoder(res, index, spaceEnc.Id)
+	if err != nil {
+		return err
+	}
+	return fillSelect(enc, spaceEnc, indexEnc, offset, limit, iterator, key, after, fetchPos)
 }
 
 // RefImplInsertBody is reference implementation for filling of an insert
 // request's body.
-func RefImplInsertBody(enc *msgpack.Encoder, space uint32, tuple interface{}) error {
-	return fillInsert(enc, space, tuple)
+func RefImplInsertBody(enc *msgpack.Encoder, res SchemaResolver, space,
+	tuple interface{}) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	return fillInsert(enc, spaceEnc, tuple)
 }
 
 // RefImplReplaceBody is reference implementation for filling of a replace
 // request's body.
-func RefImplReplaceBody(enc *msgpack.Encoder, space uint32, tuple interface{}) error {
-	return fillInsert(enc, space, tuple)
+func RefImplReplaceBody(enc *msgpack.Encoder, res SchemaResolver, space,
+	tuple interface{}) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	return fillInsert(enc, spaceEnc, tuple)
 }
 
 // RefImplDeleteBody is reference implementation for filling of a delete
 // request's body.
-func RefImplDeleteBody(enc *msgpack.Encoder, space, index uint32, key interface{}) error {
-	return fillDelete(enc, space, index, key)
+func RefImplDeleteBody(enc *msgpack.Encoder, res SchemaResolver, space, index,
+	key interface{}) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	indexEnc, err := newIndexEncoder(res, index, spaceEnc.Id)
+	if err != nil {
+		return err
+	}
+	return fillDelete(enc, spaceEnc, indexEnc, key)
 }
 
 // RefImplUpdateBody is reference implementation for filling of an update
 // request's body.
-func RefImplUpdateBody(enc *msgpack.Encoder, space, index uint32, key, ops interface{}) error {
-	return fillUpdate(enc, space, index, key, ops)
+func RefImplUpdateBody(enc *msgpack.Encoder, res SchemaResolver, space, index,
+	key, ops interface{}) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	indexEnc, err := newIndexEncoder(res, index, spaceEnc.Id)
+	if err != nil {
+		return err
+	}
+	return fillUpdate(enc, spaceEnc, indexEnc, key, ops)
 }
 
 // RefImplUpsertBody is reference implementation for filling of an upsert
 // request's body.
-func RefImplUpsertBody(enc *msgpack.Encoder, space uint32, tuple, ops interface{}) error {
-	return fillUpsert(enc, space, tuple, ops)
+func RefImplUpsertBody(enc *msgpack.Encoder, res SchemaResolver, space,
+	tuple, ops interface{}) error {
+	spaceEnc, err := newSpaceEncoder(res, space)
+	if err != nil {
+		return err
+	}
+	return fillUpsert(enc, spaceEnc, tuple, ops)
 }
 
 // RefImplCallBody is reference implementation for filling of a call or call17

--- a/protocol.go
+++ b/protocol.go
@@ -56,6 +56,7 @@ var clientProtocolInfo ProtocolInfo = ProtocolInfo{
 		iproto.IPROTO_FEATURE_ERROR_EXTENSION,
 		iproto.IPROTO_FEATURE_WATCHERS,
 		iproto.IPROTO_FEATURE_PAGINATION,
+		iproto.IPROTO_FEATURE_SPACE_AND_INDEX_NAMES,
 		iproto.IPROTO_FEATURE_WATCH_ONCE,
 	},
 }

--- a/request_test.go
+++ b/request_test.go
@@ -387,8 +387,7 @@ func TestPingRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplPingBody(refEnc)
 	if err != nil {
-		t.Errorf("An unexpected RefImplPingBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplPingBody() error: %q", err.Error())
 	}
 
 	req := NewPingRequest()
@@ -402,8 +401,7 @@ func TestSelectRequestDefaultValues(t *testing.T) {
 	err := RefImplSelectBody(refEnc, &resolver, validSpace, defaultIndex, 0, 0xFFFFFFFF,
 		IterAll, []interface{}{}, nil, false)
 	if err != nil {
-		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplSelectBody() error %q", err.Error())
 	}
 
 	req := NewSelectRequest(validSpace)
@@ -451,8 +449,7 @@ func TestSelectRequestDefaultIteratorEqIfKey(t *testing.T) {
 	err := RefImplSelectBody(refEnc, &resolver, validSpace, defaultIndex, 0, 0xFFFFFFFF,
 		IterEq, key, nil, false)
 	if err != nil {
-		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplSelectBody() error %q", err.Error())
 	}
 
 	req := NewSelectRequest(validSpace).
@@ -469,8 +466,7 @@ func TestSelectRequestIteratorNotChangedIfKey(t *testing.T) {
 	err := RefImplSelectBody(refEnc, &resolver, validSpace, defaultIndex, 0, 0xFFFFFFFF,
 		iter, key, nil, false)
 	if err != nil {
-		t.Errorf("An unexpected RefImplSelectBody() error %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplSelectBody() error %q", err.Error())
 	}
 
 	req := NewSelectRequest(validSpace).
@@ -492,16 +488,14 @@ func TestSelectRequestSetters(t *testing.T) {
 	err := RefImplSelectBody(refEncAfterBytes, &resolver, validSpace, validIndex, offset,
 		limit, iter, key, afterBytes, true)
 	if err != nil {
-		t.Errorf("An unexpected RefImplSelectBody() error %s", err)
-		return
+		t.Fatalf("An unexpected RefImplSelectBody() error %s", err)
 	}
 
 	refEncAfterKey := msgpack.NewEncoder(&refBufAfterKey)
 	err = RefImplSelectBody(refEncAfterKey, &resolver, validSpace, validIndex, offset,
 		limit, iter, key, afterKey, true)
 	if err != nil {
-		t.Errorf("An unexpected RefImplSelectBody() error %s", err)
-		return
+		t.Fatalf("An unexpected RefImplSelectBody() error %s", err)
 	}
 
 	reqAfterBytes := NewSelectRequest(validSpace).
@@ -531,8 +525,7 @@ func TestInsertRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplInsertBody(refEnc, &resolver, validSpace, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplInsertBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplInsertBody() error: %q", err.Error())
 	}
 
 	req := NewInsertRequest(validSpace)
@@ -561,8 +554,7 @@ func TestInsertRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplInsertBody(refEnc, &resolver, validSpace, tuple)
 	if err != nil {
-		t.Errorf("An unexpected RefImplInsertBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplInsertBody() error: %q", err.Error())
 	}
 
 	req := NewInsertRequest(validSpace).
@@ -576,8 +568,7 @@ func TestReplaceRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplReplaceBody(refEnc, &resolver, validSpace, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplReplaceBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplReplaceBody() error: %q", err.Error())
 	}
 
 	req := NewReplaceRequest(validSpace)
@@ -592,8 +583,7 @@ func TestReplaceRequestSpaceByName(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplReplaceBody(refEnc, &resolver, "valid", []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplReplaceBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplReplaceBody() error: %q", err.Error())
 	}
 
 	req := NewReplaceRequest("valid")
@@ -607,8 +597,7 @@ func TestReplaceRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplReplaceBody(refEnc, &resolver, validSpace, tuple)
 	if err != nil {
-		t.Errorf("An unexpected RefImplReplaceBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplReplaceBody() error: %q", err.Error())
 	}
 
 	req := NewReplaceRequest(validSpace).
@@ -622,8 +611,7 @@ func TestDeleteRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplDeleteBody(refEnc, &resolver, validSpace, defaultIndex, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplDeleteBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplDeleteBody() error: %q", err.Error())
 	}
 
 	req := NewDeleteRequest(validSpace)
@@ -668,8 +656,7 @@ func TestDeleteRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplDeleteBody(refEnc, &resolver, validSpace, validIndex, key)
 	if err != nil {
-		t.Errorf("An unexpected RefImplDeleteBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplDeleteBody() error: %q", err.Error())
 	}
 
 	req := NewDeleteRequest(validSpace).
@@ -685,8 +672,7 @@ func TestUpdateRequestDefaultValues(t *testing.T) {
 	err := RefImplUpdateBody(refEnc, &resolver, validSpace, defaultIndex,
 		[]interface{}{}, []Op{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplUpdateBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplUpdateBody() error: %q", err.Error())
 	}
 
 	req := NewUpdateRequest(validSpace)
@@ -734,8 +720,7 @@ func TestUpdateRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplUpdateBody(refEnc, &resolver, validSpace, validIndex, key, refOps)
 	if err != nil {
-		t.Errorf("An unexpected RefImplUpdateBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplUpdateBody() error: %q", err.Error())
 	}
 
 	req := NewUpdateRequest(validSpace).
@@ -751,8 +736,7 @@ func TestUpsertRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplUpsertBody(refEnc, &resolver, validSpace, []interface{}{}, []Op{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplUpsertBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplUpsertBody() error: %q", err.Error())
 	}
 
 	req := NewUpsertRequest(validSpace)
@@ -782,8 +766,7 @@ func TestUpsertRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplUpsertBody(refEnc, &resolver, validSpace, tuple, refOps)
 	if err != nil {
-		t.Errorf("An unexpected RefImplUpsertBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplUpsertBody() error: %q", err.Error())
 	}
 
 	req := NewUpsertRequest(validSpace).
@@ -798,8 +781,7 @@ func TestCallRequestsDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplCallBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCallBody() error: %q", err.Error())
 	}
 
 	req := NewCallRequest(validExpr)
@@ -817,8 +799,7 @@ func TestCallRequestsSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplCallBody(refEnc, validExpr, args)
 	if err != nil {
-		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCallBody() error: %q", err.Error())
 	}
 
 	req := NewCallRequest(validExpr).
@@ -838,8 +819,7 @@ func TestEvalRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplEvalBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplEvalBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplEvalBody() error: %q", err.Error())
 	}
 
 	req := NewEvalRequest(validExpr)
@@ -853,8 +833,7 @@ func TestEvalRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplEvalBody(refEnc, validExpr, args)
 	if err != nil {
-		t.Errorf("An unexpected RefImplEvalBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplEvalBody() error: %q", err.Error())
 	}
 
 	req := NewEvalRequest(validExpr).
@@ -868,8 +847,7 @@ func TestExecuteRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplExecuteBody(refEnc, validExpr, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplExecuteBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplExecuteBody() error: %q", err.Error())
 	}
 
 	req := NewExecuteRequest(validExpr)
@@ -883,8 +861,7 @@ func TestExecuteRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplExecuteBody(refEnc, validExpr, args)
 	if err != nil {
-		t.Errorf("An unexpected RefImplExecuteBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplExecuteBody() error: %q", err.Error())
 	}
 
 	req := NewExecuteRequest(validExpr).
@@ -898,8 +875,7 @@ func TestPrepareRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplPrepareBody(refEnc, validExpr)
 	if err != nil {
-		t.Errorf("An unexpected RefImplPrepareBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplPrepareBody() error: %q", err.Error())
 	}
 
 	req := NewPrepareRequest(validExpr)
@@ -912,8 +888,7 @@ func TestUnprepareRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplUnprepareBody(refEnc, *validStmt)
 	if err != nil {
-		t.Errorf("An unexpected RefImplUnprepareBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplUnprepareBody() error: %q", err.Error())
 	}
 
 	req := NewUnprepareRequest(validStmt)
@@ -928,8 +903,7 @@ func TestExecutePreparedRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplExecutePreparedBody(refEnc, *validStmt, args)
 	if err != nil {
-		t.Errorf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
 	}
 
 	req := NewExecutePreparedRequest(validStmt).
@@ -944,8 +918,7 @@ func TestExecutePreparedRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplExecutePreparedBody(refEnc, *validStmt, []interface{}{})
 	if err != nil {
-		t.Errorf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplExecutePreparedBody() error: %q", err.Error())
 	}
 
 	req := NewExecutePreparedRequest(validStmt)
@@ -959,8 +932,7 @@ func TestBeginRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplBeginBody(refEnc, defaultIsolationLevel, defaultTimeout)
 	if err != nil {
-		t.Errorf("An unexpected RefImplBeginBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplBeginBody() error: %q", err.Error())
 	}
 
 	req := NewBeginRequest()
@@ -973,8 +945,7 @@ func TestBeginRequestSetters(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplBeginBody(refEnc, ReadConfirmedLevel, validTimeout)
 	if err != nil {
-		t.Errorf("An unexpected RefImplBeginBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplBeginBody() error: %q", err.Error())
 	}
 
 	req := NewBeginRequest().TxnIsolation(ReadConfirmedLevel).Timeout(validTimeout)
@@ -987,8 +958,7 @@ func TestCommitRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplCommitBody(refEnc)
 	if err != nil {
-		t.Errorf("An unexpected RefImplCommitBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCommitBody() error: %q", err.Error())
 	}
 
 	req := NewCommitRequest()
@@ -1001,8 +971,7 @@ func TestRollbackRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplRollbackBody(refEnc)
 	if err != nil {
-		t.Errorf("An unexpected RefImplRollbackBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplRollbackBody() error: %q", err.Error())
 	}
 
 	req := NewRollbackRequest()
@@ -1016,8 +985,7 @@ func TestBroadcastRequestDefaultValues(t *testing.T) {
 	expectedArgs := []interface{}{validKey}
 	err := RefImplCallBody(refEnc, "box.broadcast", expectedArgs)
 	if err != nil {
-		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCallBody() error: %q", err.Error())
 	}
 
 	req := NewBroadcastRequest(validKey)
@@ -1032,8 +1000,7 @@ func TestBroadcastRequestSetters(t *testing.T) {
 	expectedArgs := []interface{}{validKey, value}
 	err := RefImplCallBody(refEnc, "box.broadcast", expectedArgs)
 	if err != nil {
-		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCallBody() error: %q", err.Error())
 	}
 
 	req := NewBroadcastRequest(validKey).Value(value)
@@ -1046,8 +1013,7 @@ func TestWatchOnceRequestDefaultValues(t *testing.T) {
 	refEnc := msgpack.NewEncoder(&refBuf)
 	err := RefImplWatchOnceBody(refEnc, validKey)
 	if err != nil {
-		t.Errorf("An unexpected RefImplCallBody() error: %q", err.Error())
-		return
+		t.Fatalf("An unexpected RefImplCallBody() error: %q", err.Error())
 	}
 
 	req := NewWatchOnceRequest(validKey)

--- a/settings/request_test.go
+++ b/settings/request_test.go
@@ -16,24 +16,16 @@ import (
 type ValidSchemeResolver struct {
 }
 
-func (*ValidSchemeResolver) ResolveSpaceIndex(s, i interface{}) (uint32, uint32, error) {
-	var spaceNo, indexNo uint32
-	if s == nil {
-		if s == "_session_settings" {
-			spaceNo = 380
-		} else {
-			spaceNo = uint32(s.(int))
-		}
-	} else {
-		spaceNo = 0
-	}
-	if i != nil {
-		indexNo = uint32(i.(int))
-	} else {
-		indexNo = 0
-	}
+func (*ValidSchemeResolver) ResolveSpace(s interface{}) (uint32, error) {
+	return 0, nil
+}
 
-	return spaceNo, indexNo, nil
+func (*ValidSchemeResolver) ResolveIndex(i interface{}, spaceNo uint32) (uint32, error) {
+	return 0, nil
+}
+
+func (r *ValidSchemeResolver) NamesUseSupported() bool {
+	return false
 }
 
 var resolver ValidSchemeResolver


### PR DESCRIPTION
Support `IPROTO_FEATURE_SPACE_AND_INDEX_NAMES` for Tarantool version >= 3.0.0-alpha1. It allows to use space and index names in requests instead of their IDs.

`ResolveSpaceIndex` function for `SchemaResolver` interface split into two: `ResolveSpace` and `ResolveIndex`. `NamesUseSupported` function added into the interface to get information if usage of space and index names is supported.

`Schema` structure no longer implements `SchemaResolver` interface.

Update Tarantool EE version 1.10.11 to 1.10.15, 2.10.0 to 2.10.8 and 2.11.0 to 2.11.1. This was done because of the one flacking test: https://github.com/tarantool/go-tarantool/actions/runs/6805504621/job/18505152412

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Closes #338
