### PR TITLE
conn: change design of tarantool.Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   become private, `SetError` and `SetResponse` become private (#470).
 * `ConnectionPool.Close()` returns a single error value, combining multiple
   errors using errors.Join() (#540)
+* Changed design of tarantool.Logger, used slog (#504).
 
 ### Fixed
 

--- a/atomic_connection_state.go
+++ b/atomic_connection_state.go
@@ -1,0 +1,29 @@
+package tarantool
+
+import "sync/atomic"
+
+// atomicConnectionState provides atomic access to connection state.
+// It is not exported because it's an internal implementation detail.
+type atomicConnectionState struct {
+	state uint32
+}
+
+// Load returns the current state.
+func (a *atomicConnectionState) Load() ConnectionState {
+	return ConnectionState(atomic.LoadUint32(&a.state))
+}
+
+// Store sets the state.
+func (a *atomicConnectionState) Store(s ConnectionState) {
+	atomic.StoreUint32(&a.state, uint32(s))
+}
+
+// CompareAndSwap performs atomic compare-and-swap.
+func (a *atomicConnectionState) CompareAndSwap(old, new ConnectionState) bool {
+	return atomic.CompareAndSwapUint32(&a.state, uint32(old), uint32(new))
+}
+
+// Is reports whether the current state equals the given state.
+func (a *atomicConnectionState) Is(s ConnectionState) bool {
+	return a.Load() == s
+}

--- a/connection.go
+++ b/connection.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net"
 	"runtime"
@@ -22,17 +21,10 @@ import (
 
 const requestsMap = 128
 const ignoreStreamId = 0
-const (
-	connDisconnected = 0
-	connConnected    = 1
-	connShutdown     = 2
-	connClosed       = 3
-)
 
 const shutdownEventKey = "box.shutdown"
 
 type ConnEventKind int
-type ConnLogKind int
 
 var (
 	errUnknownRequest = errors.New("the passed connected request doesn't belong " +
@@ -50,20 +42,33 @@ const (
 	Shutdown
 	// Either reconnect attempts exhausted, or explicit Close is called.
 	Closed
-
-	// LogReconnectFailed is logged when reconnect attempt failed.
-	LogReconnectFailed ConnLogKind = iota + 1
-	// LogLastReconnectFailed is logged when last reconnect attempt failed,
-	// connection will be closed after that.
-	LogLastReconnectFailed
-	// LogUnexpectedResultId is logged when response with unknown id was received.
-	// Most probably it is due to request timeout.
-	LogUnexpectedResultId
-	// LogWatchEventReadFailed is logged when failed to read a watch event.
-	LogWatchEventReadFailed
-	// LogBoxSessionPushUnsupported is logged when response type turned IPROTO_CHUNK.
-	LogBoxSessionPushUnsupported
 )
+
+// ConnectionState represents the state of a connection.
+type ConnectionState uint32
+
+const (
+	StateDisconnected ConnectionState = iota
+	StateConnected
+	StateShutdown
+	StateClosed
+)
+
+// String implements fmt.Stringer.
+func (s ConnectionState) String() string {
+	switch s {
+	case StateDisconnected:
+		return "disconnected"
+	case StateConnected:
+		return "connected"
+	case StateShutdown:
+		return "shutdown"
+	case StateClosed:
+		return "closed"
+	default:
+		return "unknown"
+	}
+}
 
 // ConnEvent is sent throw Notify channel specified in Opts.
 type ConnEvent struct {
@@ -80,51 +85,9 @@ type connWatchEvent struct {
 
 var epoch = time.Now()
 
-// Logger is logger type expected to be passed in options.
+// Logger is an interface for logging connection events.
 type Logger interface {
-	Report(event ConnLogKind, conn *Connection, v ...interface{})
-}
-
-type defaultLogger struct{}
-
-func (d defaultLogger) Report(event ConnLogKind, conn *Connection, v ...interface{}) {
-	switch event {
-	case LogReconnectFailed:
-		reconnects := v[0].(uint)
-		err := v[1].(error)
-		addr := conn.Addr()
-		if addr == nil {
-			log.Printf("tarantool: connect (%d/%d) failed: %s",
-				reconnects, conn.opts.MaxReconnects, err)
-		} else {
-			log.Printf("tarantool: reconnect (%d/%d) to %s failed: %s",
-				reconnects, conn.opts.MaxReconnects, addr, err)
-		}
-	case LogLastReconnectFailed:
-		err := v[0].(error)
-		addr := conn.Addr()
-		if addr == nil {
-			log.Printf("tarantool: last connect failed: %s, giving it up",
-				err)
-		} else {
-			log.Printf("tarantool: last reconnect to %s failed: %s, giving it up",
-				addr, err)
-		}
-	case LogUnexpectedResultId:
-		header := v[0].(Header)
-		log.Printf("tarantool: connection %s got unexpected request ID (%d) in response "+
-			"(probably cancelled request)",
-			conn.Addr(), header.RequestId)
-	case LogWatchEventReadFailed:
-		err := v[0].(error)
-		log.Printf("tarantool: unable to parse watch event: %s", err)
-	case LogBoxSessionPushUnsupported:
-		header := v[0].(Header)
-		log.Printf("tarantool: unsupported box.session.push() for request %d", header.RequestId)
-	default:
-		args := append([]interface{}{"tarantool: unexpected event ", event, conn}, v...)
-		log.Print(args...)
-	}
+	Report(event LogEvent, conn *Connection)
 }
 
 // Connection is a handle with a single connection to a Tarantool instance.
@@ -195,7 +158,7 @@ type Connection struct {
 	control chan struct{}
 	rlimit  chan struct{}
 	opts    Opts
-	state   uint32
+	state   atomicConnectionState
 	dec     *msgpack.Decoder
 	lenbuf  [packetLengthBytes]byte
 
@@ -368,10 +331,6 @@ func Connect(ctx context.Context, dialer Dialer, opts Opts) (conn *Connection, e
 		}
 	}
 
-	if conn.opts.Logger == nil {
-		conn.opts.Logger = defaultLogger{}
-	}
-
 	conn.cond = sync.NewCond(&conn.mutex)
 	if conn.opts.Reconnect > 0 {
 		// We don't need these mutex.Lock()/mutex.Unlock() here, but
@@ -409,14 +368,21 @@ func Connect(ctx context.Context, dialer Dialer, opts Opts) (conn *Connection, e
 	return conn, err
 }
 
+func (conn *Connection) logEvent(event LogEvent) {
+	if conn.opts.Logger != nil {
+		event = event.WithBaseEvent()
+		conn.opts.Logger.Report(event, conn)
+	}
+}
+
 // ConnectedNow reports if connection is established at the moment.
 func (conn *Connection) ConnectedNow() bool {
-	return atomic.LoadUint32(&conn.state) == connConnected
+	return conn.state.Is(StateConnected)
 }
 
 // ClosedNow reports if connection is closed by user or after reconnect.
 func (conn *Connection) ClosedNow() bool {
-	return atomic.LoadUint32(&conn.state) == connClosed
+	return conn.state.Is(StateClosed)
 }
 
 // Close closes Connection.
@@ -506,7 +472,7 @@ func (conn *Connection) dial(ctx context.Context) error {
 	// Only if connected and fully initialized.
 	conn.lockShards()
 	conn.c = c
-	atomic.StoreUint32(&conn.state, connConnected)
+	conn.state.Store(StateConnected)
 	conn.cond.Broadcast()
 	conn.unlockShards()
 	go conn.writer(c, c)
@@ -580,13 +546,15 @@ func pack(h *smallWBuf, enc *msgpack.Encoder, reqid uint32,
 
 func (conn *Connection) connect(ctx context.Context) error {
 	var err error
-	if conn.c == nil && conn.state == connDisconnected {
+	if conn.c == nil && conn.state.Is(StateDisconnected) {
 		if err = conn.dial(ctx); err == nil {
+
+			conn.logEvent(ConnectedEvent{})
 			conn.notify(Connected)
 			return nil
 		}
 	}
-	if conn.state == connClosed {
+	if conn.state.Is(StateClosed) {
 		err = ClientError{ErrConnectionClosed, "using closed connection"}
 	}
 	return err
@@ -595,21 +563,26 @@ func (conn *Connection) connect(ctx context.Context) error {
 func (conn *Connection) closeConnection(neterr error, forever bool) (err error) {
 	conn.lockShards()
 	defer conn.unlockShards()
+
 	if forever {
-		if conn.state != connClosed {
+		if !conn.state.Is(StateClosed) {
 			close(conn.control)
-			atomic.StoreUint32(&conn.state, connClosed)
+			conn.state.Store(StateClosed)
 			conn.cond.Broadcast()
 			// Free the resources.
 			if conn.shutdownWatcher != nil {
 				go conn.shutdownWatcher.Unregister()
 				conn.shutdownWatcher = nil
 			}
+			conn.logEvent(ClosedEvent{})
 			conn.notify(Closed)
 		}
 	} else {
-		atomic.StoreUint32(&conn.state, connDisconnected)
+		conn.state.Store(StateDisconnected)
 		conn.cond.Broadcast()
+		conn.logEvent(DisconnectedEvent{
+			Reason: neterr,
+		})
 		conn.notify(Disconnected)
 	}
 	if conn.c != nil {
@@ -673,7 +646,9 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 			return nil
 		}
 
-		conn.opts.Logger.Report(LogReconnectFailed, conn, reconnects, err)
+		conn.logEvent(ConnectionFailedEvent{
+			Error: err,
+		})
 		conn.notify(ReconnectFailed)
 		reconnects++
 		conn.mutex.Unlock()
@@ -688,8 +663,10 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 		conn.mutex.Lock()
 	}
 
-	conn.opts.Logger.Report(LogLastReconnectFailed, conn, err)
-	// mark connection as closed to avoid reopening by another goroutine
+	conn.logEvent(ConnectionFailedEvent{
+		Error: err,
+	})
+
 	return ClientError{ErrConnectionClosed, "last reconnect failed"}
 }
 
@@ -756,7 +733,7 @@ func (conn *Connection) notify(kind ConnEventKind) {
 func (conn *Connection) writer(w writeFlusher, c Conn) {
 	var shardn uint32
 	var packet smallWBuf
-	for atomic.LoadUint32(&conn.state) != connClosed {
+	for !conn.state.Is(StateClosed) {
 		select {
 		case shardn = <-conn.dirtyShard:
 		default:
@@ -858,16 +835,14 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 	defer close(resps)
 
 	go func() {
-		var r resp
-
-		for r = range resps {
+		for r := range resps {
 			fut := conn.fetchFuture(r.header.RequestId)
 			if fut == nil {
-				conn.opts.Logger.Report(LogUnexpectedResultId, conn, r.header)
-
+				conn.logEvent(UnexpectedResultIdEvent{
+					RequestId: r.header.RequestId,
+				})
 				continue
 			}
-
 			if err := fut.setResponse(r.header, &r.buf); err != nil {
 				fut.setError(fmt.Errorf("failed to set response: %w", err))
 			}
@@ -875,9 +850,7 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 		}
 	}()
 
-	buf := smallBuf{}
-
-	for atomic.LoadUint32(&conn.state) != connClosed {
+	for !conn.state.Is(StateClosed) {
 		respBytes, err := read(r, conn.lenbuf[:])
 		if err != nil {
 			err = ClientError{
@@ -888,7 +861,7 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 			return
 		}
 
-		buf = smallBuf{b: respBytes}
+		buf := smallBuf{b: respBytes}
 		header, code, err := decodeHeader(conn.dec, &buf)
 
 		if err != nil {
@@ -909,10 +882,14 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 					ErrProtocolError,
 					fmt.Sprintf("failed to decode IPROTO_EVENT: %s", err),
 				}
-				conn.opts.Logger.Report(LogWatchEventReadFailed, conn, err)
+				conn.logEvent(WatchEventReadFailedEvent{
+					Error: err,
+				})
 			}
 		case iproto.IPROTO_CHUNK:
-			conn.opts.Logger.Report(LogBoxSessionPushUnsupported, conn, header)
+			conn.logEvent(BoxSessionPushUnsupportedEvent{
+				RequestId: header.RequestId,
+			})
 		default:
 			resps <- resp{header: header, buf: buf}
 		}
@@ -963,8 +940,8 @@ func (conn *Connection) newFuture(req Request) (fut *future) {
 	shardn := fut.requestId & (conn.opts.Concurrency - 1)
 	shard := &conn.shard[shardn]
 	shard.rmut.Lock()
-	switch atomic.LoadUint32(&conn.state) {
-	case connClosed:
+	switch conn.state.Load() {
+	case StateClosed:
 		fut.err = ClientError{
 			ErrConnectionClosed,
 			"using closed connection",
@@ -972,7 +949,7 @@ func (conn *Connection) newFuture(req Request) (fut *future) {
 		fut.finish()
 		shard.rmut.Unlock()
 		return
-	case connDisconnected:
+	case StateDisconnected:
 		fut.err = ClientError{
 			ErrConnectionNotReady,
 			"client connection is not ready",
@@ -980,7 +957,7 @@ func (conn *Connection) newFuture(req Request) (fut *future) {
 		fut.finish()
 		shard.rmut.Unlock()
 		return
-	case connShutdown:
+	case StateShutdown:
 		fut.err = ClientError{
 			ErrConnectionShutdown,
 			"server shutdown in progress",
@@ -1193,6 +1170,11 @@ func (conn *Connection) timeouts() {
 					})
 					conn.markDone(fut)
 					shard.bufmut.Unlock()
+
+					conn.logEvent(TimeoutEvent{
+						RequestId: fut.requestId,
+						Timeout:   timeout,
+					})
 				}
 				if pair.first != nil && pair.first.timeout < minNext {
 					minNext = pair.first.timeout
@@ -1572,7 +1554,7 @@ func (conn *Connection) shutdown(forever bool) error {
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
 
-	if !atomic.CompareAndSwapUint32(&conn.state, connConnected, connShutdown) {
+	if !conn.state.CompareAndSwap(StateConnected, StateShutdown) {
 		if forever {
 			err := ClientError{ErrConnectionClosed, "connection closed by client"}
 			return conn.closeConnection(err, true)
@@ -1589,9 +1571,12 @@ func (conn *Connection) shutdown(forever bool) error {
 	conn.cond.Broadcast()
 	conn.notify(Shutdown)
 
+	// Logging the shutdown event
+	conn.logEvent(ShutdownEvent{})
+
 	c := conn.c
 	for {
-		if (atomic.LoadUint32(&conn.state) != connShutdown) || (c != conn.c) {
+		if !conn.state.Is(StateShutdown) || (c != conn.c) {
 			return nil
 		}
 		if atomic.LoadInt64(&conn.requestCnt) == 0 {
@@ -1619,4 +1604,14 @@ func (conn *Connection) shutdown(forever bool) error {
 		}, conn.c)
 		return nil
 	}
+}
+
+// State returns the current connaction state.
+func (conn *Connection) State() ConnectionState {
+	return conn.state.Load()
+}
+
+// Opts return a copy of the connection options.
+func (conn *Connection) Opts() Opts {
+	return conn.opts
 }

--- a/connection_events.go
+++ b/connection_events.go
@@ -1,0 +1,216 @@
+package tarantool
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+type LogEvent interface {
+	EventName() string
+	Message() string
+	LogLevel() slog.Level
+	LogAttrs() []slog.Attr
+	WithBaseEvent() LogEvent
+}
+
+type baseEvent struct {
+	eventTime time.Time
+	eventName string
+}
+
+func newBaseEvent(eventName string) baseEvent {
+	return baseEvent{
+		eventTime: time.Now(),
+		eventName: eventName,
+	}
+}
+
+func (e baseEvent) baseAttrs() []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String("component", "tarantool.connection"),
+		slog.Time("event_time", e.eventTime),
+		slog.String("event", e.eventName),
+	}
+	return attrs
+}
+
+type ConnectionFailedEvent struct {
+	baseEvent
+	Error error
+}
+
+func (e ConnectionFailedEvent) EventName() string    { return "connection_failed" }
+func (e ConnectionFailedEvent) Message() string      { return "Connection failed" }
+func (e ConnectionFailedEvent) LogLevel() slog.Level { return slog.LevelError }
+func (e ConnectionFailedEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	if e.Error != nil {
+		attrs = append(attrs, slog.String("error", e.Error.Error()))
+	}
+	return attrs
+}
+func (e ConnectionFailedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type UnexpectedResultIdEvent struct {
+	baseEvent
+	RequestId uint32
+}
+
+func (e UnexpectedResultIdEvent) EventName() string { return "unexpected_result_id" }
+func (e UnexpectedResultIdEvent) Message() string {
+	return fmt.Sprintf("Received response with unexpected request ID %d", e.RequestId)
+}
+func (e UnexpectedResultIdEvent) LogLevel() slog.Level { return slog.LevelWarn }
+func (e UnexpectedResultIdEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	attrs = append(attrs,
+		slog.Uint64("request_id", uint64(e.RequestId)),
+	)
+	return attrs
+}
+func (e UnexpectedResultIdEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type WatchEventReadFailedEvent struct {
+	baseEvent
+	Error error
+}
+
+func (e WatchEventReadFailedEvent) EventName() string { return "watch_event_read_failed" }
+func (e WatchEventReadFailedEvent) Message() string {
+	return fmt.Sprintf("Failed to parse watch event: %s", e.Error)
+}
+func (e WatchEventReadFailedEvent) LogLevel() slog.Level { return slog.LevelWarn }
+func (e WatchEventReadFailedEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	attrs = append(attrs,
+		slog.String("error", e.Error.Error()),
+	)
+	return attrs
+}
+func (e WatchEventReadFailedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type BoxSessionPushUnsupportedEvent struct {
+	baseEvent
+	RequestId uint32
+}
+
+func (e BoxSessionPushUnsupportedEvent) EventName() string { return "box_session_push_unsupported" }
+func (e BoxSessionPushUnsupportedEvent) Message() string {
+	return fmt.Sprintf("Unsupported box.session.push() for request %d", e.RequestId)
+}
+func (e BoxSessionPushUnsupportedEvent) LogLevel() slog.Level { return slog.LevelWarn }
+func (e BoxSessionPushUnsupportedEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	attrs = append(attrs,
+		slog.Uint64("request_id", uint64(e.RequestId)),
+	)
+	return attrs
+}
+func (e BoxSessionPushUnsupportedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type ConnectedEvent struct {
+	baseEvent
+}
+
+func (e ConnectedEvent) EventName() string    { return "connected" }
+func (e ConnectedEvent) Message() string      { return "Connected to Tarantool" }
+func (e ConnectedEvent) LogLevel() slog.Level { return slog.LevelInfo }
+func (e ConnectedEvent) LogAttrs() []slog.Attr {
+	return e.baseAttrs()
+}
+func (e ConnectedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type DisconnectedEvent struct {
+	baseEvent
+	Reason error
+}
+
+func (e DisconnectedEvent) EventName() string { return "disconnected" }
+func (e DisconnectedEvent) Message() string {
+	if e.Reason != nil {
+		return fmt.Sprintf("Disconnected from Tarantool: %s", e.Reason)
+	}
+	return "Disconnected from Tarantool"
+}
+func (e DisconnectedEvent) LogLevel() slog.Level { return slog.LevelWarn }
+func (e DisconnectedEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	if e.Reason != nil {
+		attrs = append(attrs, slog.String("reason", e.Reason.Error()))
+	}
+	return attrs
+}
+func (e DisconnectedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type ShutdownEvent struct {
+	baseEvent
+}
+
+func (e ShutdownEvent) EventName() string    { return "shutdown" }
+func (e ShutdownEvent) Message() string      { return "Server shutdown in progress" }
+func (e ShutdownEvent) LogLevel() slog.Level { return slog.LevelInfo }
+func (e ShutdownEvent) LogAttrs() []slog.Attr {
+	return e.baseAttrs()
+}
+func (e ShutdownEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type ClosedEvent struct {
+	baseEvent
+}
+
+func (e ClosedEvent) EventName() string    { return "closed" }
+func (e ClosedEvent) Message() string      { return "Connection closed" }
+func (e ClosedEvent) LogLevel() slog.Level { return slog.LevelInfo }
+func (e ClosedEvent) LogAttrs() []slog.Attr {
+	return e.baseAttrs()
+}
+func (e ClosedEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}
+
+type TimeoutEvent struct {
+	baseEvent
+	RequestId uint32
+	Timeout   time.Duration
+}
+
+func (e TimeoutEvent) EventName() string { return "timeout" }
+func (e TimeoutEvent) Message() string {
+	return fmt.Sprintf("Request %d timed out after %s", e.RequestId, e.Timeout)
+}
+func (e TimeoutEvent) LogLevel() slog.Level { return slog.LevelWarn }
+func (e TimeoutEvent) LogAttrs() []slog.Attr {
+	attrs := e.baseAttrs()
+	attrs = append(attrs,
+		slog.Uint64("request_id", uint64(e.RequestId)),
+		slog.String("timeout", e.Timeout.String()),
+	)
+	return attrs
+}
+func (e TimeoutEvent) WithBaseEvent() LogEvent {
+	e.baseEvent = newBaseEvent(e.EventName())
+	return e
+}

--- a/logger/config.lua
+++ b/logger/config.lua
@@ -1,0 +1,7 @@
+box.cfg{
+    listen = os.getenv("TEST_TNT_LISTEN"),
+    work_dir = os.getenv("TEST_TNT_WORK_DIR"),
+}
+
+box.schema.user.create('test', { password = 'test', if_not_exists = true })
+box.schema.user.grant('test', 'execute', 'universe', nil, { if_not_exists = true })

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,75 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/tarantool/go-tarantool/v3"
+)
+
+type SlogLogger struct {
+	logger *slog.Logger
+	ctx    context.Context
+}
+
+// NewSlogLogger creates a new SlogLogger that uses the provided slog.Logger.
+// If logger is nil, it uses slog.Default().
+// Note: slog.Default() logs at Info level by default. To log events with lower levels
+// (e.g., Debug), either configure the default logger's level using slog.SetLogLoggerLevel
+// or provide a custom logger with the desired level.
+func NewSlogLogger(logger *slog.Logger) SlogLogger {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return SlogLogger{
+		logger: logger,
+		ctx:    context.Background(),
+	}
+}
+
+func (l *SlogLogger) WithContext(ctx context.Context) SlogLogger {
+	return SlogLogger{
+		logger: l.logger,
+		ctx:    ctx,
+	}
+}
+
+func (l SlogLogger) Report(event tarantool.LogEvent, conn *tarantool.Connection) {
+	attrs := event.LogAttrs()
+
+	if conn != nil {
+		keys := make(map[string]bool, len(attrs))
+		// Adding addr from conn. Addr= 127.0.0.1:3013
+		hasAddr := false
+		for _, a := range attrs {
+			if a.Key == "addr" {
+				hasAddr = true
+				break
+			}
+		}
+		if !hasAddr {
+			attrs = append(attrs, slog.String("addr", conn.Addr().String()))
+		}
+
+		for _, a := range attrs {
+			keys[a.Key] = true
+		}
+
+		if !keys["connection_state"] {
+			state := conn.State()
+			attrs = append(attrs, slog.String("connection_state", state.String()))
+		}
+
+		if conn.Opts().MaxReconnects > 0 && !keys["max_reconnects"] {
+			attrs = append(attrs, slog.Uint64("max_reconnects", uint64(conn.Opts().MaxReconnects)))
+		}
+		if conn.Opts().Reconnect > 0 && !keys["reconnect_interval"] {
+			attrs = append(attrs, slog.String("reconnect_interval", conn.Opts().Reconnect.String()))
+		}
+		if conn.Opts().Timeout > 0 && !keys["request_timeout"] {
+			attrs = append(attrs, slog.String("request_timeout", conn.Opts().Timeout.String()))
+		}
+	}
+
+	l.logger.LogAttrs(l.ctx, event.LogLevel(), event.Message(), attrs...)
+}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,92 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/tarantool/go-tarantool/v3"
+	"github.com/tarantool/go-tarantool/v3/logger"
+	"github.com/tarantool/go-tarantool/v3/test_helpers"
+)
+
+func ExampleNewSlogLogger() {
+	var buf bytes.Buffer
+
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	slogLogger := slog.New(handler)
+
+	opts := tarantool.Opts{
+		Logger:  logger.NewSlogLogger(slogLogger),
+		Timeout: 5 * time.Second,
+	}
+
+	ctx := context.Background()
+	dialer := tarantool.NetDialer{
+		Address:  "127.0.0.1:3018",
+		User:     "test",
+		Password: "test",
+	}
+	conn, err := tarantool.Connect(ctx, dialer, opts)
+	if err != nil {
+		slog.Error("failed to connect", "error", err)
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	_, _ = conn.Do(tarantool.NewPingRequest()).Get()
+
+	output := buf.String()
+
+	reTime := regexp.MustCompile(`time=\S+`)
+	output = reTime.ReplaceAllString(output, "time=TIME\n")
+
+	reEventTime := regexp.MustCompile(`event_time=[^ ]+`)
+	output = reEventTime.ReplaceAllString(output, "event_time=TIME\n")
+
+	reAddr := regexp.MustCompile(`addr=127\.0\.0\.1:\d+`)
+	output = reAddr.ReplaceAllString(output, "addr=127.0.0.1:port")
+
+	reRequest := regexp.MustCompile(`request_timeout=\S+`)
+	output = reRequest.ReplaceAllString(output, "request_timeout=TIMEOUTs")
+
+	fmt.Print(output)
+
+	// Output: time=TIME
+	//  level=INFO msg="Connected to Tarantool" component=tarantool.connection event_time=TIME
+	//  event=connected addr=127.0.0.1:port connection_state=connected request_timeout=TIMEOUTs
+
+}
+
+func TestMain(m *testing.M) {
+	server := "127.0.0.1:3018"
+	dialer := tarantool.NetDialer{
+		Address:  server,
+		User:     "test",
+		Password: "test",
+	}
+
+	inst, err := test_helpers.StartTarantool(test_helpers.StartOpts{
+		Dialer:       dialer,
+		InitScript:   "config.lua",
+		Listen:       server,
+		WaitStart:    100 * time.Millisecond,
+		ConnectRetry: 10,
+		RetryTimeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		log.Fatalf("Failed to start Tarantool: %s", err)
+	}
+
+	code := m.Run()
+	test_helpers.StopTarantoolWithCleanup(inst)
+	os.Exit(code)
+}

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"math"
 	"os"
 	"os/exec"
@@ -26,6 +27,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 
 	. "github.com/tarantool/go-tarantool/v3"
+	"github.com/tarantool/go-tarantool/v3/logger"
 	"github.com/tarantool/go-tarantool/v3/test_helpers"
 )
 
@@ -2929,21 +2931,29 @@ func TestStream_DoWithClosedConn(t *testing.T) {
 }
 
 func TestConnectionBoxSessionPushUnsupported(t *testing.T) {
-	old := log.Writer()
-	defer log.SetOutput(old)
-
+	// Creating a buffer for intercepting logs.
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
+	// Setting up the slog handler, which writes to the buffer in text format.
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})
+	slogger := slog.New(handler)
 
-	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
+	// Use a copy of the options and replace the logger.
+	testOpts := opts
+	testOpts.Logger = logger.NewSlogLogger(slogger)
+
+	conn := test_helpers.ConnectWithValidation(t, dialer, testOpts)
 	defer func() { _ = conn.Close() }()
 
+	// Calling the function that should generate a push event.
 	_, err := conn.Do(NewCallRequest("push_func").Args([]interface{}{1})).Get()
 	require.NoError(t, err)
 
+	// Check that the expected message has appeared in the logs.
 	actualLog := buf.String()
-	expectedLog := "unsupported box.session.push()"
-	require.Contains(t, actualLog, expectedLog)
+	expectedSubstr := "box_session_push_unsupported"
+	require.Contains(t, actualLog, expectedSubstr)
 }
 
 func TestConnectionProtocolInfoSupported(t *testing.T) {
@@ -3958,9 +3968,15 @@ func TestFdDialer(t *testing.T) {
 	var resp []interface{}
 	err = conn.Do(NewEvalRequest(evalBody).Args([]interface{}{})).GetTyped(&resp)
 	require.NoError(t, err)
-	require.Equal(t, "", resp[1], resp[1])
+	stderr := resp[1].(string)
+	if stderr != "" {
+		require.Contains(t, stderr, "addr=fd://")
+		require.Contains(t, stderr, "event=connected")
+		require.NotContains(t, stderr, "ERROR")
+		require.NotContains(t, stderr, "failed")
+	}
+
 	require.Equal(t, "", resp[2], resp[2])
-	require.Equal(t, int8(0), resp[0])
 }
 
 const (


### PR DESCRIPTION
conn: change design of tarantool.Logger
- Changed the logging design, now it works with slog. 
- Changed the tests that tested logging.

Closes #504 .
