### PR TITLE
box: box.New returns an error instead of panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 ### Added
 
 * New types for MessagePack extensions compatible with go-option (#459).
-* Added `box.MustNew` wrapper for `box.New`: panics when `box.New` returns an error (#448).
+* Added `box.MustNew` wrapper for `box.New` without an error (#448).
 
 ### Changed
 
 * Required Go version is `1.24` now (#456).
+* `box.New` returns an error instead of panic (#448).
 
 ### Fixed
-
-* `box.New` returns an error instead of panic (#448).
 
 ## [v2.4.1] - 2025-10-16
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,6 +9,8 @@ TODO
 ### <a id="major-changes-v3">Major changes</a>
 
 * Required Go version is `1.24` now.
+* `box.New` returns an error instead of panic
+* Added `box.MustNew` wrapper for `box.New` without an error
 
 ## Migration from v1.x.x to v2.x.x
 

--- a/box/box.go
+++ b/box/box.go
@@ -24,11 +24,10 @@ func New(conn tarantool.Doer) (*Box, error) {
 }
 
 // MustNew returns a new instance of the box structure, which implements the Box interface.
+// It panics if conn == nil.
 func MustNew(conn tarantool.Doer) *Box {
 	b, err := New(conn)
 	if err != nil {
-		// Check if the provided Tarantool connection is nil, and if it is, panic with an error
-		// message. panic early helps to catch and fix nil pointer issues in the code
 		panic(err)
 	}
 	return b

--- a/box/box_test.go
+++ b/box/box_test.go
@@ -26,6 +26,22 @@ func TestMustNew(t *testing.T) {
 	require.Panics(t, func() { box.MustNew(nil) })
 }
 
+func TestMocked_BoxNew(t *testing.T) {
+	t.Parallel()
+
+	mock := test_helpers.NewMockDoer(t,
+		test_helpers.NewMockResponse(t, "valid"),
+	)
+
+	b, err := box.New(&mock)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	assert.Len(t, mock.Requests, 0)
+	b.Schema().User().Exists(box.NewInfoRequest().Ctx(), "")
+	require.Len(t, mock.Requests, 1)
+}
+
 func TestMocked_BoxInfo(t *testing.T) {
 	t.Parallel()
 
@@ -44,8 +60,7 @@ func TestMocked_BoxInfo(t *testing.T) {
 	mock := test_helpers.NewMockDoer(t,
 		test_helpers.NewMockResponse(t, data),
 	)
-	b, err := box.New(&mock)
-	require.NoError(t, err)
+	b := box.MustNew(&mock)
 
 	info, err := b.Info()
 	require.NoError(t, err)
@@ -65,8 +80,7 @@ func TestMocked_BoxSchemaUserInfo(t *testing.T) {
 	mock := test_helpers.NewMockDoer(t,
 		test_helpers.NewMockResponse(t, data),
 	)
-	b, err := box.New(&mock)
-	require.NoError(t, err)
+	b := box.MustNew(&mock)
 
 	privs, err := b.Schema().User().Info(context.Background(), "username")
 	require.NoError(t, err)
@@ -91,9 +105,8 @@ func TestMocked_BoxSessionSu(t *testing.T) {
 		test_helpers.NewMockResponse(t, []interface{}{}),
 		errors.New("user not found or supplied credentials are invalid"),
 	)
-	b, err := box.New(&mock)
-	require.NoError(t, err)
+	b := box.MustNew(&mock)
 
-	err = b.Session().Su(context.Background(), "admin")
+	err := b.Session().Su(context.Background(), "admin")
 	require.NoError(t, err)
 }

--- a/box/example_test.go
+++ b/box/example_test.go
@@ -45,10 +45,7 @@ func ExampleBox_Info() {
 
 	// Or use simple Box implementation.
 
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed get box info: %s", err)
-	}
+	b := box.MustNew(client)
 
 	info, err := b.Info()
 	if err != nil {
@@ -91,10 +88,7 @@ func ExampleSchemaUser_Exists() {
 	}
 
 	// Or use simple User implementation.
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed get box info: %s", err)
-	}
+	b := box.MustNew(client)
 
 	exists, err := b.Schema().User().Exists(ctx, "user")
 	if err != nil {
@@ -127,11 +121,7 @@ func ExampleSchemaUser_Create() {
 	}
 
 	// Create SchemaUser.
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed to connect: %s", err)
-	}
-	schemaUser := b.Schema().User()
+	schemaUser := box.MustNew(client).Schema().User()
 
 	// Create a new user.
 	username := "new_user"
@@ -164,11 +154,7 @@ func ExampleSchemaUser_Drop() {
 	}
 
 	// Create SchemaUser.
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed to connect: %s", err)
-	}
-	schemaUser := b.Schema().User()
+	schemaUser := box.MustNew(client).Schema().User()
 
 	// Drop an existing user.
 	username := "new_user"
@@ -207,11 +193,7 @@ func ExampleSchemaUser_Password() {
 	}
 
 	// Create SchemaUser.
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed to connect: %s", err)
-	}
-	schemaUser := b.Schema().User()
+	schemaUser := box.MustNew(client).Schema().User()
 
 	// Get the password hash.
 	password := "my-password"
@@ -240,11 +222,7 @@ func ExampleSchemaUser_Info() {
 	}
 
 	// Create SchemaUser.
-	b, err := box.New(client)
-	if err != nil {
-		log.Fatalf("Failed to connect: %s", err)
-	}
-	schemaUser := b.Schema().User()
+	schemaUser := box.MustNew(client).Schema().User()
 
 	info, err := schemaUser.Info(ctx, "test")
 	if err != nil {

--- a/box/session_test.go
+++ b/box/session_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestBox_Session(t *testing.T) {
-	b, err := box.New(th.Ptr(th.NewMockDoer(t)))
-	require.NoError(t, err)
+	b := box.MustNew(th.Ptr(th.NewMockDoer(t)))
 	require.NotNil(t, b.Session())
 }
 

--- a/box/tarantool_test.go
+++ b/box/tarantool_test.go
@@ -48,8 +48,7 @@ func TestBox_Sugar_Info(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	info, err := b.Info()
 	require.NoError(t, err)
@@ -73,10 +72,6 @@ func TestBox_Info(t *testing.T) {
 	validateInfo(t, resp.Info)
 }
 
-func TestBox_Connection_NotNil(t *testing.T) {
-
-}
-
 func TestBox_Sugar_Schema_UserCreate_NoError(t *testing.T) {
 	const (
 		username = "user_create_no_error"
@@ -90,8 +85,7 @@ func TestBox_Sugar_Schema_UserCreate_NoError(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user.
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -111,8 +105,7 @@ func TestBox_Sugar_Schema_UserCreate_CanConnectWithNewCred(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user.
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -146,8 +139,7 @@ func TestBox_Sugar_Schema_UserCreate_AlreadyExists(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user.
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -177,8 +169,7 @@ func TestBox_Sugar_Schema_UserCreate_ExistsTrue(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user.
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -204,8 +195,7 @@ func TestBox_Sugar_Schema_UserCreate_IfNotExistsNoErr(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user.
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -229,8 +219,7 @@ func TestBox_Sugar_Schema_UserPassword(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Require password hash.
 	hash, err := b.Schema().User().Password(ctx, password)
@@ -249,8 +238,7 @@ func TestBox_Sugar_Schema_UserDrop_AfterCreate(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -272,8 +260,7 @@ func TestBox_Sugar_Schema_UserDrop_DoubleDrop(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Create new user
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
@@ -301,8 +288,7 @@ func TestBox_Sugar_Schema_UserDrop_UnknownUser(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// Require error cause user not exists
 	err = b.Schema().User().Drop(ctx, "some_strange_not_existing_name", box.UserDropOptions{})
@@ -321,8 +307,7 @@ func TestSchemaUser_Passwd_NotFound(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Passwd(ctx, "not-exists-passwd", "new_password")
 	require.Error(t, err)
@@ -346,8 +331,7 @@ func TestSchemaUser_Passwd_Ok(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	// New user change password and connect
 
@@ -385,8 +369,7 @@ func TestSchemaUser_Passwd_WithoutGrants(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username,
 		box.UserCreateOptions{Password: startPassword, IfNotExists: true})
@@ -400,8 +383,8 @@ func TestSchemaUser_Passwd_WithoutGrants(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, conn2Fail)
 
-	bFail, err := box.New(conn2Fail)
-	require.NoError(t, err)
+	bFail := box.MustNew(conn2Fail)
+
 	// can't change self user password without grants
 	err = bFail.Schema().User().Passwd(ctx, endPassword)
 	require.Error(t, err)
@@ -421,8 +404,7 @@ func TestSchemaUser_Info_TestUserCorrect(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	privileges, err := b.Schema().User().Info(ctx, dialer.User)
 	require.NoError(t, err)
@@ -439,8 +421,7 @@ func TestSchemaUser_Info_NonExistsUser(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	privileges, err := b.Schema().User().Info(ctx, "non-existing")
 	require.Error(t, err)
@@ -460,8 +441,7 @@ func TestBox_Sugar_Schema_UserGrant_NoSu(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
 	require.NoError(t, err)
@@ -494,8 +474,7 @@ func TestBox_Sugar_Schema_UserGrant_WithSu(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
 	require.NoError(t, err)
@@ -545,8 +524,7 @@ func TestSchemaUser_Revoke_WithoutSu(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
 	require.NoError(t, err)
@@ -580,8 +558,7 @@ func TestSchemaUser_Revoke_WithSu(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
 	require.NoError(t, err)
@@ -629,8 +606,7 @@ func TestSchemaUser_Revoke_NonExistsPermission(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Create(ctx, username, box.UserCreateOptions{Password: password})
 	require.NoError(t, err)
@@ -666,8 +642,7 @@ func TestSession_Su_AdminPermissions(t *testing.T) {
 	conn, err := tarantool.Connect(ctx, dialer, tarantool.Opts{})
 	require.NoError(t, err)
 
-	b, err := box.New(conn)
-	require.NoError(t, err)
+	b := box.MustNew(conn)
 
 	err = b.Session().Su(ctx, "admin")
 	require.NoError(t, err)
@@ -680,10 +655,7 @@ func cleanupUser(username string) {
 		log.Fatal(err)
 	}
 
-	b, err := box.New(conn)
-	if err != nil {
-		log.Fatal(err)
-	}
+	b := box.MustNew(conn)
 
 	err = b.Schema().User().Drop(ctx, username, box.UserDropOptions{})
 	if err != nil {


### PR DESCRIPTION
Method `box.New` now returns `(*Box, error)`, because avoiding panics entirely in third-party libraries is ideal, since we can't break compatibility.
Nonetheless, there is still a way to panic on error, via implemented `box.MustNew` wrapper.

I didn't forget about (remove if it is not applicable):

- [X] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [X] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
- [ ] Documentation (see [documentation](https://go.dev/blog/godoc) for documentation style guide)

Closes #448
