### PR TITLE
pool: add Instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - Change `OverrideSchema(*Schema)` to `SetSchema(Schema)` (#7)
 - Change values, stored by pointers in the `Schema`, `Space`, `Index` structs, 
   to be stored by their values (#7)
-- Make `Dialer` mandatory for creation a single connection / connection pool (#321)
+- Make `Dialer` mandatory for creation a single connection (#321)
 - Remove `Connection.RemoteAddr()`, `Connection.LocalAddr()`.
   Add `Addr()` function instead (#321)
 - Remove `Connection.ClientProtocolInfo`, `Connection.ServerProtocolInfo`.
@@ -93,6 +93,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `Call`, `Call16`, `Call17`, `Eval`, `Execute` of a `Connector` and `Pooler`
   return response data instead of an actual responses (#237)
 - Renamed `StrangerResponse` to `MockResponse` (#237)
+- `pool.Connect`, `pool.ConnetcWithOpts` and `pool.Add` use a new type
+  `pool.Instance` to determinate connection options (#356)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -192,16 +192,19 @@ The subpackage has been deleted. You could use `pool` instead.
 
 * The `connection_pool` subpackage has been renamed to `pool`.
 * The type `PoolOpts` has been renamed to `Opts`.
-* `pool.Connect` now accepts context as first argument, which user may cancel
-  in process. If it is canceled in progress, an error will be returned.
-  All created connections will be closed.
-* `pool.Add` now accepts context as first argument, which user may cancel in
-  process.
-* Now you need to pass `map[string]Dialer` to the `pool.Connect` as the second
-  argument, instead of a list of addresses. Each dialer is associated with a
-  unique string ID, which allows them to be distinguished.
-* `pool.GetPoolInfo` has been renamed to `pool.GetInfo`. Return type has been changed
-  to `map[string]ConnectionInfo`.
+* `pool.Connect` and `pool.ConnectWithOpts`  now accept context as the first
+  argument, which user may cancel in process. If it is canceled in progress,
+  an error will be returned and all created connections will be closed.
+* `pool.Connect` and `pool.ConnectWithOpts` now accept `[]pool.Instance` as
+  the second argument instead of a list of addresses. Each instance is
+  associated with a unique string name, `Dialer` and connection options which
+  allows instances to be independently configured.
+* `pool.Add` now accepts context as the first argument, which user may cancel
+  in process.
+* `pool.Add` now accepts `pool.Instance` as the second argument instead of
+  an address, it allows to configure a new instance more flexible.
+* `pool.GetPoolInfo` has been renamed to `pool.GetInfo`. Return type has been
+  changed to `map[string]ConnectionInfo`.
 * Operations `Ping`, `Select`, `Insert`, `Replace`, `Delete`, `Update`, `Upsert`,
   `Call`, `Call16`, `Call17`, `Eval`, `Execute` of a `Pooler` return
   response data instead of an actual responses.

--- a/pool/round_robin.go
+++ b/pool/round_robin.go
@@ -24,7 +24,7 @@ func newRoundRobinStrategy(size int) *roundRobinStrategy {
 	}
 }
 
-func (r *roundRobinStrategy) GetConnById(id string) *tarantool.Connection {
+func (r *roundRobinStrategy) GetConnection(id string) *tarantool.Connection {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -36,7 +36,7 @@ func (r *roundRobinStrategy) GetConnById(id string) *tarantool.Connection {
 	return r.conns[index]
 }
 
-func (r *roundRobinStrategy) DeleteConnById(id string) *tarantool.Connection {
+func (r *roundRobinStrategy) DeleteConnection(id string) *tarantool.Connection {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
@@ -93,7 +93,7 @@ func (r *roundRobinStrategy) GetConnections() map[string]*tarantool.Connection {
 	return conns
 }
 
-func (r *roundRobinStrategy) AddConn(id string, conn *tarantool.Connection) {
+func (r *roundRobinStrategy) AddConnection(id string, conn *tarantool.Connection) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 

--- a/pool/round_robin_test.go
+++ b/pool/round_robin_test.go
@@ -18,11 +18,11 @@ func TestRoundRobinAddDelete(t *testing.T) {
 	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
 
 	for i, addr := range addrs {
-		rr.AddConn(addr, conns[i])
+		rr.AddConnection(addr, conns[i])
 	}
 
 	for i, addr := range addrs {
-		if conn := rr.DeleteConnById(addr); conn != conns[i] {
+		if conn := rr.DeleteConnection(addr); conn != conns[i] {
 			t.Errorf("Unexpected connection on address %s", addr)
 		}
 	}
@@ -37,16 +37,16 @@ func TestRoundRobinAddDuplicateDelete(t *testing.T) {
 	conn1 := &tarantool.Connection{}
 	conn2 := &tarantool.Connection{}
 
-	rr.AddConn(validAddr1, conn1)
-	rr.AddConn(validAddr1, conn2)
+	rr.AddConnection(validAddr1, conn1)
+	rr.AddConnection(validAddr1, conn2)
 
-	if rr.DeleteConnById(validAddr1) != conn2 {
+	if rr.DeleteConnection(validAddr1) != conn2 {
 		t.Errorf("Unexpected deleted connection")
 	}
 	if !rr.IsEmpty() {
 		t.Errorf("RoundRobin does not empty")
 	}
-	if rr.DeleteConnById(validAddr1) != nil {
+	if rr.DeleteConnection(validAddr1) != nil {
 		t.Errorf("Unexpected value after second deletion")
 	}
 }
@@ -58,7 +58,7 @@ func TestRoundRobinGetNextConnection(t *testing.T) {
 	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
 
 	for i, addr := range addrs {
-		rr.AddConn(addr, conns[i])
+		rr.AddConnection(addr, conns[i])
 	}
 
 	expectedConns := []*tarantool.Connection{conns[0], conns[1], conns[0], conns[1]}
@@ -76,7 +76,7 @@ func TestRoundRobinStrategy_GetConnections(t *testing.T) {
 	conns := []*tarantool.Connection{&tarantool.Connection{}, &tarantool.Connection{}}
 
 	for i, addr := range addrs {
-		rr.AddConn(addr, conns[i])
+		rr.AddConnection(addr, conns[i])
 	}
 
 	rr.GetConnections()[validAddr2] = conns[0] // GetConnections() returns a copy.


### PR DESCRIPTION
The type Instance:
```Go
type Instance struct {
	// Name is an unique name of the instance.
	Name   string
	// Dialer will be used to create a connection to the instance.
	Dialer tarantool.Dialer
	// Opts will be used to specify a connection options.
	Opts   tarantool.Opts
}
```

The type allows to specify a dialer and connection options per a pool instance. It is used in `pool.Connect`, `pool.ConnectWithOpts` and `pool.Add` to specify an instance configuration now.

Closes https://github.com/tarantool/go-tarantool/issues/356