### PR TITLE
pool: fix notify on remove a connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- `ConnectionPool.Remove()` does not notify a `ConnectionHandler` after
+  an instance is already removed from the pool (#385)
+
 ## [2.0.0] - 2024-02-12
 
 There are a lot of changes in the new major version. The main ones:

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -1374,6 +1374,7 @@ func (p *ConnectionPool) controller(ctx context.Context, e *endpoint) {
 					// we need to start an another one for the shutdown.
 					go func() {
 						e.closeErr = e.conn.CloseGraceful()
+						p.handlerDeactivated(e.name, e.conn, e.role)
 						close(e.closed)
 					}()
 				} else {


### PR DESCRIPTION
ConnectionPool.Remove() does not notify a ConnectionHandler on an instance removing from the pool.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)