### PR TITLE
api: write a connection schema getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Support `IPROTO_FEATURE_SPACE_AND_INDEX_NAMES` for Tarantool
   version >= 3.0.0-alpha1 (#338). It allows to use space and index names 
   in requests instead of their IDs.
+- `GetSchema` function to get the actual schema (#7)
 
 ### Changed
 
@@ -51,6 +52,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   instead of `crud.OptUint` (#342)
 - Change all `Upsert` and `Update` requests to accept `*tarantool.Operations` 
   as `ops` parameters instead of `interface{}` (#348)
+- Change `OverrideSchema(*Schema)` to `SetSchema(Schema)` (#7)
+- Change values, stored by pointers in the `Schema`, `Space`, `Index` structs, 
+  to be stored by their values (#7)
 
 ### Deprecated
 
@@ -70,6 +74,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - UUID_extId (#158)
 - IPROTO constants (#158)
 - Code() method from the Request interface (#158)
+- `Schema` field from the `Connection` struct (#7)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,13 @@ now does not attempt to reconnect and tries to establish a connection only once.
 Function might be canceled via context. Context accepted as first argument, 
 and user may cancel it in process.
 
+#### Connection schema
+
+* Removed `Schema` field from the `Connection` struct. Instead, new 
+`GetSchema(Connector)` function was added to get the actual connection 
+schema on demand.
+* `OverrideSchema(*Schema)` method replaced with the `SetSchema(Schema)`.
+
 #### Protocol changes
 
 * `iproto.Feature` type used instead of `ProtocolFeature`.
@@ -260,6 +267,10 @@ and user may cancel it in process.
 interface to get information if the usage of space and index names in requests 
 is supported.
 * `Schema` structure no longer implements `SchemaResolver` interface.
+* `Spaces` and `SpacesById` fields of the `Schema` struct store spaces by value.
+* `Fields` and `FieldsById` fields of the `Space` struct store fields by value.
+`Index` and `IndexById` fields of the `Space` struct store indexes by value.
+* `Fields` field of the `Index` struct store `IndexField` by value.
 
 ## Contributing
 

--- a/example_test.go
+++ b/example_test.go
@@ -1063,7 +1063,10 @@ func ExampleSchema() {
 	conn := exampleConnect(opts)
 	defer conn.Close()
 
-	schema := conn.Schema
+	schema, err := tarantool.GetSchema(conn)
+	if err != nil {
+		fmt.Printf("unexpected error: %s\n", err.Error())
+	}
 	if schema.SpacesById == nil {
 		fmt.Println("schema.SpacesById is nil")
 	}
@@ -1080,13 +1083,30 @@ func ExampleSchema() {
 	// Space 2 ID 616 schematest
 }
 
+// Example demonstrates how to update the connection schema.
+func ExampleConnection_SetSchema() {
+	conn := exampleConnect(opts)
+	defer conn.Close()
+
+	// Get the actual schema.
+	schema, err := tarantool.GetSchema(conn)
+	if err != nil {
+		fmt.Printf("unexpected error: %s\n", err.Error())
+	}
+	// Update the current schema to match the actual one.
+	conn.SetSchema(schema)
+}
+
 // Example demonstrates how to retrieve information with space schema.
 func ExampleSpace() {
 	conn := exampleConnect(opts)
 	defer conn.Close()
 
 	// Save Schema to a local variable to avoid races
-	schema := conn.Schema
+	schema, err := tarantool.GetSchema(conn)
+	if err != nil {
+		fmt.Printf("unexpected error: %s\n", err.Error())
+	}
 	if schema.SpacesById == nil {
 		fmt.Println("schema.SpacesById is nil")
 	}
@@ -1120,7 +1140,7 @@ func ExampleSpace() {
 	// Space 1 ID 617 test memtx
 	// Space 1 ID 0 false
 	// Index 0 primary
-	// &{0 unsigned} &{2 string}
+	// {0 unsigned} {2 string}
 	// SpaceField 1 name0 unsigned
 	// SpaceField 2 name3 unsigned
 }


### PR DESCRIPTION
Write a helper function to load the actual schema for the user.

Previously we stored actual schema in a private `schemaResolver` field and `Schema` field was used only to get a current schema. But now because of the new function, we don't need to store the `Schema` as a different field. So `Schema` was also removed.

To update the schema, one needs to use `GetSchema` + `SetSchema` in pair. `SetSchema(Schema)` replacing the `OverrideSchema(*Schema)`.

`Spaces` and `SpacesById` fields of the `Schema` struct store spaces by value.
`Fields` and `FieldsById` fields of the `Space` struct store fields by value. `Index` and `IndexById` fields of the `Space` struct store indexes by value.
`Fields` field of the `Index` struct store `IndexField` by value.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Closes #7
