### PR TITLE
api: replaced Future.done with a sync.Cond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Added `box.MustNew` wrapper for `box.New` without an error (#448).
 * Added missing IPROTO feature flags to greeting negotiation
   (iproto.IPROTO_FEATURE_IS_SYNC, iproto.IPROTO_FEATURE_INSERT_ARROW) (#466).
+* Added Future.cond (sync.Cond) and Future.finished bool. Added Future.finish() marks Future as done (#496).
 
 ### Changed
 
@@ -28,6 +29,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * `LogAppendPushFailed` replaced with `LogBoxSessionPushUnsupported` (#480).
 * Removed deprecated `Connection` methods, related interfaces and tests are updated (#479).
 * Replaced the use of optional types in crud with go-option library (#492).
+* Future.done replaced with Future.cond (sync.Cond) + Future.finished bool (#496).
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,6 +15,7 @@ TODO
 * Removed `box.session.push()` support: Future.AppendPush() and Future.GetIterator()
   methods, ResponseIterator and TimeoutResponseIterator types.
 * Removed deprecated `Connection` methods, related interfaces and tests are updated.
+
   *NOTE*: due to Future.GetTyped() doesn't decode SelectRequest into structure, substitute Connection.GetTyped() following the example:
   ```Go
   var singleTpl = Tuple{}
@@ -30,6 +31,7 @@ TODO
   ).GetTyped(&tpl)
   singleTpl := tpl[0]
   ```
+* Future.done replaced with Future.cond (sync.Cond) + Future.finished bool.
 
 ## Migration from v1.x.x to v2.x.x
 


### PR DESCRIPTION
This commit reduces allocations.

Future.done allocation replaced with
- Future.cond (sync.Cond)
- Future.finished (bool)

Other code use `Future.finished` instead `Future.done == nil` check.

Added Future.finish() marks Future as done.
Future.WaitChan() now creates channel on demand.

Closes https://github.com/tarantool/go-tarantool/issues/496

- [X] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [X] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)