### PR TITLE
 api: add helper Dialer implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   the response (#237)
 - Ability to mock connections for tests (#237). Added new types `MockDoer`,
   `MockRequest` to `test_helpers`.
+- `AuthDialer` type for creating a dialer with authentication (#301)
+- `ProtocolDialer` type for creating a dialer with `ProtocolInfo` receiving and 
+  check (#301)
+- `GreetingDialer` type for creating a dialer, that fills `Greeting` of a
+  connection (#301)
 
 ### Changed
 

--- a/connection.go
+++ b/connection.go
@@ -440,7 +440,9 @@ func (conn *Connection) dial(ctx context.Context) error {
 	}
 
 	conn.addr = c.Addr()
-	conn.Greeting.Version = c.Greeting().Version
+	connGreeting := c.Greeting()
+	conn.Greeting.Version = connGreeting.Version
+	conn.Greeting.Salt = connGreeting.Salt
 	conn.serverProtocolInfo = c.ProtocolInfo()
 
 	spaceAndIndexNamesSupported :=

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -654,9 +654,8 @@ func TestOpenSslDialer_Dial_basic(t *testing.T) {
 			expectedProtocolInfo: idResponseTyped.Clone(),
 		},
 		{
-			name: "id request unsupported",
-			// Dialer sets auth.
-			expectedProtocolInfo: ProtocolInfo{Auth: ChapSha1Auth},
+			name:                 "id request unsupported",
+			expectedProtocolInfo: ProtocolInfo{},
 			isIdUnsupported:      true,
 		},
 		{
@@ -730,8 +729,9 @@ func TestOpenSslDialer_Dial_papSha256Auth(t *testing.T) {
 		Auth:     PapSha256Auth,
 	}
 
+	// Response from the server.
 	protocol := idResponseTyped.Clone()
-	protocol.Auth = PapSha256Auth
+	protocol.Auth = ChapSha1Auth
 
 	testDialer(t, l, dialer, testDialOpts{
 		expectedProtocolInfo: protocol,

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -772,6 +772,24 @@ func TestNetDialer(t *testing.T) {
 	assert.Equal([]byte{0x83, 0x00, 0xce, 0x00, 0x00, 0x00, 0x00}, buf[:7])
 }
 
+func TestNetDialer_BadUser(t *testing.T) {
+	badDialer := NetDialer{
+		Address:  server,
+		User:     "Cpt Smollett",
+		Password: "none",
+	}
+	ctx, cancel := test_helpers.GetConnectContext()
+	defer cancel()
+
+	conn, err := Connect(ctx, badDialer, opts)
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "failed to authenticate")
+	if conn != nil {
+		conn.Close()
+		t.Errorf("connection is not nil")
+	}
+}
+
 func TestFutureMultipleGetGetTyped(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
 	defer conn.Close()
@@ -3273,9 +3291,7 @@ func TestConnectionProtocolInfoUnsupported(t *testing.T) {
 	defer conn.Close()
 
 	serverProtocolInfo := conn.ProtocolInfo()
-	expected := ProtocolInfo{
-		Auth: ChapSha1Auth,
-	}
+	expected := ProtocolInfo{}
 	require.Equal(t, expected, serverProtocolInfo)
 }
 


### PR DESCRIPTION
To disable SSL by default we want to transfer `OpenSslDialer` to the go-openssl repository. In order to do so, we need to minimize the amount of copy-paste of the private functions.

`AuthDialer` is created as a dialer-wrapper, that calls authentication methods.
`ProtoDialer` is created to check the `ProtocolInfo` in the created connection.
`GreetingDialer` is created to fill the `Greeting` in the created connection.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [x] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:
Part of #301