### PR TITLE
pool: add a new method `Pool.DoInstance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   check (#301)
 - `GreetingDialer` type for creating a dialer, that fills `Greeting` of a
   connection (#301)
+- New method `Pool.DoInstance` to execute a request on a target instance in
+  a pool (#376).
 
 ### Changed
 

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -1002,6 +1002,16 @@ func (p *ConnectionPool) Do(req tarantool.Request, userMode Mode) *tarantool.Fut
 	return conn.Do(req)
 }
 
+// DoInstance sends the request into a target instance and returns a future.
+func (p *ConnectionPool) DoInstance(req tarantool.Request, name string) *tarantool.Future {
+	conn := p.anyPool.GetConnection(name)
+	if conn == nil {
+		return newErrorFuture(ErrNoHealthyInstance)
+	}
+
+	return conn.Do(req)
+}
+
 //
 // private
 //


### PR DESCRIPTION
The method allows to execute a request on the target instance in a pool.

Closes #376
