### PR TITLE
test: fix flaky TestAdd_Close_concurrent

### DIFF
--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -283,6 +283,13 @@ func (p *ConnectionPool) Add(ctx context.Context, instance Instance) error {
 			canceled = false
 		}
 		if canceled {
+			if p.state.get() != connectedState {
+				// If it is canceled (or could be canceled) due to a
+				// Close()/CloseGraceful() call we overwrite the error
+				// to make behavior expected.
+				err = ErrClosed
+			}
+
 			p.endsMutex.Lock()
 			delete(p.ends, instance.Name)
 			p.endsMutex.Unlock()


### PR DESCRIPTION
We need to reset an error to pool.ErrClosed in a Pool.Add() method if a pool already closed or closing in progress to make the behavior deterministic.