### PR TITLE
pool: get instance status from `WatchOnce` request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+- `execute` access for `box.info` is no longer required for ConnectionPool
+  for a Tarantool version >= 3.0.0 (#380)
+
 ### Fixed
 
 - `ConnectionPool.Remove()` does not notify a `ConnectionHandler` after

--- a/pool/config.lua
+++ b/pool/config.lua
@@ -9,6 +9,9 @@ box.once("init", function()
     box.schema.user.create('test', { password = 'test' })
     box.schema.user.grant('test', 'read,write,execute', 'universe')
 
+    box.schema.user.create('test_noexec', { password = 'test' })
+    box.schema.user.grant('test_noexec', 'read,write', 'universe')
+
     local s = box.schema.space.create('testPool', {
         id = 520,
         if_not_exists = true,

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -2591,13 +2591,7 @@ func TestConnectionDoWatchOnceRequest(t *testing.T) {
 }
 
 func TestConnectionDoWatchOnceOnEmptyKey(t *testing.T) {
-	watchOnceNotSupported, err := test_helpers.IsTarantoolVersionLess(3, 0, 0)
-	if err != nil {
-		log.Fatalf("Could not check the Tarantool version: %s", err)
-	}
-	if watchOnceNotSupported {
-		return
-	}
+	test_helpers.SkipIfWatchOnceUnsupported(t)
 
 	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
 	defer conn.Close()

--- a/test_helpers/utils.go
+++ b/test_helpers/utils.go
@@ -200,6 +200,14 @@ func SkipIfWatchOnceUnsupported(t *testing.T) {
 	SkipIfFeatureUnsupported(t, "watch once", 3, 0, 0)
 }
 
+// SkipIfWatchOnceSupported skips test run if Tarantool with WatchOnce
+// request type is used.
+func SkipIfWatchOnceSupported(t *testing.T) {
+	t.Helper()
+
+	SkipIfFeatureSupported(t, "watch once", 3, 0, 0)
+}
+
 // SkipIfCrudSpliceBroken skips test run if splice operation is broken
 // on the crud side.
 // https://github.com/tarantool/crud/issues/397


### PR DESCRIPTION
Starting from Tarantool version >= 3.0.0 `WatchOnce` requset is supported. So we can get instance status using this request instead of calling `box.info`.

This way user can add instances to the `ConnectionPool` without the `execute` access.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
Closes #380
