### PR TITLE
pool: add Instance info to ConnectionInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 - Extend box with replication information (#427).
+- The Instance info has been added to ConnectionInfo for GetInfo response (#429).
 
 ### Changed
 

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -93,6 +93,7 @@ ConnectionInfo structure for information about connection statuses:
 type ConnectionInfo struct {
 	ConnectedNow bool
 	ConnRole     Role
+	Instance     Instance
 }
 
 /*
@@ -393,13 +394,25 @@ func (p *ConnectionPool) GetInfo() map[string]ConnectionInfo {
 		return info
 	}
 
-	for name := range p.ends {
+	for name, end := range p.ends {
 		conn, role := p.getConnectionFromPool(name)
-		if conn != nil {
-			info[name] = ConnectionInfo{ConnectedNow: conn.ConnectedNow(), ConnRole: role}
-		} else {
-			info[name] = ConnectionInfo{ConnectedNow: false, ConnRole: UnknownRole}
+
+		connInfo := ConnectionInfo{
+			ConnectedNow: false,
+			ConnRole:     UnknownRole,
+			Instance: Instance{
+				Name:   name,
+				Dialer: end.dialer,
+				Opts:   end.opts,
+			},
 		}
+
+		if conn != nil {
+			connInfo.ConnRole = role
+			connInfo.ConnectedNow = conn.ConnectedNow()
+		}
+
+		info[name] = connInfo
 	}
 
 	return info


### PR DESCRIPTION
The Instance info has been added to ConnectionInfo, which is necessary to monitor the current state of the pool. This should help implement dynamic tracking of tarantool topology changes.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [ ] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:
