### PR TITLE
pool: fix pool.Connect if a server i/o hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,18 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+- Previously, `pool.Connect` attempted to establish a connection one after
+  another instance. It could cause the entire chain to hang if one connection
+  hanged. Now connections are established in parallel. After the first
+  successful connection, the remaining connections wait with a timeout of
+  `pool.Opts.CheckTimeout` (#444).
+
 ### Fixed
 
 - Connect() may not cancel Dial() call on context expiration if network
   connection hangs (#443).
+- pool.Connect() failed to connect to any instance if a first instance
+  connection hangs (#444).
 
 ## [v2.3.1] - 2025-04-03
 

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -3927,11 +3927,12 @@ func TestConnect_schema_update(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
 	defer conn.Close()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	for i := 0; i < 100; i++ {
 		fut := conn.Do(NewCallRequest("create_spaces"))
 
-		ctx, cancel := test_helpers.GetConnectContext()
-		defer cancel()
 		if conn, err := Connect(ctx, dialer, opts); err != nil {
 			if err.Error() != "concurrent schema update" {
 				t.Errorf("unexpected error: %s", err)


### PR DESCRIPTION
Previously, `pool.Connect` attempted to establish a connection one after another instance. It could cause the entire chain to hang if one connection hanged. Now connections are established in parallel. After the first successful connection, the remaining connections wait with a timeout of `pool.Opts.CheckTimeout`.

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #TNTP-2018