### PR TITLE
pool: Pooler interface supports GetInfo method in TopologyEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
+## Unreleased
+
+### Added
+
+- GetInfo method added to Pooler TopologyEditor interface.
+
 ## [v2.3.0] - 2025-03-11
 
 The release extends box.info responses and ConnectionPool.GetInfo return data.

--- a/pool/pooler.go
+++ b/pool/pooler.go
@@ -12,6 +12,7 @@ import (
 type TopologyEditor interface {
 	Add(ctx context.Context, instance Instance) error
 	Remove(name string) error
+	GetInfo() map[string]ConnectionInfo
 }
 
 // Pooler is the interface that must be implemented by a connection pool.


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [ ] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [ ] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [ ] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues:
