### PR TITLE
future: wrap fut.finished with mutex

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -1037,7 +1037,7 @@ func (conn *Connection) send(req Request, streamId uint64) *Future {
 
 	fut := conn.newFuture(req)
 
-	if fut.finished {
+	if fut.isFinished() {
 		conn.decrementRequestCnt()
 		return fut
 	}
@@ -1061,7 +1061,7 @@ func (conn *Connection) putFuture(fut *Future, req Request, streamId uint64) {
 	shard := &conn.shard[shardn]
 	shard.bufmut.Lock()
 
-	if fut.finished {
+	if fut.isFinished() {
 		shard.bufmut.Unlock()
 		return
 	}

--- a/future.go
+++ b/future.go
@@ -42,6 +42,13 @@ func (fut *Future) finish() {
 	fut.cond.Broadcast()
 }
 
+func (fut *Future) isFinished() bool {
+	fut.mutex.Lock()
+	defer fut.mutex.Unlock()
+
+	return fut.finished
+}
+
 // NewFuture creates a new empty Future for a given Request.
 func NewFuture(req Request) (fut *Future) {
 	fut = &Future{}


### PR DESCRIPTION
Make race checker happier.

Closes #521

Mutex is used just to make race-checker happier, so data race still possible. 
There were 3 ways: no mutex, with mutex, and using atomic.Bool.

I tested all of 3 with TestBenchmakAsync, CPU in performance mode, Tarantool 3.7.0-entrypoint-41-gc32b82582e, Linux-x86_64-Debug:
**Median RPS**:
without mutex = 111111.04
with mutex = 103009.10
atomic.Bool = 85813.27

So, I've chosen mutex.