### PR TITLE
future: interface transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   (iproto.IPROTO_FEATURE_IS_SYNC, iproto.IPROTO_FEATURE_INSERT_ARROW) (#466).
 * Added Future.cond (sync.Cond) and Future.finished bool. Added Future.finish() marks Future as done (#496).
 * Added function String() for type datetime (#322).
+* New `Future` interface (#470).
 
 ### Changed
 
@@ -31,6 +32,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Removed deprecated `Connection` methods, related interfaces and tests are updated (#479).
 * Replaced the use of optional types in crud with go-option library (#492).
 * Future.done replaced with Future.cond (sync.Cond) + Future.finished bool (#496).
+* `Future` transform into `future` that implements interface `Future` and become private,
+  `SetError` and `SetResponse` become private (#470).
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,6 +32,7 @@ TODO
   singleTpl := tpl[0]
   ```
 * Future.done replaced with Future.cond (sync.Cond) + Future.finished bool.
+* `Future` is an interface now.
 
 ## Migration from v1.x.x to v2.x.x
 

--- a/connector.go
+++ b/connector.go
@@ -5,7 +5,7 @@ import "time"
 // Doer is an interface that performs requests asynchronously.
 type Doer interface {
 	// Do performs a request asynchronously.
-	Do(req Request) (fut *Future)
+	Do(req Request) Future
 }
 
 type Connector interface {

--- a/future.go
+++ b/future.go
@@ -6,11 +6,19 @@ import (
 	"time"
 )
 
-// Future is a handle for asynchronous request.
-type Future struct {
+// Future is an interface that handle asynchronous request.
+type Future interface {
+	Get() ([]interface{}, error)
+	GetTyped(result interface{}) error
+	GetResponse() (Response, error)
+	WaitChan() <-chan struct{}
+}
+
+// future is inner implementation of Future interface.
+type future struct {
 	requestId uint32
 	req       Request
-	next      *Future
+	next      *future
 	timeout   time.Duration
 	mutex     sync.Mutex
 	resp      Response
@@ -20,7 +28,9 @@ type Future struct {
 	done      chan struct{}
 }
 
-func (fut *Future) wait() {
+var _ = Future(&future{})
+
+func (fut *future) wait() {
 	fut.mutex.Lock()
 	defer fut.mutex.Unlock()
 
@@ -29,7 +39,7 @@ func (fut *Future) wait() {
 	}
 }
 
-func (fut *Future) finish() {
+func (fut *future) finish() {
 	fut.mutex.Lock()
 	defer fut.mutex.Unlock()
 
@@ -42,16 +52,25 @@ func (fut *Future) finish() {
 	fut.cond.Broadcast()
 }
 
-func (fut *Future) isFinished() bool {
-	fut.mutex.Lock()
-	defer fut.mutex.Unlock()
-
-	return fut.finished
+// NewFutureWithErr returns Future with given error.
+func NewFutureWithErr(req Request, err error) Future {
+	fut := newFuture(req)
+	fut.setError(err)
+	return fut
 }
 
-// NewFuture creates a new empty Future for a given Request.
-func NewFuture(req Request) (fut *Future) {
-	fut = &Future{}
+// NewFutureWithResponse returns Future with given Response.
+func NewFutureWithResponse(req Request, header Header, body io.Reader) (Future, error) {
+	fut := newFuture(req)
+	if err := fut.setResponse(header, body); err != nil {
+		return nil, err
+	}
+	return fut, nil
+}
+
+// newFuture creates a new empty future for a given Request.
+func newFuture(req Request) (fut *future) {
+	fut = &future{}
 	fut.done = nil
 	fut.finished = false
 	fut.cond.L = &fut.mutex
@@ -59,8 +78,15 @@ func NewFuture(req Request) (fut *Future) {
 	return fut
 }
 
-// SetResponse sets a response for the future and finishes the future.
-func (fut *Future) SetResponse(header Header, body io.Reader) error {
+func (fut *future) isFinished() bool {
+	fut.mutex.Lock()
+	defer fut.mutex.Unlock()
+
+	return fut.finished
+}
+
+// setResponse sets a response for the future and finishes the future.
+func (fut *future) setResponse(header Header, body io.Reader) error {
 	fut.mutex.Lock()
 	defer fut.mutex.Unlock()
 
@@ -85,8 +111,8 @@ func (fut *Future) SetResponse(header Header, body io.Reader) error {
 	return nil
 }
 
-// SetError sets an error for the future and finishes the future.
-func (fut *Future) SetError(err error) {
+// setError sets an error for the future and finishes the future.
+func (fut *future) setError(err error) {
 	fut.mutex.Lock()
 	defer fut.mutex.Unlock()
 
@@ -110,7 +136,7 @@ func (fut *Future) SetError(err error) {
 //
 // "error" could be Error, if it is error returned by Tarantool,
 // or ClientError, if something bad happens in a client process.
-func (fut *Future) GetResponse() (Response, error) {
+func (fut *future) GetResponse() (Response, error) {
 	fut.wait()
 	return fut.resp, fut.err
 }
@@ -121,7 +147,7 @@ func (fut *Future) GetResponse() (Response, error) {
 //
 // "error" could be Error, if it is error returned by Tarantool,
 // or ClientError, if something bad happens in a client process.
-func (fut *Future) Get() ([]interface{}, error) {
+func (fut *future) Get() ([]interface{}, error) {
 	fut.wait()
 	if fut.err != nil {
 		return nil, fut.err
@@ -133,7 +159,7 @@ func (fut *Future) Get() ([]interface{}, error) {
 // It is could be much faster than Get() function.
 //
 // Note: Tarantool usually returns array of tuples (except for Eval and Call17 actions).
-func (fut *Future) GetTyped(result interface{}) error {
+func (fut *future) GetTyped(result interface{}) error {
 	fut.wait()
 	if fut.err != nil {
 		return fut.err
@@ -148,7 +174,7 @@ func init() {
 }
 
 // WaitChan returns channel which becomes closed when response arrived or error occurred.
-func (fut *Future) WaitChan() <-chan struct{} {
+func (fut *future) WaitChan() <-chan struct{} {
 	fut.mutex.Lock()
 	defer fut.mutex.Unlock()
 

--- a/pool/connector.go
+++ b/pool/connector.go
@@ -81,6 +81,6 @@ func (c *ConnectorAdapter) NewWatcher(key string,
 }
 
 // Do performs a request asynchronously on the connection.
-func (c *ConnectorAdapter) Do(req tarantool.Request) *tarantool.Future {
+func (c *ConnectorAdapter) Do(req tarantool.Request) tarantool.Future {
 	return c.pool.Do(req, c.mode)
 }

--- a/pool/connector_test.go
+++ b/pool/connector_test.go
@@ -125,7 +125,7 @@ func TestConnectorConfiguredTimeoutWithError(t *testing.T) {
 // Tests for that ConnectorAdapter is just a proxy for requests.
 
 var errReq error = errors.New("response error")
-var reqFuture *tarantool.Future = &tarantool.Future{}
+var reqFuture tarantool.Future = tarantool.NewFutureWithErr(nil, nil)
 
 var reqFunctionName string = "any_name"
 var reqPrepared *tarantool.Prepared = &tarantool.Prepared{}
@@ -233,7 +233,7 @@ type doMock struct {
 	mode   Mode
 }
 
-func (m *doMock) Do(req tarantool.Request, mode Mode) *tarantool.Future {
+func (m *doMock) Do(req tarantool.Request, mode Mode) tarantool.Future {
 	m.called++
 	m.req = req
 	m.mode = mode

--- a/pool/pooler.go
+++ b/pool/pooler.go
@@ -28,5 +28,5 @@ type Pooler interface {
 	NewStream(mode Mode) (*tarantool.Stream, error)
 	NewWatcher(key string, callback tarantool.WatchCallback,
 		mode Mode) (tarantool.Watcher, error)
-	Do(req tarantool.Request, mode Mode) (fut *tarantool.Future)
+	Do(req tarantool.Request, mode Mode) (fut tarantool.Future)
 }

--- a/stream.go
+++ b/stream.go
@@ -238,12 +238,10 @@ func (req *RollbackRequest) Context(ctx context.Context) *RollbackRequest {
 //
 // An error is returned if the request was formed incorrectly, or failure to
 // create the future.
-func (s *Stream) Do(req Request) *Future {
+func (s *Stream) Do(req Request) Future {
 	if connectedReq, ok := req.(ConnectedRequest); ok {
 		if connectedReq.Conn() != s.Conn {
-			fut := NewFuture(req)
-			fut.SetError(errUnknownStreamRequest)
-			return fut
+			return NewFutureWithErr(req, errUnknownStreamRequest)
 		}
 	}
 	return s.Conn.send(req, s.Id)

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -360,7 +360,7 @@ func TestBenchmarkAsync(t *testing.T) {
 			for i := range cc {
 				wg.Add(1)
 
-				ch := make(chan *Future, 1024)
+				ch := make(chan Future, 1024)
 
 				go func(i int) {
 					defer close(ch)
@@ -2491,7 +2491,7 @@ func TestClientRequestObjectsWithContext(t *testing.T) {
 	req.wg.Add(1)
 
 	var futWg sync.WaitGroup
-	var fut *Future
+	var fut Future
 
 	futWg.Add(1)
 	go func() {


### PR DESCRIPTION
Changed Future into interface, add inner `future` type, updated methods and functions with new interface.

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Closes #470 