### PR TITLE
crud: refactor optional types to use go-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Removed deprecated `box.session.push()` support: Future.AppendPush()
   and Future.GetIterator() methods, ResponseIterator and TimeoutResponseIterator types,
   Future.pushes[], Future.ready (#480, #497).
-* `LogAppendPushFailed` replaced with `LogBoxSessionPushUnsupported` (#480)
-* Removed deprecated `Connection` methods, related interfaces and tests are updated (#479)
+* `LogAppendPushFailed` replaced with `LogBoxSessionPushUnsupported` (#480).
+* Removed deprecated `Connection` methods, related interfaces and tests are updated (#479).
+* Replaced the use of optional types in crud with go-option library (#492).
 
 ### Fixed
 

--- a/crud/count.go
+++ b/crud/count.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"context"
 
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
@@ -15,30 +16,30 @@ type CountResult = NumberResult
 type CountOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Mode is a parameter with `write`/`read` possible values,
 	// if `write` is specified then operation is performed on master.
-	Mode OptString
+	Mode option.String
 	// PreferReplica is a parameter to specify preferred target
 	// as one of the replicas.
-	PreferReplica OptBool
+	PreferReplica option.Bool
 	// Balance is a parameter to use replica according to vshard
 	// load balancing policy.
-	Balance OptBool
+	Balance option.Bool
 	// YieldEvery describes number of tuples processed to yield after.
 	// Should be positive.
-	YieldEvery OptUint
+	YieldEvery option.Uint
 	// BucketId is a bucket ID.
-	BucketId OptUint
+	BucketId option.Uint
 	// ForceMapCall describes the map call is performed without any
 	// optimizations even if full primary key equal condition is specified.
-	ForceMapCall OptBool
+	ForceMapCall option.Bool
 	// Fullscan describes if a critical log entry will be skipped on
 	// potentially long count.
-	Fullscan OptBool
+	Fullscan option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.

--- a/crud/example_test.go
+++ b/crud/example_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/tarantool/go-option"
+
 	"github.com/tarantool/go-tarantool/v3"
 	"github.com/tarantool/go-tarantool/v3/crud"
 )
@@ -288,7 +290,7 @@ func ExampleResult_noreturn() {
 			[]interface{}{uint(2011), nil, "bla"},
 		}).
 		Opts(crud.ReplaceManyOpts{
-			Noreturn: crud.MakeOptBool(true),
+			Noreturn: option.SomeBool(true),
 		})
 
 	ret := crud.Result{}
@@ -375,8 +377,8 @@ func ExampleSelectRequest_pagination() {
 
 	req := crud.MakeSelectRequest(exampleSpace).
 		Opts(crud.SelectOpts{
-			First: crud.MakeOptInt(2),
-			After: crud.MakeOptTuple(tuple),
+			First: option.SomeInt64(2),
+			After: option.SomeAny(tuple),
 		})
 	ret := crud.Result{}
 	if err := conn.Do(req).GetTyped(&ret); err != nil {

--- a/crud/get.go
+++ b/crud/get.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"context"
 
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
@@ -12,28 +13,28 @@ import (
 type GetOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// BucketId is a bucket ID.
-	BucketId OptUint
+	BucketId option.Uint
 	// Mode is a parameter with `write`/`read` possible values,
 	// if `write` is specified then operation is performed on master.
-	Mode OptString
+	Mode option.String
 	// PreferReplica is a parameter to specify preferred target
 	// as one of the replicas.
-	PreferReplica OptBool
+	PreferReplica option.Bool
 	// Balance is a parameter to use replica according to vshard
 	// load balancing policy.
-	Balance OptBool
+	Balance option.Bool
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.

--- a/crud/options.go
+++ b/crud/options.go
@@ -1,6 +1,7 @@
 package crud
 
 import (
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 )
 
@@ -26,124 +27,14 @@ const (
 	cachedOptName                        = "cached"
 )
 
-// OptUint is an optional uint.
-type OptUint struct {
-	value uint
-	exist bool
-}
-
-// MakeOptUint creates an optional uint from value.
-func MakeOptUint(value uint) OptUint {
-	return OptUint{
-		value: value,
-		exist: true,
-	}
-}
-
-// Get returns the integer value or an error if not present.
-func (opt OptUint) Get() (uint, bool) {
-	return opt.value, opt.exist
-}
-
-// OptInt is an optional int.
-type OptInt struct {
-	value int
-	exist bool
-}
-
-// MakeOptInt creates an optional int from value.
-func MakeOptInt(value int) OptInt {
-	return OptInt{
-		value: value,
-		exist: true,
-	}
-}
-
-// Get returns the integer value or an error if not present.
-func (opt OptInt) Get() (int, bool) {
-	return opt.value, opt.exist
-}
-
-// OptFloat64 is an optional float64.
-type OptFloat64 struct {
-	value float64
-	exist bool
-}
-
-// MakeOptFloat64 creates an optional float64 from value.
-func MakeOptFloat64(value float64) OptFloat64 {
-	return OptFloat64{
-		value: value,
-		exist: true,
-	}
-}
-
-// Get returns the float64 value or an error if not present.
-func (opt OptFloat64) Get() (float64, bool) {
-	return opt.value, opt.exist
-}
-
-// OptString is an optional string.
-type OptString struct {
-	value string
-	exist bool
-}
-
-// MakeOptString creates an optional string from value.
-func MakeOptString(value string) OptString {
-	return OptString{
-		value: value,
-		exist: true,
-	}
-}
-
-// Get returns the string value or an error if not present.
-func (opt OptString) Get() (string, bool) {
-	return opt.value, opt.exist
-}
-
-// OptBool is an optional bool.
-type OptBool struct {
-	value bool
-	exist bool
-}
-
-// MakeOptBool creates an optional bool from value.
-func MakeOptBool(value bool) OptBool {
-	return OptBool{
-		value: value,
-		exist: true,
-	}
-}
-
-// Get returns the boolean value or an error if not present.
-func (opt OptBool) Get() (bool, bool) {
-	return opt.value, opt.exist
-}
-
-// OptTuple is an optional tuple.
-type OptTuple struct {
-	tuple interface{}
-}
-
-// MakeOptTuple creates an optional tuple from tuple.
-func MakeOptTuple(tuple interface{}) OptTuple {
-	return OptTuple{tuple}
-}
-
-// Get returns the tuple value or an error if not present.
-func (o *OptTuple) Get() (interface{}, bool) {
-	return o.tuple, o.tuple != nil
-}
-
 // BaseOpts describes base options for CRUD operations.
 type BaseOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -164,22 +55,22 @@ func (opts BaseOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type SimpleOperationOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// BucketId is a bucket ID.
-	BucketId OptUint
+	BucketId option.Uint
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 	// Noreturn suppresses successfully processed data (first return value is `nil`).
 	// Disabled by default.
-	Noreturn OptBool
+	Noreturn option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -206,25 +97,25 @@ func (opts SimpleOperationOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type SimpleOperationObjectOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// BucketId is a bucket ID.
-	BucketId OptUint
+	BucketId option.Uint
 	// SkipNullabilityCheckOnFlatten is a parameter to allow
 	// setting null values to non-nullable fields.
-	SkipNullabilityCheckOnFlatten OptBool
+	SkipNullabilityCheckOnFlatten option.Bool
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 	// Noreturn suppresses successfully processed data (first return value is `nil`).
 	// Disabled by default.
-	Noreturn OptBool
+	Noreturn option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -252,27 +143,27 @@ func (opts SimpleOperationObjectOpts) EncodeMsgpack(enc *msgpack.Encoder) error 
 type OperationManyOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// StopOnError is a parameter to stop on a first error and report
 	// error regarding the failed operation and error about what tuples
 	// were not performed.
-	StopOnError OptBool
+	StopOnError option.Bool
 	// RollbackOnError is a parameter because of what any failed operation
 	// will lead to rollback on a storage, where the operation is failed.
-	RollbackOnError OptBool
+	RollbackOnError option.Bool
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 	// Noreturn suppresses successfully processed data (first return value is `nil`).
 	// Disabled by default.
-	Noreturn OptBool
+	Noreturn option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -300,30 +191,30 @@ func (opts OperationManyOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type OperationObjectManyOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// StopOnError is a parameter to stop on a first error and report
 	// error regarding the failed operation and error about what tuples
 	// were not performed.
-	StopOnError OptBool
+	StopOnError option.Bool
 	// RollbackOnError is a parameter because of what any failed operation
 	// will lead to rollback on a storage, where the operation is failed.
-	RollbackOnError OptBool
+	RollbackOnError option.Bool
 	// SkipNullabilityCheckOnFlatten is a parameter to allow
 	// setting null values to non-nullable fields.
-	SkipNullabilityCheckOnFlatten OptBool
+	SkipNullabilityCheckOnFlatten option.Bool
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 	// Noreturn suppresses successfully processed data (first return value is `nil`).
 	// Disabled by default.
-	Noreturn OptBool
+	Noreturn option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -352,17 +243,17 @@ func (opts OperationObjectManyOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 type BorderOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.

--- a/crud/request_test.go
+++ b/crud/request_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/tarantool/go-iproto"
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
@@ -102,7 +103,7 @@ func BenchmarkLenRequest(b *testing.B) {
 		buf.Reset()
 		req := crud.MakeLenRequest(spaceName).
 			Opts(crud.LenOpts{
-				Timeout: crud.MakeOptFloat64(3.5),
+				Timeout: option.SomeFloat64(3.5),
 			})
 		if err := req.Body(nil, enc); err != nil {
 			b.Error(err)
@@ -121,9 +122,9 @@ func BenchmarkSelectRequest(b *testing.B) {
 		buf.Reset()
 		req := crud.MakeSelectRequest(spaceName).
 			Opts(crud.SelectOpts{
-				Timeout:      crud.MakeOptFloat64(3.5),
-				VshardRouter: crud.MakeOptString("asd"),
-				Balance:      crud.MakeOptBool(true),
+				Timeout:      option.SomeFloat64(3.5),
+				VshardRouter: option.SomeString("asd"),
+				Balance:      option.SomeBool(true),
 			})
 		if err := req.Body(nil, enc); err != nil {
 			b.Error(err)
@@ -636,7 +637,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeInsertRequest(validSpace).Opts(crud.InsertOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -647,7 +648,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeInsertObjectRequest(validSpace).Opts(crud.InsertObjectOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -658,7 +659,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeInsertManyRequest(validSpace).Opts(crud.InsertManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -669,7 +670,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeInsertObjectManyRequest(validSpace).Opts(crud.InsertObjectManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -680,7 +681,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeGetRequest(validSpace).Opts(crud.GetOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -692,7 +693,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeUpdateRequest(validSpace).Opts(crud.UpdateOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -703,7 +704,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeDeleteRequest(validSpace).Opts(crud.DeleteOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -714,7 +715,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeReplaceRequest(validSpace).Opts(crud.ReplaceOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -725,7 +726,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeReplaceObjectRequest(validSpace).Opts(crud.ReplaceObjectOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -736,7 +737,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeReplaceManyRequest(validSpace).Opts(crud.ReplaceManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -747,7 +748,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeReplaceObjectManyRequest(validSpace).Opts(crud.ReplaceObjectManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -759,7 +760,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeUpsertRequest(validSpace).Opts(crud.UpsertOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -771,7 +772,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeUpsertObjectRequest(validSpace).Opts(crud.UpsertObjectOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -782,7 +783,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeUpsertManyRequest(validSpace).Opts(crud.UpsertManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -793,7 +794,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeUpsertObjectManyRequest(validSpace).Opts(crud.UpsertObjectManyOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -804,7 +805,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeSelectRequest(validSpace).Opts(crud.SelectOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -815,7 +816,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeMinRequest(validSpace).Opts(crud.MinOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -826,7 +827,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeMaxRequest(validSpace).Opts(crud.MaxOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -836,7 +837,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeTruncateRequest(validSpace).Opts(crud.TruncateOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -846,7 +847,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeLenRequest(validSpace).Opts(crud.LenOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -857,7 +858,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeCountRequest(validSpace).Opts(crud.CountOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -866,7 +867,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeStorageInfoRequest().Opts(crud.StorageInfoOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -876,7 +877,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeSchemaRequest().Opts(crud.SchemaOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 		{
@@ -886,7 +887,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]interface{}{"vshard_router": "custom_router"},
 			}),
 			target: crud.MakeSchemaRequest().Space(validSpace).Opts(crud.SchemaOpts{
-				VshardRouter: crud.MakeOptString("custom_router"),
+				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
 	}

--- a/crud/schema.go
+++ b/crud/schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 	"github.com/vmihailenco/msgpack/v5/msgpcode"
 
@@ -18,12 +19,12 @@ func msgpackIsMap(code byte) bool {
 type SchemaOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Cached defines whether router should reload storage schema on call.
-	Cached OptBool
+	Cached option.Bool
 }
 
 // EncodeMsgpack provides custom msgpack encoder.
@@ -45,7 +46,7 @@ func (opts SchemaOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // for execution by a Connection.
 type SchemaRequest struct {
 	baseRequest
-	space OptString
+	space option.String
 	opts  SchemaOpts
 }
 
@@ -59,7 +60,7 @@ func MakeSchemaRequest() SchemaRequest {
 // Space sets the space name for the SchemaRequest request.
 // Note: default value is nil.
 func (req SchemaRequest) Space(space string) SchemaRequest {
-	req.space = MakeOptString(space)
+	req.space = option.SomeString(space)
 	return req
 }
 

--- a/crud/select.go
+++ b/crud/select.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"context"
 
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
@@ -12,43 +13,43 @@ import (
 type SelectOpts struct {
 	// Timeout is a `vshard.call` timeout and vshard
 	// master discovery timeout (in seconds).
-	Timeout OptFloat64
+	Timeout option.Float64
 	// VshardRouter is cartridge vshard group name or
 	// vshard router instance.
-	VshardRouter OptString
+	VshardRouter option.String
 	// Fields is field names for getting only a subset of fields.
-	Fields OptTuple
+	Fields option.Any
 	// BucketId is a bucket ID.
-	BucketId OptUint
+	BucketId option.Uint
 	// Mode is a parameter with `write`/`read` possible values,
 	// if `write` is specified then operation is performed on master.
-	Mode OptString
+	Mode option.String
 	// PreferReplica is a parameter to specify preferred target
 	// as one of the replicas.
-	PreferReplica OptBool
+	PreferReplica option.Bool
 	// Balance is a parameter to use replica according to vshard
 	// load balancing policy.
-	Balance OptBool
+	Balance option.Bool
 	// First describes the maximum count of the objects to return.
-	First OptInt
+	First option.Int64
 	// After is a tuple after which objects should be selected.
-	After OptTuple
+	After option.Any
 	// BatchSize is a number of tuples to process per one request to storage.
-	BatchSize OptUint
+	BatchSize option.Uint
 	// ForceMapCall describes the map call is performed without any
 	// optimizations even if full primary key equal condition is specified.
-	ForceMapCall OptBool
+	ForceMapCall option.Bool
 	// Fullscan describes if a critical log entry will be skipped on
 	// potentially long select.
-	Fullscan OptBool
+	Fullscan option.Bool
 	// FetchLatestMetadata guarantees the up-to-date metadata (space format)
 	// in first return value, otherwise it may not take into account
 	// the latest migration of the data format. Performance overhead is up to 15%.
 	// Disabled by default.
-	FetchLatestMetadata OptBool
+	FetchLatestMetadata option.Bool
 	// YieldEvery describes number of tuples processed to yield after.
 	// Should be positive.
-	YieldEvery OptUint
+	YieldEvery option.Uint
 }
 
 // EncodeMsgpack provides custom msgpack encoder.

--- a/crud/stats.go
+++ b/crud/stats.go
@@ -3,6 +3,7 @@ package crud
 import (
 	"context"
 
+	"github.com/tarantool/go-option"
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
@@ -12,7 +13,7 @@ import (
 // for execution by a Connection.
 type StatsRequest struct {
 	baseRequest
-	space OptString
+	space option.String
 }
 
 // MakeStatsRequest returns a new empty StatsRequest.
@@ -25,7 +26,7 @@ func MakeStatsRequest() StatsRequest {
 // Space sets the space name for the StatsRequest request.
 // Note: default value is nil.
 func (req StatsRequest) Space(space string) StatsRequest {
-	req.space = MakeOptString(space)
+	req.space = option.SomeString(space)
 	return req
 }
 

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tarantool/go-iproto"
+	"github.com/tarantool/go-option"
 
 	"github.com/tarantool/go-tarantool/v3"
 	"github.com/tarantool/go-tarantool/v3/crud"
@@ -109,48 +110,48 @@ var operations = []crud.Operation{
 }
 
 var selectOpts = crud.SelectOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var countOpts = crud.CountOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var getOpts = crud.GetOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var minOpts = crud.MinOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var maxOpts = crud.MaxOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var baseOpts = crud.BaseOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var simpleOperationOpts = crud.SimpleOperationOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var simpleOperationObjectOpts = crud.SimpleOperationObjectOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var opManyOpts = crud.OperationManyOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var opObjManyOpts = crud.OperationObjectManyOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
+	Timeout: option.SomeFloat64(timeout),
 }
 
 var schemaOpts = crud.SchemaOpts{
-	Timeout: crud.MakeOptFloat64(timeout),
-	Cached:  crud.MakeOptBool(false),
+	Timeout: option.SomeFloat64(timeout),
+	Cached:  option.SomeBool(false),
 }
 
 var conditions = []crud.Condition{
@@ -954,11 +955,11 @@ func TestGetAdditionalOpts(t *testing.T) {
 	defer conn.Close()
 
 	req := crud.MakeGetRequest(spaceName).Key(key).Opts(crud.GetOpts{
-		Timeout:       crud.MakeOptFloat64(1.1),
-		Fields:        crud.MakeOptTuple([]interface{}{"name"}),
-		Mode:          crud.MakeOptString("read"),
-		PreferReplica: crud.MakeOptBool(true),
-		Balance:       crud.MakeOptBool(true),
+		Timeout:       option.SomeFloat64(1.1),
+		Fields:        option.SomeAny([]interface{}{"name"}),
+		Mode:          option.SomeString("read"),
+		PreferReplica: option.SomeBool(true),
+		Balance:       option.SomeBool(true),
 	})
 	resp := crud.Result{}
 
@@ -979,7 +980,7 @@ var testMetadataCases = []struct {
 		crud.MakeInsertRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.InsertOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -987,7 +988,7 @@ var testMetadataCases = []struct {
 		crud.MakeInsertObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.InsertObjectOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -995,7 +996,7 @@ var testMetadataCases = []struct {
 		crud.MakeInsertManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.InsertManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1003,7 +1004,7 @@ var testMetadataCases = []struct {
 		crud.MakeInsertObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.InsertObjectManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1011,7 +1012,7 @@ var testMetadataCases = []struct {
 		crud.MakeReplaceRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.ReplaceOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1019,7 +1020,7 @@ var testMetadataCases = []struct {
 		crud.MakeReplaceObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.ReplaceObjectOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1027,7 +1028,7 @@ var testMetadataCases = []struct {
 		crud.MakeReplaceManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.ReplaceManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1035,7 +1036,7 @@ var testMetadataCases = []struct {
 		crud.MakeReplaceObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.ReplaceObjectManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1044,7 +1045,7 @@ var testMetadataCases = []struct {
 			Tuple(tuple).
 			Operations(operations).
 			Opts(crud.UpsertOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1053,7 +1054,7 @@ var testMetadataCases = []struct {
 			Object(object).
 			Operations(operations).
 			Opts(crud.UpsertObjectOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1061,7 +1062,7 @@ var testMetadataCases = []struct {
 		crud.MakeUpsertManyRequest(spaceName).
 			TuplesOperationsData(tuplesOperationsData).
 			Opts(crud.UpsertManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1069,7 +1070,7 @@ var testMetadataCases = []struct {
 		crud.MakeUpsertObjectManyRequest(spaceName).
 			ObjectsOperationsData(objectsOperationData).
 			Opts(crud.UpsertObjectManyOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1077,7 +1078,7 @@ var testMetadataCases = []struct {
 		crud.MakeSelectRequest(spaceName).
 			Conditions(conditions).
 			Opts(crud.SelectOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1085,7 +1086,7 @@ var testMetadataCases = []struct {
 		crud.MakeGetRequest(spaceName).
 			Key(key).
 			Opts(crud.GetOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1094,7 +1095,7 @@ var testMetadataCases = []struct {
 			Key(key).
 			Operations(operations).
 			Opts(crud.UpdateOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1102,21 +1103,21 @@ var testMetadataCases = []struct {
 		crud.MakeDeleteRequest(spaceName).
 			Key(key).
 			Opts(crud.DeleteOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
 		"Min",
 		crud.MakeMinRequest(spaceName).
 			Opts(crud.MinOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
 		"Max",
 		crud.MakeMaxRequest(spaceName).
 			Opts(crud.MaxOpts{
-				FetchLatestMetadata: crud.MakeOptBool(true),
+				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 }
@@ -1162,7 +1163,7 @@ var testNoreturnCases = []struct {
 		crud.MakeInsertRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.InsertOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1170,7 +1171,7 @@ var testNoreturnCases = []struct {
 		crud.MakeInsertObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.InsertObjectOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1178,7 +1179,7 @@ var testNoreturnCases = []struct {
 		crud.MakeInsertManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.InsertManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1186,7 +1187,7 @@ var testNoreturnCases = []struct {
 		crud.MakeInsertObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.InsertObjectManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1194,7 +1195,7 @@ var testNoreturnCases = []struct {
 		crud.MakeReplaceRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.ReplaceOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1202,7 +1203,7 @@ var testNoreturnCases = []struct {
 		crud.MakeReplaceObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.ReplaceObjectOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1210,7 +1211,7 @@ var testNoreturnCases = []struct {
 		crud.MakeReplaceManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.ReplaceManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1218,7 +1219,7 @@ var testNoreturnCases = []struct {
 		crud.MakeReplaceObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.ReplaceObjectManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1227,7 +1228,7 @@ var testNoreturnCases = []struct {
 			Tuple(tuple).
 			Operations(operations).
 			Opts(crud.UpsertOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1236,7 +1237,7 @@ var testNoreturnCases = []struct {
 			Object(object).
 			Operations(operations).
 			Opts(crud.UpsertObjectOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1244,7 +1245,7 @@ var testNoreturnCases = []struct {
 		crud.MakeUpsertManyRequest(spaceName).
 			TuplesOperationsData(tuplesOperationsData).
 			Opts(crud.UpsertManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1252,7 +1253,7 @@ var testNoreturnCases = []struct {
 		crud.MakeUpsertObjectManyRequest(spaceName).
 			ObjectsOperationsData(objectsOperationData).
 			Opts(crud.UpsertObjectManyOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1261,7 +1262,7 @@ var testNoreturnCases = []struct {
 			Key(key).
 			Operations(operations).
 			Opts(crud.UpdateOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 	{
@@ -1269,7 +1270,7 @@ var testNoreturnCases = []struct {
 		crud.MakeDeleteRequest(spaceName).
 			Key(key).
 			Opts(crud.DeleteOpts{
-				Noreturn: crud.MakeOptBool(true),
+				Noreturn: option.SomeBool(true),
 			}),
 	},
 }
@@ -1480,14 +1481,14 @@ var testStorageYieldCases = []struct {
 		"Count",
 		crud.MakeCountRequest(spaceName).
 			Opts(crud.CountOpts{
-				YieldEvery: crud.MakeOptUint(500),
+				YieldEvery: option.SomeUint(500),
 			}),
 	},
 	{
 		"Select",
 		crud.MakeSelectRequest(spaceName).
 			Opts(crud.SelectOpts{
-				YieldEvery: crud.MakeOptUint(500),
+				YieldEvery: option.SomeUint(500),
 			}),
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/tarantool/go-tarantool/v3
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tarantool/go-iproto v1.1.0
-	github.com/tarantool/go-option v1.0.0
+	github.com/tarantool/go-option v1.1.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/tarantool/go-iproto v1.1.0 h1:HULVOIHsiehI+FnHfM7wMDntuzUddO09DKqu2Wn
 github.com/tarantool/go-iproto v1.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/tarantool/go-option v1.0.0 h1:+Etw0i3TjsXvADTo5rfZNCfsXe3BfHOs+iVfIrl0Nlo=
 github.com/tarantool/go-option v1.0.0/go.mod h1:lXzzeZtL+rPUtLOCDP6ny3FemFBjruG9aHKzNN2bS08=
+github.com/tarantool/go-option v1.1.0 h1:ShoOhNsdL41sRpm4hXCRDjV8H0WzPkd4UnKhLKbW//w=
+github.com/tarantool/go-option v1.1.0/go.mod h1:hMr9z2JXOWlgdCBpCPSL2nwp8718GKYvNBJ+ZuzJbCo=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
- Remove: OptUint, OptInt, OptFloat64, OptString, OptBool, OptTuple.
- Remove: MakeOptUint, MakeOptInt, MakeOptFloat64, MakeOptString, MakeOptBool, MakeOptTuple.
- Add: OptAny = option.Generic[interface{}] .
- Add: MakeOptAny constructor.
- Update: All option structs to use option.* types.
- Fix: Test type inconsistencies.

Changed #492
