### PR TITLE
ci: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,22 +6,22 @@ on:
 
 jobs:
   luacheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
 
     - name: Setup Tarantool
-      uses: tarantool/setup-tarantool@v2
+      uses: tarantool/setup-tarantool@v4
       with:
-        tarantool-version: '2.8'
+        tarantool-version: '3.4'
 
     - name: Setup tt
       run: |
-        curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+        curl -L https://tarantool.io/release/3/installer.sh | sudo bash
         sudo apt install -y tt
         tt version
 
@@ -32,15 +32,15 @@ jobs:
       run: ./.rocks/bin/luacheck .
 
   golangci-lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -57,13 +57,13 @@ jobs:
           args: --out-${NO_FUTURE}format colored-line-number --config=.golangci.yaml
 
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: |
       github.event_name == 'push' ||
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
 
       - name: Install codespell
         run: pip3 install codespell

--- a/.github/workflows/reusable-run.yml
+++ b/.github/workflows/reusable-run.yml
@@ -1,0 +1,98 @@
+name: Reusable Test Run
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      tarantool-version:
+        required: true
+        type: string
+      go-version:
+        required: true
+        type: string
+      coveralls:
+        required: false
+        type: boolean
+        default: false
+      fuzzing:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  run-tests:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Clone the connector
+        uses: actions/checkout@v5
+
+      - name: Setup tt
+        run: |
+          curl -L https://tarantool.io/release/3/installer.sh | sudo bash
+          sudo apt install -y tt
+
+      - name: Setup tt environment
+        run: tt init
+
+      - name: Setup Tarantool ${{ inputs.tarantool-version }}
+        if: inputs.tarantool-version != 'master'
+        uses: tarantool/setup-tarantool@v4
+        with:
+          tarantool-version: ${{ inputs.tarantool-version }}
+
+      - name: Get Tarantool master commit
+        if: inputs.tarantool-version == 'master'
+        run: |
+          commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch master | head -c 8)
+          echo "LATEST_COMMIT=${commit_hash}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Cache Tarantool master
+        if: inputs.tarantool-version == 'master'
+        id: cache-latest
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/bin
+            ${{ github.workspace }}/include
+          key: cache-latest-${{ env.LATEST_COMMIT }}
+
+      - name: Setup Tarantool master
+        if: inputs.tarantool-version == 'master' && steps.cache-latest.outputs.cache-hit != 'true'
+        run: |
+          sudo tt install tarantool master
+
+      - name: Add Tarantool master to PATH
+        if: inputs.tarantool-version == 'master'
+        run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
+
+      - name: Setup golang for the connector and tests
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Install test dependencies
+        run: make deps
+
+      - name: Run regression tests
+        run: make test
+
+      - name: Run race tests
+        run: make testrace
+
+      - name: Run fuzzing tests
+        if: ${{ inputs.fuzzing }}
+        run: make fuzzing TAGS="go_tarantool_decimal_fuzzing"
+
+      - name: Run tests, collect code coverage data and send to Coveralls
+        if: ${{ inputs.coveralls }}
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          make coveralls
+
+      - name: Check workability of benchmark tests
+        if: inputs.go-version == 'stable'
+        run: make bench-deps bench DURATION=1x COUNT=1

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the go-tarantool connector
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/go-tarantool
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           TNT_VERSION=$(tarantool --version | grep -e '^Tarantool')
           echo "TNT_VERSION=$TNT_VERSION" >> $GITHUB_ENV
-
+п
       - name: Setup golang for connector and tests
         uses: actions/setup-go@v5
         with:
@@ -40,7 +40,7 @@ jobs:
 
       - name: Setup tt
         run: |
-          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
+          curl -L https://tarantool.io/release/3/installer.sh | sudo bash
           sudo apt install -y tt
           tt version
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,34 +8,36 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-tests-ce:
-    # We want to run on external PRs, but not on our own internal
-    # PRs as they'll be run by the push to the branch.
-    #
-    # The main trick is described here:
-    # https://github.com/Dart-Code/Dart-Code/pull/2375
-    #
-    # Also we want to run it always for manually triggered workflows.
+  run-tests-tarantool-1-10:
     if: (github.event_name == 'push') ||
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name != github.repository) ||
       (github.event_name == 'workflow_dispatch')
-
-    # We could replace it with ubuntu-latest after fixing the bug:
-    # https://github.com/tarantool/setup-tarantool/issues/37
-    runs-on: ubuntu-22.04
-
     strategy:
       fail-fast: false
       matrix:
