### PR TITLE
doc: rename NewDatetime to MakeDatetime in comments

### DIFF
--- a/datetime/datetime.go
+++ b/datetime/datetime.go
@@ -101,7 +101,7 @@ const (
 // [-12 * 60 * 60, 14 * 60 * 60].
 //
 // NOTE: Tarantool's datetime.tz value is picked from t.Location().String().
-// "Local" location is unsupported, see ExampleNewDatetime_localUnsupported.
+// "Local" location is unsupported, see ExampleMakeDatetime_localUnsupported.
 func MakeDatetime(t time.Time) (Datetime, error) {
 	dt := Datetime{}
 	seconds := t.Unix()
@@ -253,7 +253,7 @@ func datetimeEncoder(e *msgpack.Encoder, v reflect.Value) ([]byte, error) {
 	zone := tm.Location().String()
 	_, offset := tm.Zone()
 	if zone != NoTimezone {
-		// The zone value already checked in NewDatetime() or
+		// The zone value already checked in MakeDatetime() or
 		// UnmarshalMsgpack() calls.
 		dt.tzIndex = int16(timezoneToIndex[zone])
 	}


### PR DESCRIPTION
Since NewDatetime was renamed to MakeDatetime, I renamed it in the comment section too. 
I didn't forget about (remove if it is not applicable):

- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)
