### PR TITLE
bugfix: schema is reset after a reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- `unable to use an index name because schema is not loaded` error after
+  a reconnect (#424).
+
 ## [v2.2.0] - 2024-12-16
 
 The release introduces the IPROTO_INSERT_ARROW request (arrow.InsertRequest)

--- a/connection.go
+++ b/connection.go
@@ -446,12 +446,13 @@ func (conn *Connection) dial(ctx context.Context) error {
 	conn.Greeting.Salt = connGreeting.Salt
 	conn.serverProtocolInfo = c.ProtocolInfo()
 
-	spaceAndIndexNamesSupported :=
-		isFeatureInSlice(iproto.IPROTO_FEATURE_SPACE_AND_INDEX_NAMES,
+	if conn.schemaResolver == nil {
+		namesSupported := isFeatureInSlice(iproto.IPROTO_FEATURE_SPACE_AND_INDEX_NAMES,
 			conn.serverProtocolInfo.Features)
 
-	conn.schemaResolver = &noSchemaResolver{
-		SpaceAndIndexNamesSupported: spaceAndIndexNamesSupported,
+		conn.schemaResolver = &noSchemaResolver{
+			SpaceAndIndexNamesSupported: namesSupported,
+		}
 	}
 
 	// Watchers.


### PR DESCRIPTION
We need to keep an existing schema resolver to avoid a schema reset after a reconnect. An another approach could be to get a schema on each reconnect, but we will change the expected behavior in this case: load a schema once on a first connect.
