### PR TITLE
tests: fix flaky_TestConnectionHandlerOpenUpdateClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* Fixed the fluctuating behavior of the TestConnectionHandlerOpenUpdateClose
+  test by increasing the waiting time (#502).
+
 ## [v2.4.1] - 2025-10-16
 
 This maintenance release marks the end of active development on the `v2`

--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -1123,7 +1123,7 @@ func TestConnectionHandlerOpenUpdateClose(t *testing.T) {
 
 	h := &testHandler{}
 	poolOpts := pool.Opts{
-		CheckTimeout:      100 * time.Microsecond,
+		CheckTimeout:      100 * time.Millisecond,
 		ConnectionHandler: h,
 	}
 	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)


### PR DESCRIPTION
tests: fix flaky_TestConnectionHandlerOpenUpdateClose

- Increased the waiting time to milliseconds. 
- Changed the require.Nilf on require.NoError.

Closes #502 