### PR TITLE
pool: add GetInstances method, that returns current instances connections state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - Extend box with replication information (#427).
+- The GetConnections method has been added,
+which is necessary to monitor the current state of the pool (#428).
 
 ### Changed
 

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -1506,3 +1506,21 @@ func isFeatureInSlice(expected iproto.Feature, actualSlice []iproto.Feature) boo
 	}
 	return false
 }
+
+// GetInstances retrieves a slice of Instance objects representing the connections in the pool.
+func (p *ConnectionPool) GetInstances() []Instance {
+	p.endsMutex.Lock()
+	defer p.endsMutex.Unlock()
+
+	res := make([]Instance, 0, len(p.ends))
+
+	for _, end := range p.ends {
+		res = append(res, Instance{
+			Name:   end.name,
+			Dialer: end.dialer,
+			Opts:   end.opts,
+		})
+	}
+
+	return res
+}

--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -3449,6 +3449,27 @@ func TestWatcher_Unregister_concurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestConnectionPool_GetInstances(t *testing.T) {
+	var tCases [][]pool.Instance
+
+	tCases = append(tCases, makeInstances([]string{servers[0], servers[1]}, connOpts))
+	tCases = append(tCases, makeInstances([]string{servers[0], servers[1], servers[3]}, connOpts))
+	tCases = append(tCases, makeInstances([]string{servers[0]}, connOpts))
+
+	for _, tc := range tCases {
+		ctx, cancel := test_helpers.GetPoolConnectContext()
+		connPool, err := pool.Connect(ctx, tc)
+		cancel()
+		require.Nilf(t, err, "failed to connect")
+		require.NotNilf(t, connPool, "conn is nil after Connect")
+
+		poolInstns := connPool.GetInstances()
+		require.ElementsMatch(t, tc, poolInstns)
+		connPool.Close()
+	}
+
+}
+
 // runTestMain is a body of TestMain function
 // (see https://pkg.go.dev/testing#hdr-Main).
 // Using defer + os.Exit is not works so TestMain body


### PR DESCRIPTION
The GetConnections method has been added, which is necessary to monitor the current state of the pool. This should help implement dynamic tracking of tarantool topology changes.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [ ] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:
