### PR TITLE
api: more informative request canceling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+- More informative request canceling: log the probable reason for unexpected request ID
+  and add request ID info to context done error message (#407).
+
 ### Fixed
 
 ## [2.1.0] - 2024-03-06

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"time"
 
 	"github.com/tarantool/go-iproto"
@@ -163,10 +164,10 @@ func ExamplePingRequest_Context() {
 	// Ping a Tarantool instance to check connection.
 	data, err := conn.Do(req).Get()
 	fmt.Println("Ping Resp data", data)
-	fmt.Println("Ping Error", err)
+	fmt.Println("Ping Error", regexp.MustCompile("[0-9]+").ReplaceAllString(err.Error(), "N"))
 	// Output:
 	// Ping Resp data []
-	// Ping Error context is done
+	// Ping Error context is done (request ID N)
 }
 
 func ExampleSelectRequest() {


### PR DESCRIPTION
Log the probable reason for unexpected requestId.
Add requestId info to context done error message.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
