### PR TITLE
dial: Connect() does not cancel by context if no i/o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+- Connect() may not cancel Dial() call on context expiration if network
+  connection hangs (#443).
+
 ## [v2.3.1] - 2025-04-03
 
 The patch releases fixes expected Connect() behavior and reduces allocations.
@@ -21,7 +24,7 @@ The patch releases fixes expected Connect() behavior and reduces allocations.
 ### Added
 
 - A usage of sync.Pool of msgpack.Decoder saves 2 object allocations per
-  a response decoding.
+  a response decoding (#440).
 
 ### Changed
 

--- a/connection.go
+++ b/connection.go
@@ -489,7 +489,7 @@ func (conn *Connection) dial(ctx context.Context) error {
 		}
 
 		req := newWatchRequest(key.(string))
-		if err = writeRequest(c, req); err != nil {
+		if err = writeRequest(ctx, c, req); err != nil {
 			st <- state
 			return false
 		}


### PR DESCRIPTION
NetDialer, GreetingDialer, AuthDialer and ProtocolDialer may not cancel Dial() on context expiration when network connection hangs.

The issue occurred because context wasn't properly handled during network I/O operations, potentially causing infinite waiting.

Part of TNTP-2018
