### PR TITLE
Release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+### Fixed
+
+## [v2.3.2] - 2025-04-14
+
+This release improves the logic of `Connect` and `pool.Connect` in case of a
+hung I/O connection.
+
+### Changed
+
 - Previously, `pool.Connect` attempted to establish a connection one after
   another instance. It could cause the entire chain to hang if one connection
   hanged. Now connections are established in parallel. After the first


### PR DESCRIPTION
This release improves the logic of `Connect` and `pool.Connect` in case of a hung I/O connection.

### Changed

- Previously, `pool.Connect` attempted to establish a connection one after another instance. It could cause the entire chain to hang if one connection hanged. Now connections are established in parallel. After the first successful connection, the remaining connections wait with a timeout of `pool.Opts.CheckTimeout` (#444).

### Fixed

- Connect() may not cancel Dial() call on context expiration if network connection hangs (#443).
- pool.Connect() failed to connect to any instance if a first instance connection hangs (#444).
