### PR TITLE
ci: fix actions on macOS flows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,14 +75,9 @@ jobs:
           - '1.20'
           - 'stable'
         runs-on:
-          - macos-13
           - macos-14
-        tarantool:
-          - brew
-          - 1.10.15
-        exclude:
-          - runs-on: macos-14
-            tarantool: 1.10.15
+          - macos-15
+          - macos-26
 
     env:
       # Make sense only for non-brew jobs.
@@ -101,92 +96,13 @@ jobs:
         with:
           path: ${{ env.SRCDIR }}
 
-      - name: Restore cache of tarantool ${{ env.T_VERSION }}
-        uses: actions/cache@v4
-        id: cache
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
         with:
-          path: ${{ env.T_TARDIR }}
-          key: ${{ matrix.runs-on }}-${{ matrix.tarantool }}
-        if: matrix.tarantool != 'brew'
+          cmake-version: '3.29.x'
 
       - name: Install latest tarantool from brew
         run: brew install tarantool
-        if: matrix.tarantool == 'brew'
-
-      - name: Install tarantool build dependencies
-        run: brew install autoconf automake libtool openssl@1.1
-        if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
-
-      - name: Clone tarantool ${{ env.T_VERSION }}
-        uses: actions/checkout@v5
-        with:
-          repository: tarantool/tarantool
-          ref: ${{ env.T_VERSION }}
-          path: ${{ env.T_TARDIR }}
-          submodules: true
-          # fetch-depth is 1 by default and it is okay for
-          # building from a tag. However we have master in
-          # the version list.
-          fetch-depth: 0
-        if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
-
-      - name: Build tarantool ${{ env.T_VERSION }} from sources
-        run: |
-          cd "${T_TARDIR}"
-          # Set RelWithDebInfo just to disable -Werror.
-          #
-          # There are tarantool releases on which AppleClang
-          # complains about the problem that was fixed later in
-          # https://github.com/tarantool/tarantool/commit/7e8688ff8885cc7813d12225e03694eb8886de29
-          #
-          # Set OpenSSL root directory for linking tarantool with OpenSSL of version 1.1
-          # This is related to #49. There are too much deprecations which affect the build and tests.
-          # Must be revisited after fixing https://github.com/tarantool/tarantool/issues/6477
-          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_DIST=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DOPENSSL_LIBRARIES=/usr/local/opt/openssl@1.1/lib
-          # {{{ Workaround Mac OS build failure (gh-6076)
-          #
-          # https://github.com/tarantool/tarantool/issues/6076
-          #
-          # In brief: when "src/lib/small" is in include paths,
-          # `#include <version>` from inside Mac OS SDK headers
-          # attempts to include "src/lib/small/VERSION" as a
-          # header file that leads to a syntax error.
-          #
-          # It was fixed in the following commits:
-          #
-          # * 1.10.10-24-g7bce4abd1
-          # * 2.7.2-44-gbb1d32903
-          # * 2.8.1-56-ga6c29c5af
-          # * 2.9.0-84-gc5ae543f3
-          #
-          # However applying the workaround for all versions looks
-          # harmless.
-          #
-          # Added -f just in case: I guess we'll drop this useless
-          # obsoleted VERSION file from the git repository sooner
-          # or later.
-          rm -f src/lib/small/VERSION
-          # The same as above, but for the VERSION file generated
-          # by tarantool's CMake script.
-          rm VERSION
-          # }}} Workaround Mac OS build failure (gh-6076)
-          # Continue the build.
-          make -j$(sysctl -n hw.logicalcpu)
-          make install
-        if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
-
-      - name: Install tarantool
-        run: |
-          cd "${T_TARDIR}"
-          make install
-        if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit == 'true'
-
-      - name: Verify tarantool version
-        run: |
-          # Workaround https://github.com/tarantool/tarantool/issues/4983
-          # Workaround https://github.com/tarantool/tarantool/issues/5040
-          tarantool -e "require('fiber').sleep(0) assert(_TARANTOOL:startswith('${T_VERSION}'), _TARANTOOL) os.exit()"
-        if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Setup golang for the connector and tests
         uses: actions/setup-go@v5
@@ -195,7 +111,6 @@ jobs:
 
       # Workaround issue https://github.com/tarantool/tt/issues/640
       - name: Fix tt rocks
-        if: matrix.tarantool == 'brew'
         run: |
           brew ls --verbose tarantool | grep macosx.lua | xargs rm -f
 


### PR DESCRIPTION
* Removed unsupported macos-13 from CI actions.
* Added new and supported by apple/github macos-15 and macos-26.
* Removed tests for 1.10 on macOS (they won't even build on new versions of llvm that are shipped with macos-14 and newer ones).
* Use actions-setup-cmake@v2 for new versions of macOS, since they are shipped with cmake 4.* or cmake 3.31, but supported cmake version for macOS is 3.29.x.