### PR TITLE
fix: returning comparable error on contex's cancelled errorcase 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 * Required Go version is `1.24` now (#456).
 * `box.New` returns an error instead of panic (#448).
+* Now cases of `<-ctx.Done()` returns wrapped error provided by `ctx.Cause()`.
+  Allows you compare it using `errors.Is/As` (#457).
 
 ### Fixed
 

--- a/connection.go
+++ b/connection.go
@@ -984,7 +984,8 @@ func (conn *Connection) newFuture(req Request) (fut *Future) {
 	if ctx != nil {
 		select {
 		case <-ctx.Done():
-			fut.SetError(fmt.Errorf("context is done (request ID %d)", fut.requestId))
+			fut.SetError(fmt.Errorf("context is done (request ID %d): %w",
+				fut.requestId, context.Cause(ctx)))
 			shard.rmut.Unlock()
 			return
 		default:
@@ -1026,7 +1027,8 @@ func (conn *Connection) contextWatchdog(fut *Future, ctx context.Context) {
 	case <-fut.done:
 		return
 	default:
-		conn.cancelFuture(fut, fmt.Errorf("context is done (request ID %d)", fut.requestId))
+		conn.cancelFuture(fut, fmt.Errorf("context is done (request ID %d): %w",
+			fut.requestId, context.Cause(ctx)))
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -167,7 +167,7 @@ func ExamplePingRequest_Context() {
 	fmt.Println("Ping Error", regexp.MustCompile("[0-9]+").ReplaceAllString(err.Error(), "N"))
 	// Output:
 	// Ping Resp data []
-	// Ping Error context is done (request ID N)
+	// Ping Error context is done (request ID N): context deadline exceeded
 }
 
 func ExampleSelectRequest() {


### PR DESCRIPTION
Returing wrapped context.Cause(ctx) error in <-ctx.Done() case. Allows compare errors using errors.Is/As.

Fixes #457

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
