### PR TITLE
test: fix compare_box_errors invocation

### DIFF
--- a/box_error_test.go
+++ b/box_error_test.go
@@ -358,7 +358,7 @@ func TestErrorTypeInsert(t *testing.T) {
 				local tuple_err = tuple[2]
 				assert(tuple_err ~= nil)
 
-				return compare_box_errors(err, tuple_err)
+				return compare_box_errors(tuple_err, err)
 			`, testcase.ttObj, space, testcase.tuple.pk)
 
 			// In fact, compare_box_errors does not check than File and Line
@@ -400,7 +400,7 @@ func TestErrorTypeInsertTyped(t *testing.T) {
 				local tuple_err = tuple[2]
 				assert(tuple_err ~= nil)
 
-				return compare_box_errors(err, tuple_err)
+				return compare_box_errors(tuple_err, err)
 			`, testcase.ttObj, space, testcase.tuple.pk)
 
 			// In fact, compare_box_errors does not check than File and Line


### PR DESCRIPTION
The function signature is (expected, actual) so expected should be called first. It is significant as the function checks that all payload fields of expected are present in actual. The reverse inclusion is not true generally speaking.

Need for https://github.com/tarantool/tarantool/issues/9108
