### PR TITLE
api: fix panic in conn.NewWatcher()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Fixed panic when calling NewWatcher() during reconnection or after
+  connection is closed (#438).
+
 ## [v2.3.2] - 2025-04-14
 
 This release improves the logic of `Connect` and `pool.Connect` in case of a

--- a/connection.go
+++ b/connection.go
@@ -1461,7 +1461,7 @@ func (conn *Connection) NewWatcher(key string, callback WatchCallback) (Watcher,
 	// That's why we can't just check the Tarantool response for an unsupported
 	// request error.
 	if !isFeatureInSlice(iproto.IPROTO_FEATURE_WATCHERS,
-		conn.c.ProtocolInfo().Features) {
+		conn.serverProtocolInfo.Features) {
 		err := fmt.Errorf("the feature %s must be supported by connection "+
 			"to create a watcher", iproto.IPROTO_FEATURE_WATCHERS)
 		return nil, err


### PR DESCRIPTION
Before this patch, `conn.c` was not checked for `nil` before calling its method. This could cause a panic if the connection was lost or closed.

Closes #438

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues: #438
