### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+### Fixed
+
+## [2.1.0] - 2024-03-06
+
+The small release improves the ConnectionPool. The ConnectionPool now does not
+require execute access for `box.info` from a user for Tarantool >= 3.0.0.
+
+### Changed
+
 - `execute` access for `box.info` is no longer required for ConnectionPool
   for a Tarantool version >= 3.0.0 (#380)
 


### PR DESCRIPTION
## Overview

The small release improves the ConnectionPool. The ConnectionPool is no longer required execute access for `box.info` from a user for Tarantool >= 3.0.0.

## Breaking changes

There are no breaking changes in the release.

## New features

* `execute` access for `box.info` is no longer required for ConnectionPool for a Tarantool version >= 3.0.0 (#380).

## Bugfixes

* `ConnectionPool.Remove()` does not notify a `ConnectionHandler` after an instance is already removed from the pool (#385).