### PR TITLE
ci: bump actions in reusable_testing.yml

### DIFF
--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone the go-tarantool connector
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/go-tarantool
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -34,7 +34,7 @@ jobs:
           echo "TNT_VERSION=$TNT_VERSION" >> $GITHUB_ENV
 
       - name: Setup golang for connector and tests
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20'
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4. Bump version of the `actions/setup-go` action to v5. It is needed for fixing the following GitHub warnings:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20

    The following actions uses node12 which is deprecated and will be
    forced to run on node16
