### PR TITLE
lint: enabled errcheck

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,9 +2,8 @@ run:
   timeout: 3m
 
 linters:
-  disable:
-    - errcheck
   enable:
+    - errcheck
     - forbidigo
     - gocritic
     - goimports

--- a/arrow/request_test.go
+++ b/arrow/request_test.go
@@ -42,9 +42,9 @@ func TestResponseDecode(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	enc := msgpack.NewEncoder(buf)
 
-	enc.EncodeMapLen(1)
-	enc.EncodeUint8(uint8(iproto.IPROTO_DATA))
-	enc.Encode([]interface{}{'v', '2'})
+	require.NoError(t, enc.EncodeMapLen(1))
+	require.NoError(t, enc.EncodeUint8(uint8(iproto.IPROTO_DATA)))
+	require.NoError(t, enc.Encode([]interface{}{'v', '2'}))
 
 	request := arrow.NewInsertRequest(validSpace, arrow.Arrow{})
 	resp, err := request.Response(header, bytes.NewBuffer(buf.Bytes()))
@@ -61,9 +61,9 @@ func TestResponseDecodeTyped(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	enc := msgpack.NewEncoder(buf)
 
-	enc.EncodeMapLen(1)
-	enc.EncodeUint8(uint8(iproto.IPROTO_DATA))
-	enc.EncodeBytes([]byte{'v', '2'})
+	require.NoError(t, enc.EncodeMapLen(1))
+	require.NoError(t, enc.EncodeUint8(uint8(iproto.IPROTO_DATA)))
+	require.NoError(t, enc.EncodeBytes([]byte{'v', '2'}))
 
 	request := arrow.NewInsertRequest(validSpace, arrow.Arrow{})
 	resp, err := request.Response(header, bytes.NewBuffer(buf.Bytes()))

--- a/box/box_test.go
+++ b/box/box_test.go
@@ -38,7 +38,7 @@ func TestMocked_BoxNew(t *testing.T) {
 	require.NotNil(t, b)
 
 	assert.Len(t, mock.Requests, 0)
-	b.Schema().User().Exists(box.NewInfoRequest().Ctx(), "")
+	_, _ = b.Schema().User().Exists(box.NewInfoRequest().Ctx(), "")
 	require.Len(t, mock.Requests, 1)
 }
 

--- a/boxerror_test.go
+++ b/boxerror_test.go
@@ -204,7 +204,7 @@ func TestMessagePackDecode(t *testing.T) {
 func TestMessagePackUnmarshalToNil(t *testing.T) {
 	var val *BoxError = nil
 	require.PanicsWithValue(t, "cannot unmarshal to a nil pointer",
-		func() { val.UnmarshalMsgpack(mpDecodeSamples["InnerMapExtraKey"].b) })
+		func() { _ = val.UnmarshalMsgpack(mpDecodeSamples["InnerMapExtraKey"].b) })
 }
 
 func TestMessagePackEncodeNil(t *testing.T) {

--- a/client_tools.go
+++ b/client_tools.go
@@ -11,8 +11,12 @@ type IntKey struct {
 }
 
 func (k IntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeArrayLen(1)
-	enc.EncodeInt(int64(k.I))
+	if err := enc.EncodeArrayLen(1); err != nil {
+		return err
+	}
+	if err := enc.EncodeInt(int64(k.I)); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -24,8 +28,12 @@ type UintKey struct {
 }
 
 func (k UintKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeArrayLen(1)
-	enc.EncodeUint(uint64(k.I))
+	if err := enc.EncodeArrayLen(1); err != nil {
+		return err
+	}
+	if err := enc.EncodeUint(uint64(k.I)); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -36,8 +44,12 @@ type StringKey struct {
 }
 
 func (k StringKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeArrayLen(1)
-	enc.EncodeString(k.S)
+	if err := enc.EncodeArrayLen(1); err != nil {
+		return err
+	}
+	if err := enc.EncodeString(k.S); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -48,9 +60,15 @@ type IntIntKey struct {
 }
 
 func (k IntIntKey) EncodeMsgpack(enc *msgpack.Encoder) error {
-	enc.EncodeArrayLen(2)
-	enc.EncodeInt(int64(k.I1))
-	enc.EncodeInt(int64(k.I2))
+	if err := enc.EncodeArrayLen(2); err != nil {
+		return err
+	}
+	if err := enc.EncodeInt(int64(k.I1)); err != nil {
+		return err
+	}
+	if err := enc.EncodeInt(int64(k.I2)); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/crud/object.go
+++ b/crud/object.go
@@ -20,5 +20,5 @@ type Objects = interface{}
 type MapObject map[string]interface{}
 
 func (o MapObject) EncodeMsgpack(enc *msgpack.Encoder) {
-	enc.Encode(o)
+	_ = enc.Encode(o)
 }

--- a/crud/options.go
+++ b/crud/options.go
@@ -398,8 +398,12 @@ func encodeOptions(enc *msgpack.Encoder,
 	if mapLen > 0 {
 		for i, name := range names {
 			if exists[i] {
-				enc.EncodeString(name)
-				enc.Encode(values[i])
+				if err := enc.EncodeString(name); err != nil {
+					return err
+				}
+				if err := enc.Encode(values[i]); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -559,7 +559,8 @@ func TestCrudGenerateData(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 
 			data, err := conn.Do(testCase.req).Get()
@@ -571,7 +572,8 @@ func TestCrudGenerateData(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -590,7 +592,8 @@ func TestCrudProcessData(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -799,7 +802,8 @@ func TestBoolResult(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		req := tarantool.NewDeleteRequest(spaceName).
 			Key([]interface{}{uint(i)})
-		conn.Do(req).Get()
+		_, err := conn.Do(req).Get()
+		require.NoError(t, err)
 	}
 }
 
@@ -824,7 +828,8 @@ func TestNumberResult(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		req := tarantool.NewDeleteRequest(spaceName).
 			Key([]interface{}{uint(i)})
-		conn.Do(req).Get()
+		_, err = conn.Do(req).Get()
+		require.NoError(t, err)
 	}
 }
 
@@ -869,7 +874,8 @@ func TestBaseResult(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		req := tarantool.NewDeleteRequest(spaceName).
 			Key([]interface{}{uint(i)})
-		conn.Do(req).Get()
+		_, err = conn.Do(req).Get()
+		require.NoError(t, err)
 	}
 }
 
@@ -914,7 +920,8 @@ func TestManyResult(t *testing.T) {
 	for i := 1010; i < 1020; i++ {
 		req := tarantool.NewDeleteRequest(spaceName).
 			Key([]interface{}{uint(i)})
-		conn.Do(req).Get()
+		_, err := conn.Do(req).Get()
+		require.NoError(t, err)
 	}
 }
 
@@ -1130,7 +1137,8 @@ func TestFetchLatestMetadataOption(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 
 			resp := crud.Result{}
@@ -1147,7 +1155,8 @@ func TestFetchLatestMetadataOption(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err = conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1283,7 +1292,8 @@ func TestNoreturnOption(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 
 			data, err := conn.Do(testCase.req).Get()
@@ -1306,7 +1316,8 @@ func TestNoreturnOption(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err = conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1321,7 +1332,8 @@ func TestNoreturnOptionTyped(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err := conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 
 			resp := crud.Result{}
@@ -1342,7 +1354,8 @@ func TestNoreturnOptionTyped(t *testing.T) {
 			for i := 1010; i < 1020; i++ {
 				req := tarantool.NewDeleteRequest(spaceName).
 					Key([]interface{}{uint(i)})
-				conn.Do(req).Get()
+				_, err = conn.Do(req).Get()
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -855,7 +855,9 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 	if err := e.EncodeString(c.Orig); err != nil {
 		return err
 	}
-	e.Encode(c.Events)
+	if err := e.Encode(c.Events); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -879,7 +881,9 @@ func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	}
 	c.Events = make([]Event, l)
 	for i := 0; i < l; i++ {
-		d.Decode(&c.Events[i])
+		if err = d.Decode(&c.Events[i]); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/deadline_io.go
+++ b/deadline_io.go
@@ -12,7 +12,9 @@ type deadlineIO struct {
 
 func (d *deadlineIO) Write(b []byte) (n int, err error) {
 	if d.to > 0 {
-		d.c.SetWriteDeadline(time.Now().Add(d.to))
+		if err = d.c.SetWriteDeadline(time.Now().Add(d.to)); err != nil {
+			return
+		}
 	}
 	n, err = d.c.Write(b)
 	return
@@ -20,7 +22,9 @@ func (d *deadlineIO) Write(b []byte) (n int, err error) {
 
 func (d *deadlineIO) Read(b []byte) (n int, err error) {
 	if d.to > 0 {
-		d.c.SetReadDeadline(time.Now().Add(d.to))
+		if err = d.c.SetReadDeadline(time.Now().Add(d.to)); err != nil {
+			return
+		}
 	}
 	n, err = d.c.Read(b)
 	return

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/vmihailenco/msgpack/v5"
 
 	. "github.com/tarantool/go-tarantool/v3"
@@ -507,7 +508,8 @@ func BenchmarkEncodeStringToBCD(b *testing.B) {
 		b.Run(testcase.numString, func(b *testing.B) {
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				EncodeStringToBCD(testcase.numString)
+				_, err := EncodeStringToBCD(testcase.numString)
+				assert.NoError(b, err)
 			}
 		})
 	}
@@ -520,7 +522,8 @@ func BenchmarkDecodeStringFromBCD(b *testing.B) {
 			bcdBuf := trimMPHeader(buf, testcase.fixExt)
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				DecodeStringFromBCD(bcdBuf)
+				_, _, err := DecodeStringFromBCD(bcdBuf)
+				assert.NoError(b, err)
 			}
 		})
 	}

--- a/dial_test.go
+++ b/dial_test.go
@@ -463,25 +463,25 @@ func testDialAccept(opts testDialOpts, l net.Listener) chan dialServerActual {
 		}
 		defer client.Close()
 		if opts.isErrGreeting {
-			client.Write(errResponse)
+			_, _ = client.Write(errResponse)
 			return
 		} else {
 			// Write greeting.
-			client.Write(testDialVersion[:])
-			client.Write(testDialSalt[:])
+			_, _ = client.Write(testDialVersion[:])
+			_, _ = client.Write(testDialSalt[:])
 		}
 
 		// Read Id request.
 		idRequestActual := make([]byte, len(idRequestExpected))
-		client.Read(idRequestActual)
+		_, _ = client.Read(idRequestActual)
 
 		// Make Id response.
 		if opts.isErrId {
-			client.Write(errResponse)
+			_, _ = client.Write(errResponse)
 		} else if opts.isIdUnsupported {
-			client.Write(idResponseNotSupported)
+			_, _ = client.Write(idResponseNotSupported)
 		} else {
-			client.Write(idResponse)
+			_, _ = client.Write(idResponse)
 		}
 
 		// Read Auth request.
@@ -490,13 +490,13 @@ func testDialAccept(opts testDialOpts, l net.Listener) chan dialServerActual {
 			authRequestExpected = []byte{}
 		}
 		authRequestActual := make([]byte, len(authRequestExpected))
-		client.Read(authRequestActual)
+		_, _ = client.Read(authRequestActual)
 
 		// Make Auth response.
 		if opts.isErrAuth {
-			client.Write(errResponse)
+			_, _ = client.Write(errResponse)
 		} else {
-			client.Write(okResponse)
+			_, _ = client.Write(okResponse)
 		}
 		ch <- dialServerActual{
 			IdRequest:   idRequestActual,
@@ -667,7 +667,7 @@ func TestFdDialer_Dial(t *testing.T) {
 			// We already tried to use the SyscallConn(), but it has the same
 			// issue.
 			time.Sleep(time.Millisecond)
-			sock.(*net.TCPConn).SetLinger(0)
+			_ = sock.(*net.TCPConn).SetLinger(0)
 
 			f, err := sock.(*net.TCPConn).File()
 			require.NoError(t, err)
@@ -698,7 +698,7 @@ func TestFdDialer_Dial_requirements(t *testing.T) {
 	// We already tried to use the SyscallConn(), but it has the same
 	// issue.
 	time.Sleep(time.Millisecond)
-	sock.(*net.TCPConn).SetLinger(0)
+	_ = sock.(*net.TCPConn).SetLinger(0)
 
 	f, err := sock.(*net.TCPConn).File()
 	require.NoError(t, err)

--- a/example_custom_unpacking_test.go
+++ b/example_custom_unpacking_test.go
@@ -36,7 +36,9 @@ func (c *Tuple2) EncodeMsgpack(e *msgpack.Encoder) error {
 	if err := e.EncodeString(c.Orig); err != nil {
 		return err
 	}
-	e.Encode(c.Members)
+	if err := e.Encode(c.Members); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -60,7 +62,9 @@ func (c *Tuple2) DecodeMsgpack(d *msgpack.Decoder) error {
 	}
 	c.Members = make([]Member, l)
 	for i := 0; i < l; i++ {
-		d.Decode(&c.Members[i])
+		if err = d.Decode(&c.Members[i]); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/example_test.go
+++ b/example_test.go
@@ -39,10 +39,11 @@ func ExampleIntKey() {
 	const space = "test"
 	const index = "primary"
 	tuple := []interface{}{int(1111), "hello", "world"}
-	conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	_, err := conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	fmt.Println("Error", err)
 
 	var t []Tuple
-	err := conn.Do(tarantool.NewSelectRequest(space).
+	err = conn.Do(tarantool.NewSelectRequest(space).
 		Index(index).
 		Iterator(tarantool.IterEq).
 		Key(tarantool.IntKey{1111}),
@@ -50,6 +51,7 @@ func ExampleIntKey() {
 	fmt.Println("Error", err)
 	fmt.Println("Data", t)
 	// Output:
+	// Error <nil>
 	// Error <nil>
 	// Data [{{} 1111 hello world}]
 }
@@ -61,10 +63,11 @@ func ExampleUintKey() {
 	const space = "test"
 	const index = "primary"
 	tuple := []interface{}{uint(1111), "hello", "world"}
-	conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	_, err := conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	fmt.Println("Error", err)
 
 	var t []Tuple
-	err := conn.Do(tarantool.NewSelectRequest(space).
+	err = conn.Do(tarantool.NewSelectRequest(space).
 		Index(index).
 		Iterator(tarantool.IterEq).
 		Key(tarantool.UintKey{1111}),
@@ -72,6 +75,7 @@ func ExampleUintKey() {
 	fmt.Println("Error", err)
 	fmt.Println("Data", t)
 	// Output:
+	// Error <nil>
 	// Error <nil>
 	// Data [{{} 1111 hello world}]
 }
@@ -83,13 +87,14 @@ func ExampleStringKey() {
 	const space = "teststring"
 	const index = "primary"
 	tuple := []interface{}{"any", []byte{0x01, 0x02}}
-	conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	_, err := conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	fmt.Println("Error", err)
 
 	t := []struct {
 		Key   string
 		Value []byte
 	}{}
-	err := conn.Do(tarantool.NewSelectRequest(space).
+	err = conn.Do(tarantool.NewSelectRequest(space).
 		Index(index).
 		Iterator(tarantool.IterEq).
 		Key(tarantool.StringKey{"any"}),
@@ -97,6 +102,7 @@ func ExampleStringKey() {
 	fmt.Println("Error", err)
 	fmt.Println("Data", t)
 	// Output:
+	// Error <nil>
 	// Error <nil>
 	// Data [{any [1 2]}]
 }
@@ -108,14 +114,15 @@ func ExampleIntIntKey() {
 	const space = "testintint"
 	const index = "primary"
 	tuple := []interface{}{1, 2, "foo"}
-	conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	_, err := conn.Do(tarantool.NewReplaceRequest(space).Tuple(tuple)).Get()
+	fmt.Println("Error", err)
 
 	t := []struct {
 		Key1  int
 		Key2  int
 		Value string
 	}{}
-	err := conn.Do(tarantool.NewSelectRequest(space).
+	err = conn.Do(tarantool.NewSelectRequest(space).
 		Index(index).
 		Iterator(tarantool.IterEq).
 		Key(tarantool.IntIntKey{1, 2}),
@@ -123,6 +130,7 @@ func ExampleIntIntKey() {
 	fmt.Println("Error", err)
 	fmt.Println("Data", t)
 	// Output:
+	// Error <nil>
 	// Error <nil>
 	// Data [{1 2 foo}]
 }
@@ -175,9 +183,10 @@ func ExampleSelectRequest() {
 	defer conn.Close()
 
 	for i := 1111; i <= 1112; i++ {
-		conn.Do(tarantool.NewReplaceRequest(spaceNo).
+		_, err := conn.Do(tarantool.NewReplaceRequest(spaceNo).
 			Tuple([]interface{}{uint(i), "hello", "world"}),
 		).Get()
+		fmt.Println("Error", err)
 	}
 
 	key := []interface{}{uint(1111)}
@@ -225,6 +234,8 @@ func ExampleSelectRequest() {
 	fmt.Printf("response is %v\n", res)
 
 	// Output:
+	// Error <nil>
+	// Error <nil>
 	// pos for Select is []
 	// response is []interface {}{[]interface {}{0x457, "hello", "world"}}
 	// response is [{{} 1111 hello world}]
@@ -265,15 +276,17 @@ func ExampleInsertRequest() {
 	fmt.Println("Data", data)
 
 	// Delete tuple with primary key { 31 }.
-	conn.Do(tarantool.NewDeleteRequest("test").
+	_, err = conn.Do(tarantool.NewDeleteRequest("test").
 		Index("primary").
 		Key([]interface{}{uint(31)}),
 	).Get()
+	fmt.Println("Error", err)
 	// Delete tuple with primary key { 32 }.
-	conn.Do(tarantool.NewDeleteRequest("test").
+	_, err = conn.Do(tarantool.NewDeleteRequest("test").
 		Index(indexNo).
 		Key([]interface{}{uint(31)}),
 	).Get()
+	fmt.Println("Error", err)
 	// Output:
 	// Insert 31
 	// Error <nil>
@@ -281,6 +294,8 @@ func ExampleInsertRequest() {
 	// Insert 32
 	// Error <nil>
 	// Data [[32 test one]]
+	// Error <nil>
+	// Error <nil>
 }
 
 func ExampleInsertRequest_spaceAndIndexNames() {
@@ -302,13 +317,15 @@ func ExampleDeleteRequest() {
 	defer conn.Close()
 
 	// Insert a new tuple { 35, 1 }.
-	conn.Do(tarantool.NewInsertRequest(spaceNo).
+	_, err := conn.Do(tarantool.NewInsertRequest(spaceNo).
 		Tuple([]interface{}{uint(35), "test", "one"}),
 	).Get()
+	fmt.Println("Error", err)
 	// Insert a new tuple { 36, 1 }.
-	conn.Do(tarantool.NewInsertRequest("test").
+	_, err = conn.Do(tarantool.NewInsertRequest("test").
 		Tuple(&Tuple{Id: 36, Msg: "test", Name: "one"}),
 	).Get()
+	fmt.Println("Error", err)
 
 	// Delete tuple with primary key { 35 }.
 	data, err := conn.Do(tarantool.NewDeleteRequest(spaceNo).
@@ -328,6 +345,8 @@ func ExampleDeleteRequest() {
 	fmt.Println("Error", err)
 	fmt.Println("Data", data)
 	// Output:
+	// Error <nil>
+	// Error <nil>
 	// Delete 35
 	// Error <nil>
 	// Data [[35 test one]]
@@ -356,7 +375,7 @@ func ExampleReplaceRequest() {
 	defer conn.Close()
 
 	// Insert a new tuple { 13, 1 }.
-	conn.Do(tarantool.NewInsertRequest(spaceNo).
+	_, _ = conn.Do(tarantool.NewInsertRequest(spaceNo).
 		Tuple([]interface{}{uint(13), "test", "one"}),
 	).Get()
 
@@ -421,9 +440,10 @@ func ExampleUpdateRequest() {
 	defer conn.Close()
 
 	for i := 1111; i <= 1112; i++ {
-		conn.Do(tarantool.NewReplaceRequest(spaceNo).
+		_, err := conn.Do(tarantool.NewReplaceRequest(spaceNo).
 			Tuple([]interface{}{uint(i), "text", 1, 1, 1, 1, 1}),
 		).Get()
+		fmt.Println("Error", err)
 	}
 
 	req := tarantool.NewUpdateRequest(617).
@@ -444,6 +464,8 @@ func ExampleUpdateRequest() {
 	}
 	fmt.Printf("response is %#v\n", data)
 	// Output:
+	// Error <nil>
+	// Error <nil>
 	// response is []interface {}{[]interface {}{0x457, "t!!t", 2, 0, 1, 1, 0, "updated"}}
 }
 
@@ -1426,7 +1448,7 @@ func ExampleConnection_NewWatcher() {
 	}
 	defer watcher.Unregister()
 
-	conn.Do(tarantool.NewBroadcastRequest(key).Value(value)).Get()
+	_, _ = conn.Do(tarantool.NewBroadcastRequest(key).Value(value)).Get()
 	time.Sleep(time.Second)
 }
 
@@ -1444,7 +1466,7 @@ func ExampleConnection_CloseGraceful_force() {
 
 	done := make(chan struct{})
 	go func() {
-		conn.CloseGraceful()
+		_ = conn.CloseGraceful()
 		fmt.Println("Connection.CloseGraceful() done!")
 		close(done)
 	}()
@@ -1479,7 +1501,7 @@ func ExampleWatchOnceRequest() {
 	conn := exampleConnect(dialer, opts)
 	defer conn.Close()
 
-	conn.Do(tarantool.NewBroadcastRequest(key).Value(value)).Get()
+	_, _ = conn.Do(tarantool.NewBroadcastRequest(key).Value(value)).Get()
 
 	data, err := conn.Do(tarantool.NewWatchOnceRequest(key)).Get()
 	if err != nil {

--- a/future_test.go
+++ b/future_test.go
@@ -78,7 +78,8 @@ func createFutureMockResponse(header Header, body io.Reader) (Response, error) {
 
 func TestFuture_Get(t *testing.T) {
 	fut := NewFuture(&futureMockRequest{})
-	fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'}))
+	err := fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'}))
+	assert.NoError(t, err)
 
 	resp, err := fut.GetResponse()
 	assert.NoError(t, err)
@@ -94,7 +95,8 @@ func TestFuture_Get(t *testing.T) {
 
 func TestFuture_GetTyped(t *testing.T) {
 	fut := NewFuture(&futureMockRequest{})
-	fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'}))
+	assert.NoError(t,
+		fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'})))
 
 	resp, err := fut.GetResponse()
 	assert.NoError(t, err)
@@ -115,7 +117,8 @@ func TestFuture_GetResponse(t *testing.T) {
 	assert.NoError(t, err)
 
 	fut := NewFuture(&futureMockRequest{})
-	fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'}))
+	assert.NoError(t,
+		fut.SetResponse(Header{}, bytes.NewReader([]byte{'v', '2'})))
 
 	resp, err := fut.GetResponse()
 	assert.NoError(t, err)

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -630,7 +630,7 @@ func (p *ConnectionPool) deleteConnection(name string) {
 		p.watcherContainer.mutex.RLock()
 		defer p.watcherContainer.mutex.RUnlock()
 
-		p.watcherContainer.foreach(func(watcher *poolWatcher) error {
+		_ = p.watcherContainer.foreach(func(watcher *poolWatcher) error {
 			watcher.unwatch(conn)
 			return nil
 		})

--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -1359,8 +1359,8 @@ func TestConnectionHandlerDeactivated_on_remove(t *testing.T) {
 	require.Nil(t, err)
 
 	for _, server := range poolServers {
-		connPool.Remove(server)
-		connPool.Remove(server)
+		err = connPool.Remove(server)
+		require.NoError(t, err)
 	}
 
 	args = test_helpers.CheckStatusesArgs{
@@ -3315,7 +3315,7 @@ func TestConnectionPool_NewWatcher_no_watchers(t *testing.T) {
 	defer connPool.Close()
 
 	ch := make(chan struct{})
-	connPool.NewWatcher(key, func(event tarantool.WatchEvent) {
+	_, _ = connPool.NewWatcher(key, func(event tarantool.WatchEvent) {
 		close(ch)
 	}, pool.ANY)
 

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -145,7 +145,7 @@ func ExampleConnectionPool_NewWatcher() {
 	}
 	defer watcher.Unregister()
 
-	connPool.Do(tarantool.NewBroadcastRequest(key).Value(value), mode).Get()
+	_, _ = connPool.Do(tarantool.NewBroadcastRequest(key).Value(value), mode).Get()
 	time.Sleep(time.Second)
 }
 

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -258,8 +258,11 @@ func Example_connectionPool() {
 		} else if task.Data() == nil {
 			fmt.Println("task.Data() == nil")
 		} else {
-			task.Ack()
-			fmt.Println("Got data:", task.Data())
+			if err = task.Ack(); err != nil {
+				fmt.Println("Ack error:", err)
+			} else {
+				fmt.Println("Got data:", task.Data())
+			}
 		}
 		break
 	}

--- a/queue/example_msgpack_test.go
+++ b/queue/example_msgpack_test.go
@@ -101,7 +101,10 @@ func Example_simpleQueueCustomMsgPack() {
 		return
 	}
 	fmt.Println("Data is", task.Data())
-	task.Ack()
+	if err = task.Ack(); err != nil {
+		fmt.Printf("Ack error: %s", err)
+		return
+	}
 
 	// Take typed example.
 	putData := dummyData{}
@@ -129,7 +132,11 @@ func Example_simpleQueueCustomMsgPack() {
 		fmt.Printf("Put failed: %s", err)
 		return
 	}
-	task.Bury()
+	err = task.Bury()
+	if err != nil {
+		fmt.Printf("Bury error: %s", err)
+		return
+	}
 
 	task, err = que.TakeTimeout(2 * time.Second)
 	if err != nil {
@@ -140,7 +147,7 @@ func Example_simpleQueueCustomMsgPack() {
 		fmt.Println("Task is nil")
 	}
 
-	que.Drop()
+	_ = que.Drop()
 
 	// Unordered output:
 	// Task id is 0

--- a/queue/example_test.go
+++ b/queue/example_test.go
@@ -50,7 +50,9 @@ func Example_simpleQueue() {
 		return
 	}
 
-	defer q.Drop()
+	defer func() {
+		_ = q.Drop()
+	}()
 
 	testData_1 := "test_data_1"
 	if _, err = q.Put(testData_1); err != nil {
@@ -70,7 +72,11 @@ func Example_simpleQueue() {
 		fmt.Printf("error in take with is %v", err)
 		return
 	}
-	task.Ack()
+	err = task.Ack()
+	if err != nil {
+		fmt.Printf("error in Ack: %s", err)
+		return
+	}
 	fmt.Println("data_1: ", task.Data())
 
 	err = task_2.Bury()

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -117,7 +117,10 @@ func TestQueue_ReIdentify(t *testing.T) {
 		Opts:      queue.Opts{Ttl: 5 * time.Second},
 	}
 	q := createQueue(t, conn, name, cfg)
-	q.Cfg(queue.CfgOpts{InReplicaset: false, Ttr: 5 * time.Second})
+	err := q.Cfg(queue.CfgOpts{InReplicaset: false, Ttr: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Cfg failed: %s", err)
+	}
 	defer func() {
 		dropQueue(t, q)
 	}()

--- a/queue/task.go
+++ b/queue/task.go
@@ -31,7 +31,7 @@ func (t *Task) DecodeMsgpack(d *msgpack.Decoder) error {
 		return err
 	}
 	if t.data != nil {
-		d.Decode(t.data)
+		_ = d.Decode(t.data)
 	} else if t.data, err = d.DecodeInterface(); err != nil {
 		return err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -319,9 +319,9 @@ func TestResponseDecode(t *testing.T) {
 		buf := bytes.NewBuffer([]byte{})
 		enc := msgpack.NewEncoder(buf)
 
-		enc.EncodeMapLen(1)
-		enc.EncodeUint8(uint8(iproto.IPROTO_DATA))
-		enc.Encode([]interface{}{'v', '2'})
+		assert.NoError(t, enc.EncodeMapLen(1))
+		assert.NoError(t, enc.EncodeUint8(uint8(iproto.IPROTO_DATA)))
+		assert.NoError(t, enc.Encode([]interface{}{'v', '2'}))
 
 		resp, err := test.req.Response(header, bytes.NewBuffer(buf.Bytes()))
 		assert.NoError(t, err)
@@ -372,9 +372,9 @@ func TestResponseDecodeTyped(t *testing.T) {
 		buf := bytes.NewBuffer([]byte{})
 		enc := msgpack.NewEncoder(buf)
 
-		enc.EncodeMapLen(1)
-		enc.EncodeUint8(uint8(iproto.IPROTO_DATA))
-		enc.EncodeBytes([]byte{'v', '2'})
+		assert.NoError(t, enc.EncodeMapLen(1))
+		assert.NoError(t, enc.EncodeUint8(uint8(iproto.IPROTO_DATA)))
+		assert.NoError(t, enc.EncodeBytes([]byte{'v', '2'}))
 
 		resp, err := test.req.Response(header, bytes.NewBuffer(buf.Bytes()))
 		assert.NoError(t, err)

--- a/response_test.go
+++ b/response_test.go
@@ -18,11 +18,11 @@ func encodeResponseData(t *testing.T, data interface{}) io.Reader {
 	buf := bytes.NewBuffer([]byte{})
 	enc := msgpack.NewEncoder(buf)
 
-	enc.EncodeMapLen(1)
-	enc.EncodeUint8(uint8(iproto.IPROTO_DATA))
-	enc.Encode([]interface{}{data})
-	return buf
+	require.NoError(t, enc.EncodeMapLen(1))
+	require.NoError(t, enc.EncodeUint8(uint8(iproto.IPROTO_DATA)))
+	require.NoError(t, enc.Encode([]interface{}{data}))
 
+	return buf
 }
 
 func TestDecodeBaseResponse(t *testing.T) {

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -169,7 +169,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	go func() {
 		// CloseGraceful closes the connection gracefully.
-		conn.CloseGraceful()
+		_ = conn.CloseGraceful()
 		// Connection is closed.
 		assert.Equal(t, true, conn.ClosedNow())
 	}()

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -1124,7 +1124,8 @@ func TestSQLTyped(t *testing.T) {
 	fut := conn.Do(NewExecuteRequest(selectTypedQuery).
 		Args([]interface{}{1}),
 	)
-	fut.GetTyped(&mem)
+	err := fut.GetTyped(&mem)
+	assert.NoError(t, err, "Error while GetTyped")
 	resp, err := fut.GetResponse()
 	assert.NoError(t, err, "Error while getting Response")
 	exResp, ok := resp.(*ExecuteResponse)

--- a/test_helpers/doer.go
+++ b/test_helpers/doer.go
@@ -61,7 +61,7 @@ func (doer *MockDoer) Do(req tarantool.Request) *tarantool.Future {
 	if response.err != nil {
 		fut.SetError(response.err)
 	} else {
-		fut.SetResponse(response.resp.header, bytes.NewBuffer(response.resp.data))
+		_ = fut.SetResponse(response.resp.header, bytes.NewBuffer(response.resp.data))
 	}
 	doer.responses = doer.responses[1:]
 

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -171,7 +171,7 @@ func (t *TarantoolInstance) Stop() error {
 			return fmt.Errorf("failed to kill tarantool %q (pid %d), got %s",
 				t.Opts.Listen, t.Cmd.Process.Pid, err)
 		}
-		t.Wait()
+		_ = t.Wait()
 	}
 	return nil
 }

--- a/test_helpers/tcs/prepare.go
+++ b/test_helpers/tcs/prepare.go
@@ -29,7 +29,10 @@ func writeConfig(name string, port int) error {
 	}
 	defer cfg.Close()
 
-	cfg.Chmod(0644)
+	err = cfg.Chmod(0644)
+	if err != nil {
+		return err
+	}
 
 	t := template.Must(template.New("config").Parse(string(tcsConfig)))
 	return t.Execute(cfg, map[string]interface{}{


### PR DESCRIPTION
Tests and methods are updated with enabling `errcheck` for `golangci-lint` check.

Closes #334

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)
