### PR TITLE
api: block Connect() on failure if Reconnect > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic
 Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- Connect() now retry the connection if a failure occurs and opts.Reconnect > 0.
+  The number of attempts is equal to opts.MaxReconnects or unlimited if
+  opts.MaxReconnects == 0. Connect() blocks until a connection is established,
+  the context is cancelled, or the number of attempts is exhausted (#436).
+
+### Fixed
+
 ## [v2.3.0] - 2025-03-11
 
 The release extends box.info responses and ConnectionPool.GetInfo return data.


### PR DESCRIPTION
This patch makes Connect() retry connection attempts if opts.Reconnect is greater than 0. The delay between connection attempts is opts.Reconnect. If opts.MaxReconnects > 0 then the maximum number of attempts is equal to it, otherwise the maximum number of attempts is unlimited. Connect() now also blocks until a connection is established, provided context is cancelled or the number of attempts is exhausted.

Closes #436

What has been done? Why? What problem is being solved?

Connect() now handles connection retries on its own. This simplifies connecting to Tarantool instances when there is no guarantee that the connection will be established on the first try.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [ ] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Related issues: #436 
