### PR TITLE
go: bump go to 1.20

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup golang for connector and tests
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: '1.20'
 
       - name: Setup tt
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         golang:
-          - 1.13
+          - '1.20'
+          - 'stable'
         tarantool:
           - '1.10'
           - '2.8'
@@ -40,10 +41,10 @@ jobs:
         include:
           - tarantool: 'master'
             coveralls: true
-            golang: 1.13
+            golang: '1.20'
           - tarantool: 'master'
             fuzzing: true
-            golang: 1.18
+            golang: '1.20'
             coveralls: false
 
     steps:
@@ -132,7 +133,8 @@ jobs:
       fail-fast: false
       matrix:
         golang:
-          - 1.13
+          - '1.20'
+          - 'stable'
         runs-on:
           - macos-11
           - macos-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `pool.Instance` to determinate connection options (#356)
 - `pool.Connect`, `pool.ConnectWithOpts` and `pool.Add` add connections to
   the pool even it is unable to connect to it (#372)
+- Required Go version from `1.11` to `1.20` (#378)
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ coverage:
 .PHONY: coveralls
 coveralls: coverage
 	go get github.com/mattn/goveralls
+	go install github.com/mattn/goveralls
 	goveralls -coverprofile=$(COVERAGE_FILE) -service=github
 
 .PHONY: bench-deps
@@ -122,14 +123,9 @@ ${BENCH_PATH} bench-deps:
 	rm -rf ${BENCH_PATH}
 	mkdir ${BENCH_PATH}
 	go clean -testcache
-	# It is unable to build a latest version of benchstat with go 1.13. So
-	# we need to switch to an old commit.
 	cd ${BENCH_PATH} && \
-		git clone https://go.googlesource.com/perf && \
-		cd perf && \
-		git checkout 91a04616dc65ba76dbe9e5cf746b923b1402d303 && \
-		go install ./cmd/benchstat
-	rm -rf ${BENCH_PATH}/perf
+		go get golang.org/x/perf/cmd/benchstat
+		go install golang.org/x/perf/cmd/benchstat
 
 .PHONY: bench
 ${BENCH_FILE} bench: ${BENCH_PATH}

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ faster than other packages according to public benchmarks.
 We assume that you have Tarantool version 1.10+ and a modern Linux or BSD
 operating system.
 
-You need a current version of `go`, version 1.13 or later (use `go version` to
+You need a current version of `go`, version 1.20 or later (use `go version` to
 check the version number). Do not use `gccgo-go`.
 
-**Note:** If your `go` version is older than 1.13 or if `go` is not installed,
+**Note:** If your `go` version is older than 1.20 or if `go` is not installed,
 download and run the latest tarball from [golang.org][golang-dl].
 
 The package `go-tarantool` is located in [tarantool/go-tarantool][go-tarantool]
@@ -72,7 +72,7 @@ This allows us to introduce new features without losing backward compatibility.
    ```
    go_tarantool_decimal_fuzzing
    ```
-   **Note:** It crashes old Tarantool versions and requires Go 1.18+.
+   **Note:** It crashes old Tarantool versions.
 
 ## Documentation
 
@@ -222,6 +222,10 @@ is only available in Tarantool Enterprise Edition 2.10 or newer.
 ### Migration to v2
 
 The article describes migration from go-tarantool to go-tarantool/v2.
+
+#### Go version
+
+Required Go version is set to `1.20`.
 
 #### datetime package
 

--- a/connection.go
+++ b/connection.go
@@ -869,7 +869,7 @@ func (conn *Connection) eventer(events <-chan connWatchEvent) {
 			st := value.(chan watchState)
 			state := <-st
 			state.value = event.value
-			if state.version == math.MaxUint64 {
+			if state.version == math.MaxUint {
 				state.version = initWatchEventVersion + 1
 			} else {
 				state.version += 1
@@ -1277,9 +1277,8 @@ func (conn *Connection) NewStream() (*Stream, error) {
 type watchState struct {
 	// value is a current value.
 	value interface{}
-	// version is a current version of the value. The only reason for uint64:
-	// go 1.13 has no math.Uint.
-	version uint64
+	// version is a current version of the value.
+	version uint
 	// ack true if the acknowledge is already sent.
 	ack bool
 	// cnt is a count of active watchers for the key.
@@ -1292,7 +1291,7 @@ type watchState struct {
 }
 
 // initWatchEventVersion is an initial version until no events from Tarantool.
-const initWatchEventVersion uint64 = 0
+const initWatchEventVersion uint = 0
 
 // connWatcher is an internal implementation of the Watcher interface.
 type connWatcher struct {

--- a/future_test.go
+++ b/future_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -74,7 +73,7 @@ func (resp *futureMockResponse) DecodeTyped(res interface{}) error {
 }
 
 func createFutureMockResponse(header Header, body io.Reader) (Response, error) {
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tarantool/go-tarantool/v2
 
-go 1.11
+go 1.20
 
 require (
 	github.com/google/uuid v1.3.0
@@ -8,4 +8,11 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/tarantool/go-iproto v1.0.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/response.go
+++ b/response.go
@@ -3,7 +3,6 @@ package tarantool
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/tarantool/go-iproto"
 	"github.com/vmihailenco/msgpack/v5"
@@ -39,7 +38,7 @@ func createBaseResponse(header Header, body io.Reader) (baseResponse, error) {
 	if buf, ok := body.(*smallBuf); ok {
 		return baseResponse{header: header, buf: *buf}, nil
 	}
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return baseResponse{}, err
 	}

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -185,10 +184,7 @@ func StartTarantool(startOpts StartOpts) (TarantoolInstance, error) {
 	inst.Dialer = startOpts.Dialer
 
 	if startOpts.WorkDir == "" {
-		// Create work_dir for a new instance.
-		// TO DO: replace with `os.MkdirTemp` when we drop support of
-		// Go 1.16 an older
-		dir, err = ioutil.TempDir("", "work_dir")
+		dir, err = os.MkdirTemp("", "work_dir")
 		if err != nil {
 			return inst, err
 		}
@@ -305,7 +301,7 @@ func copySslCerts(dst string, sslCertsDir string) (err error) {
 }
 
 func copyDirectoryFiles(scrDir, dest string) error {
-	entries, err := ioutil.ReadDir(scrDir)
+	entries, err := os.ReadDir(scrDir)
 	if err != nil {
 		return err
 	}
@@ -324,7 +320,12 @@ func copyDirectoryFiles(scrDir, dest string) error {
 			return err
 		}
 
-		if err := os.Chmod(destPath, entry.Mode()); err != nil {
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		if err := os.Chmod(destPath, info.Mode()); err != nil {
 			return err
 		}
 	}

--- a/test_helpers/response.go
+++ b/test_helpers/response.go
@@ -3,7 +3,6 @@ package test_helpers
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/vmihailenco/msgpack/v5"
@@ -43,7 +42,7 @@ func CreateMockResponse(header tarantool.Header, body io.Reader) (*MockResponse,
 	if body == nil {
 		return &MockResponse{header: header, data: nil}, nil
 	}
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bump go version to 1.20.
Update ci to use go version 1.20 and newer.
Remove usage of the deprecated libraries.

Related issues:

Part of #378
