### PR TITLE
test: install crud from master

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -136,11 +136,14 @@ jobs:
           - '1.20'
           - 'stable'
         runs-on:
-          - macos-11
           - macos-12
+          - macos-14
         tarantool:
           - brew
           - 1.10.15
+        exclude:
+          - runs-on: macos-14
+            tarantool: 1.10.15
 
     env:
       # Make sense only for non-brew jobs.

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 deps: clean
 	@(command -v tt > /dev/null || (echo "error: tt not found" && exit 1))
 	( cd ./queue/testdata; tt rocks install queue 1.3.0 )
-	( cd ./crud/testdata; tt rocks install crud 1.4.1 )
+	( cd ./crud/testdata; tt rocks install crud )
 
 .PHONY: datetime-timezones
 datetime-timezones:


### PR DESCRIPTION
Currently `make deps`, which is used for tests, installs specified version of `crud`. Such approach complicates integration with Tarantool: when a patch in Tarantool breaks integration with both `crud` and `go-tarantool` (because it uses `crud`), one needs to fix `crud`, then release it and then bump it to the new version in makefile of `go-tarantool`. Let's simplify this process - simply install `crud` from its master for tests. Note that such approach has a drawback - any commit in `crud` can break integration with `go-tarantool`.

The patch is intended to fix failing integration [test](https://github.com/tarantool/tarantool/actions/runs/10263183465/job/28394723156?pr=9960#step:9:1075) in `tarantool`.

Along the way, the patch drops `macOS-11` runners since they are not supported by GitHub anymore.