### PR TITLE
crud: support yield_every in select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support `crud.schema` request (#336)
 - Support `IPROTO_WATCH_ONCE` request type for Tarantool 
   version >= 3.0.0-alpha1 (#337)
+- Support `yield_every` option for crud select requests (#350)
 
 ### Changed
 

--- a/crud/count.go
+++ b/crud/count.go
@@ -29,6 +29,7 @@ type CountOpts struct {
 	// load balancing policy.
 	Balance OptBool
 	// YieldEvery describes number of tuples processed to yield after.
+	// Should be positive.
 	YieldEvery OptUint
 	// BucketId is a bucket ID.
 	BucketId OptUint

--- a/crud/options.go
+++ b/crud/options.go
@@ -23,6 +23,7 @@ const (
 	batchSizeOptName                     = "batch_size"
 	fetchLatestMetadataOptName           = "fetch_latest_metadata"
 	noreturnOptName                      = "noreturn"
+	yieldEvery                           = "yield_every"
 )
 
 // OptUint is an optional uint.

--- a/crud/select.go
+++ b/crud/select.go
@@ -46,17 +46,21 @@ type SelectOpts struct {
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
 	FetchLatestMetadata OptBool
+	// YieldEvery describes number of tuples processed to yield after.
+	// Should be positive.
+	YieldEvery OptUint
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
 func (opts SelectOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
-	const optsCnt = 13
+	const optsCnt = 14
 
 	names := [optsCnt]string{timeoutOptName, vshardRouterOptName,
 		fieldsOptName, bucketIdOptName,
 		modeOptName, preferReplicaOptName, balanceOptName,
 		firstOptName, afterOptName, batchSizeOptName,
-		forceMapCallOptName, fullscanOptName, fetchLatestMetadataOptName}
+		forceMapCallOptName, fullscanOptName, fetchLatestMetadataOptName,
+		yieldEveryOptName}
 	values := [optsCnt]interface{}{}
 	exists := [optsCnt]bool{}
 	values[0], exists[0] = opts.Timeout.Get()
@@ -72,6 +76,7 @@ func (opts SelectOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 	values[10], exists[10] = opts.ForceMapCall.Get()
 	values[11], exists[11] = opts.Fullscan.Get()
 	values[12], exists[12] = opts.FetchLatestMetadata.Get()
+	values[13], exists[13] = opts.YieldEvery.Get()
 
 	return encodeOptions(enc, names[:], values[:], exists[:])
 }

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -1333,6 +1333,40 @@ func TestUnitEmptySchema(t *testing.T) {
 	require.Equal(t, result.Value, crud.Schema{}, "empty schema expected")
 }
 
+var testStorageYieldCases = []struct {
+	name string
+	req  tarantool.Request
+}{
+	{
+		"Count",
+		crud.MakeCountRequest(spaceName).
+			Opts(crud.CountOpts{
+				YieldEvery: crud.MakeOptUint(500),
+			}),
+	},
+	{
+		"Select",
+		crud.MakeSelectRequest(spaceName).
+			Opts(crud.SelectOpts{
+				YieldEvery: crud.MakeOptUint(500),
+			}),
+	},
+}
+
+func TestYieldEveryOption(t *testing.T) {
+	conn := connect(t)
+	defer conn.Close()
+
+	for _, testCase := range testStorageYieldCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := conn.Do(testCase.req).Get()
+			if err != nil {
+				t.Fatalf("Failed to Do CRUD request: %s", err)
+			}
+		})
+	}
+}
+
 // runTestMain is a body of TestMain function
 // (see https://pkg.go.dev/testing#hdr-Main).
 // Using defer + os.Exit is not works so TestMain body


### PR DESCRIPTION
`yield_every` was introduced to crud.count and crud.select in crud 1.1.1 [1]. The option is already supported for count requests, but select request misses it. This patch adds the option.

1. https://github.com/tarantool/crud/releases/tag/1.1.1

I didn't forget about:

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)