### PR TITLE
tests: add output to a version parse error

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -136,7 +136,7 @@ jobs:
           - '1.20'
           - 'stable'
         runs-on:
-          - macos-12
+          - macos-13
           - macos-14
         tarantool:
           - brew
@@ -253,12 +253,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.golang }}
-
-      # Workaround for Mac OS 12 testrace failure
-      # https://github.com/golang/go/issues/49138
-      - name: disable MallocNanoZone for macos-12
-        run: echo "MallocNanoZone=0" >> $GITHUB_ENV
-        if: matrix.runs-on  == 'macos-12'
 
       # Workaround issue https://github.com/tarantool/tt/issues/640
       - name: Fix tt rocks

--- a/arrow/tarantool_test.go
+++ b/arrow/tarantool_test.go
@@ -35,19 +35,15 @@ var opts = tarantool.Opts{
 func TestInsert_invalid(t *testing.T) {
 	arrows := []struct {
 		arrow    string
-		expected []iproto.Error
+		expected iproto.Error
 	}{
 		{
 			"",
-			// TODO: delete iproto.ER_ARROW_IPC_DECODE, see:
-			// https://github.com/tarantool/go-tarantool/issues/415
-			[]iproto.Error{iproto.ER_INVALID_MSGPACK, iproto.ER_ARROW_IPC_DECODE},
+			iproto.ER_INVALID_MSGPACK,
 		},
 		{
 			"00",
-			// TODO: delete iproto.ER_ARROW_IPC_DECODE, see:
-			// https://github.com/tarantool/go-tarantool/issues/415
-			[]iproto.Error{iproto.ER_INVALID_MSGPACK, iproto.ER_ARROW_IPC_DECODE},
+			iproto.ER_INVALID_MSGPACK,
 		},
 		{
 			"ffffffff70000000040000009effffff0400010004000000" +
@@ -59,7 +55,7 @@ func TestInsert_invalid(t *testing.T) {
 				"00000000000000000000000000000800000000000000000000000100000001000000" +
 				"0000000000000000000000000a00140004000c0010000c0014000400060008000c00" +
 				"00000000000000000000",
-			[]iproto.Error{iproto.ER_UNSUPPORTED},
+			iproto.ER_UNSUPPORTED,
 		},
 	}
 
@@ -78,13 +74,7 @@ func TestInsert_invalid(t *testing.T) {
 			_, err = conn.Do(req).Get()
 			ttErr := err.(tarantool.Error)
 
-			require.Contains(t, a.expected, ttErr.Code)
-			// TODO: replace the check with:
-			//
-			// require.Equal(t, a.expected, ttErr.Code)
-			//
-			// See:
-			// https://github.com/tarantool/go-tarantool/issues/415
+			require.Equal(t, a.expected, ttErr.Code)
 		})
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.9.0
-	github.com/tarantool/go-iproto v1.0.1-0.20241010173538-44b6566ef267
+	github.com/tarantool/go-iproto v1.1.0
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/tarantool/go-iproto v1.0.1-0.20241010173538-44b6566ef267 h1:GenzvYfP9io9aEdZFmnopfcBOXmJg6MgBWyd4t8z4oI=
-github.com/tarantool/go-iproto v1.0.1-0.20241010173538-44b6566ef267/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
+github.com/tarantool/go-iproto v1.1.0 h1:HULVOIHsiehI+FnHfM7wMDntuzUddO09DKqu2WnFQ5A=
+github.com/tarantool/go-iproto v1.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -142,19 +142,19 @@ func IsTarantoolVersionLess(majorMin uint64, minorMin uint64, patchMin uint64) (
 	parsed := tarantoolVersionRegexp.FindStringSubmatch(string(out))
 
 	if parsed == nil {
-		return true, errors.New("regexp parse failed")
+		return true, fmt.Errorf("failed to parse output %q", out)
 	}
 
 	if major, err = atoiUint64(parsed[1]); err != nil {
-		return true, fmt.Errorf("failed to parse major: %s", err)
+		return true, fmt.Errorf("failed to parse major from output %q: %w", out, err)
 	}
 
 	if minor, err = atoiUint64(parsed[2]); err != nil {
-		return true, fmt.Errorf("failed to parse minor: %s", err)
+		return true, fmt.Errorf("failed to parse minor from output %q: %w", out, err)
 	}
 
 	if patch, err = atoiUint64(parsed[3]); err != nil {
-		return true, fmt.Errorf("failed to parse patch: %s", err)
+		return true, fmt.Errorf("failed to parse patch from output %q: %w", out, err)
 	}
 
 	if major != majorMin {


### PR DESCRIPTION
Now it is difficult to determine a reason of a `tarantool --version` parsing error. The patch adds a command output to the error to make it easier.

The patchset includes other non-critical updates:

### ci: replace macos-12 with macos-13

The macos-12 is no longer supported by GitHub.

### tests: update a negative check of MP_ARROW decoding

The patch updates a check according to a latest Tarantool 3.3.0 release

Closes #415