-        golang:
-          - '1.20'
-          - 'stable'
-        tarantool:
-          - '1.10'
-          - '2.8'
-          - '2.10'
-          - 'master'
+        golang: ['1.20', 'stable']
+        tarantool: ['1.10']
+        coveralls: [false]
+        fuzzing: [false]
+    uses: ./.github/workflows/reusable-run.yml
+    with:
+      os: ubuntu-22.04
+      go-version: ${{ matrix.golang }}
+      tarantool-version: ${{ matrix.tarantool }}
+      coveralls: ${{ matrix.coveralls }}
+      fuzzing: ${{ matrix.fuzzing }}
+
+  run-tests:
+    if: (github.event_name == 'push') ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'workflow_dispatch')
+    strategy:
+      fail-fast: false
+      matrix:
+        golang: ['1.20', 'stable']
+        tarantool: ['2.11', '3.4', 'master']
         coveralls: [false]
         fuzzing: [false]
         include:
@@ -46,84 +48,13 @@ jobs:
             fuzzing: true
             golang: '1.20'
             coveralls: false
-
-    steps:
-      - name: Clone the connector
-        uses: actions/checkout@v3
-
-      - name: Setup tt
-        run: |
-          curl -L https://tarantool.io/release/2/installer.sh | sudo bash
-          sudo apt install -y tt
-
-      - name: Setup tt environment
-        run: tt init
-
-      # https://github.com/tarantool/checks/issues/64
-      - name: Install specific CMake version
-        run: pip3 install cmake==3.15.3
-
-      - name: Setup Tarantool ${{ matrix.tarantool }}
-        if: matrix.tarantool != 'master'
-        uses: tarantool/setup-tarantool@v2
-        with:
-          tarantool-version: ${{ matrix.tarantool }}
-
-      - name: Get Tarantool master commit
-        if: matrix.tarantool == 'master'
-        run: |
-          commit_hash=$(git ls-remote https://github.com/tarantool/tarantool.git --branch master | head -c 8)
-          echo "LATEST_COMMIT=${commit_hash}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Cache Tarantool master
-        if: matrix.tarantool == 'master'
-        id: cache-latest
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ github.workspace }}/bin
-            ${{ github.workspace }}/include
-          key: cache-latest-${{ env.LATEST_COMMIT }}
-
-      - name: Setup Tarantool master
-        if: matrix.tarantool == 'master' && steps.cache-latest.outputs.cache-hit != 'true'
-        run: |
-          sudo pip3 install cmake==3.15.3
-          sudo tt install tarantool master
-
-      - name: Add Tarantool master to PATH
-        if: matrix.tarantool == 'master'
-        run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
-
-      - name: Setup golang for the connector and tests
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.golang }}
-
-      - name: Install test dependencies
-        run: make deps
-
-      - name: Run regression tests
-        run: make test
-
-      - name: Run race tests
-        run: make testrace
-
-      - name: Run fuzzing tests
-        if: ${{ matrix.fuzzing }}
-        run: make fuzzing TAGS="go_tarantool_decimal_fuzzing"
-
-      - name: Run tests, collect code coverage data and send to Coveralls
-        if: ${{ matrix.coveralls }}
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          make coveralls
-
-      - name: Check workability of benchmark tests
-        if: matrix.golang == 'stable'
-        run: make bench-deps bench DURATION=1x COUNT=1
+    uses: ./.github/workflows/reusable-run.yml
+    with:
+      os: ubuntu-24.04
+      go-version: ${{ matrix.golang }}
+      tarantool-version: ${{ matrix.tarantool }}
+      coveralls: ${{ matrix.coveralls }}
+      fuzzing: ${{ matrix.fuzzing }}
 
   testing_mac_os:
     # We want to run on external PRs, but not on our own internal
@@ -165,12 +96,12 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: ${{ env.SRCDIR }}
 
       - name: Restore cache of tarantool ${{ env.T_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.T_TARDIR }}
@@ -186,7 +117,7 @@ jobs:
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Clone tarantool ${{ env.T_VERSION }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: tarantool/tarantool
           ref: ${{ env.T_VERSION }}
@@ -257,7 +188,7 @@ jobs:
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Setup golang for the connector and tests
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.golang }}
 


### PR DESCRIPTION
* Update versions of actions/checkout to v5, tarantool/setup-tarantool to v4 and actions/setup-go to v5.
* Use ubuntu-latest instead of ubuntu-22.04 if possible.

`check.yaml`:
* All jobs now run on ubuntu-latest instead of ubuntu-22.04.
* Updated actions/checkout to v5, tarantool/setup-tarantool to v4,
  and actions/setup-go to v5.
* Upgraded luacheck's Tarantool version to 3.4.

`reusable-run.yml`:
* Created a new reusable workflow to centralize testing logic, accepting
  os, tarantool-version, go-version, coveralls, and fuzzing as inputs.
* Uses actions/checkout@v5 and actions/setup-go@v5.

`reusable_testing.yml`:
* Updated actions versions and version of tt

`testing.yml`:
* Split run-tests-ce into run-tests-tarantool-1-10 (for Tarantool 1.10)
  and run-tests (for Tarantool 2.11, 3.4, and master).
* Both new jobs leverage the reusable-run.yml workflow.
* Updated actions/checkout to v5, actions/cache to v4, and actions/setup-go
  to v5.
