### PR TITLE
api: remove Future.Err()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 - `Schema` field from the `Connection` struct (#7)
 - `OkCode` and `PushCode` constants (#237)
 - SSL support (#301)
+- `Future.Err()` method (#382)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ for an `ops` field. `*Operations` needs to be used instead.
 * `Future` constructors now accept `Request` as their argument.
 * Methods `AppendPush` and `SetResponse` accepts response `Header` and data
   as their arguments.
+* Method `Err` was removed because it was causing improper error handling. You
+  You need to check an error from `Get`, `GetTyped` or `GetResponse` with
+  an addition check of a value `Response.Header().Error`, see `ExampleErrorNo`.
 
 #### Connector changes
 

--- a/future.go
+++ b/future.go
@@ -266,11 +266,3 @@ func (fut *Future) WaitChan() <-chan struct{} {
 	}
 	return fut.done
 }
-
-// Err returns error set on Future.
-// It waits for future to be set.
-// Note: it doesn't decode body, therefore decoding error are not set here.
-func (fut *Future) Err() error {
-	fut.wait()
-	return fut.err
-}


### PR DESCRIPTION
The method causes an improper error handling because it returns an error only from a client side. Therefore, it is not enough to simply check the error to find out that the request was not completed.

A user should check an error from `Future.Get()` or `Future.GetTyped()`. In addition, the user can find out whether there was an error without decoding the response body with `Future.GetResponse()`, see `ExampleErrorNo`.
