### PR TITLE
request: switch all request types to value receivers and value returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+* All top-level `New*Request()` constructors now return values instead of
+  pointers. All methods on request types use value receivers and return
+  values, enabling immutable builder-style chaining.
+* Removed intermediate `spaceRequest`, `spaceIndexRequest` types — `space`
+  and `index` fields are now inlined directly into each request struct.
+  The same flattening was applied to `crud.spaceRequest`.
 * Required Go version is `1.24` now (#456).
 * `box.New` returns an error instead of panic (#448).
 * Now cases of `<-ctx.Done()` returns wrapped error provided by `ctx.Cause()`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,6 +36,37 @@ TODO
 * `ConnectionPool.Close()` returns a single error value, combining multiple errors using errors.Join()
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
+* All request types (`PingRequest`, `SelectRequest`, `CallRequest`, etc.) now
+  use value receivers and constructors return values instead of pointers.
+  Builder methods return modified copies instead of mutating in place.
+
+  **Breaking**: calling a builder method without using its return value silently
+  discards the change:
+  ```Go
+  // Before (pointer receivers, mutation in place):
+  req := NewSelectRequest("space")
+  req.Index("idx")           // mutated req directly
+  conn.Do(req)
+
+  // After (value receivers, must use return value):
+  req := NewSelectRequest("space")
+  req = req.Index("idx")     // must reassign
+  conn.Do(req)
+
+  // Or chain directly:
+  conn.Do(NewSelectRequest("space").Index("idx"))
+  ```
+
+  The same value-receiver pattern was applied to `arrow.InsertRequest` and
+  `settings.SetRequest`/`settings.GetRequest`.
+
+  In the `box` subpackage, request types (`InfoRequest`, `UserExistsRequest`,
+  `UserCreateRequest`, `SessionSuRequest`, etc.) no longer embed
+  `tarantool.CallRequest`. They store it as a private field and implement
+  their own `Context()` method returning the wrapper type. Usage stays clean:
+  ```Go
+  req := box.NewUserExistsRequest(username).Context(ctx)
+  ```
 
 ## Migration from v1.x.x to v2.x.x
 

--- a/arrow/request.go
+++ b/arrow/request.go
@@ -19,25 +19,25 @@ type InsertRequest struct {
 }
 
 // NewInsertRequest returns a new InsertRequest.
-func NewInsertRequest(space interface{}, arrow Arrow) *InsertRequest {
-	return &InsertRequest{
+func NewInsertRequest(space interface{}, arrow Arrow) InsertRequest {
+	return InsertRequest{
 		space: space,
 		arrow: arrow,
 	}
 }
 
 // Type returns a IPROTO_INSERT_ARROW type for the request.
-func (r *InsertRequest) Type() iproto.Type {
+func (r InsertRequest) Type() iproto.Type {
 	return iproto.IPROTO_INSERT_ARROW
 }
 
 // Async returns false to the request return a response.
-func (r *InsertRequest) Async() bool {
+func (r InsertRequest) Async() bool {
 	return false
 }
 
 // Ctx returns a context of the request.
-func (r *InsertRequest) Ctx() context.Context {
+func (r InsertRequest) Ctx() context.Context {
 	return r.ctx
 }
 
@@ -47,20 +47,20 @@ func (r *InsertRequest) Ctx() context.Context {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (r *InsertRequest) Context(ctx context.Context) *InsertRequest {
+func (r InsertRequest) Context(ctx context.Context) InsertRequest {
 	r.ctx = ctx
 	return r
 }
 
 // Arrow sets the arrow for insertion the insert arrow request.
 // Note: default value is nil.
-func (r *InsertRequest) Arrow(arrow Arrow) *InsertRequest {
+func (r InsertRequest) Arrow(arrow Arrow) InsertRequest {
 	r.arrow = arrow
 	return r
 }
 
 // Body fills an msgpack.Encoder with the insert arrow request body.
-func (r *InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (r InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (r *InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder)
 }
 
 // Response creates a response for the InsertRequest.
-func (r *InsertRequest) Response(
+func (r InsertRequest) Response(
 	header tarantool.Header,
 	body io.Reader,
 ) (tarantool.Response, error) {

--- a/box/info.go
+++ b/box/info.go
@@ -1,6 +1,7 @@
 package box
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmihailenco/msgpack/v5"
@@ -8,7 +9,7 @@ import (
 	"github.com/tarantool/go-tarantool/v3"
 )
 
-var _ tarantool.Request = (*InfoRequest)(nil)
+var _ tarantool.Request = InfoRequest{}
 
 // Info represents detailed information about the Tarantool instance.
 // It includes version, node ID, read-only status, process ID, cluster information, and more.
@@ -112,14 +113,20 @@ func (ir *InfoResponse) DecodeMsgpack(d *msgpack.Decoder) error {
 // InfoRequest represents a request to retrieve information about the Tarantool instance.
 // It implements the tarantool.Request interface.
 type InfoRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewInfoRequest returns a new empty info request.
 func NewInfoRequest() InfoRequest {
-	callReq := tarantool.NewCallRequest("box.info")
-
 	return InfoRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{
+			call: tarantool.NewCallRequest("box.info"),
+		},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req InfoRequest) Context(ctx context.Context) InfoRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }

--- a/box/request.go
+++ b/box/request.go
@@ -1,0 +1,44 @@
+package box
+
+import (
+	"context"
+	"io"
+
+	"github.com/tarantool/go-iproto"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/tarantool/go-tarantool/v3"
+)
+
+// baseCallRequest wraps a tarantool.CallRequest and implements
+// the tarantool.Request interface by delegation.
+type baseCallRequest struct {
+	call tarantool.CallRequest
+}
+
+// Type returns IPROTO type for the request.
+func (req baseCallRequest) Type() iproto.Type {
+	return req.call.Type()
+}
+
+// Body fills an encoder with the request body.
+func (req baseCallRequest) Body(res tarantool.SchemaResolver,
+	enc *msgpack.Encoder) error {
+	return req.call.Body(res, enc)
+}
+
+// Ctx returns a context of the request.
+func (req baseCallRequest) Ctx() context.Context {
+	return req.call.Ctx()
+}
+
+// Async returns whether the request expects a response.
+func (req baseCallRequest) Async() bool {
+	return req.call.Async()
+}
+
+// Response creates a response for the request.
+func (req baseCallRequest) Response(header tarantool.Header,
+	body io.Reader) (tarantool.Response, error) {
+	return req.call.Response(header, body)
+}

--- a/box/schema_user.go
+++ b/box/schema_user.go
@@ -24,7 +24,7 @@ func newSchemaUser(conn tarantool.Doer) *SchemaUser {
 
 // UserExistsRequest represents a request to check if a user exists in Tarantool.
 type UserExistsRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // UserExistsResponse represents the response to a user existence check.
@@ -55,8 +55,14 @@ func NewUserExistsRequest(username string) UserExistsRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.exists").Args([]interface{}{username})
 
 	return UserExistsRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserExistsRequest) Context(ctx context.Context) UserExistsRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Exists checks if the specified user exists in Tarantool.
@@ -81,7 +87,7 @@ type UserCreateOptions struct {
 
 // UserCreateRequest represents a request to create a new user in Tarantool.
 type UserCreateRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserCreateRequest creates a new request to create a user with specified options.
@@ -90,8 +96,14 @@ func NewUserCreateRequest(username string, options UserCreateOptions) UserCreate
 		Args([]interface{}{username, options})
 
 	return UserCreateRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserCreateRequest) Context(ctx context.Context) UserCreateRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserCreateResponse represents the response to a user creation request.
@@ -127,7 +139,7 @@ type UserDropOptions struct {
 
 // UserDropRequest represents a request to drop a user from Tarantool.
 type UserDropRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserDropRequest creates a new request to drop a user with specified options.
@@ -136,8 +148,14 @@ func NewUserDropRequest(username string, options UserDropOptions) UserDropReques
 		Args([]interface{}{username, options})
 
 	return UserDropRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserDropRequest) Context(ctx context.Context) UserDropRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserDropResponse represents the response to a user drop request.
@@ -162,7 +180,7 @@ func (u *SchemaUser) Drop(ctx context.Context, username string, options UserDrop
 
 // UserPasswordRequest represents a request to retrieve a user's password from Tarantool.
 type UserPasswordRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserPasswordRequest creates a new request to fetch the user's password.
@@ -172,8 +190,14 @@ func NewUserPasswordRequest(username string) UserPasswordRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.password").Args([]interface{}{username})
 
 	return UserPasswordRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserPasswordRequest) Context(ctx context.Context) UserPasswordRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserPasswordResponse represents the response to the user password request.
@@ -225,7 +249,7 @@ func (u *SchemaUser) Password(ctx context.Context, password string) (string, err
 
 // UserPasswdRequest represents a request to change a user's password in Tarantool.
 type UserPasswdRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserPasswdRequest creates a new request to change  a user's password in Tarantool.
@@ -234,15 +258,21 @@ func NewUserPasswdRequest(args ...string) (UserPasswdRequest, error) {
 
 	switch len(args) {
 	case 1:
-		callReq.Args([]interface{}{args[0]})
+		callReq = callReq.Args([]interface{}{args[0]})
 	case 2:
-		callReq.Args([]interface{}{args[0], args[1]})
+		callReq = callReq.Args([]interface{}{args[0], args[1]})
 	default:
 		return UserPasswdRequest{}, fmt.Errorf("len of fields must be 1 or 2, got %d", len(args))
 
 	}
 
-	return UserPasswdRequest{callReq}, nil
+	return UserPasswdRequest{baseCallRequest: baseCallRequest{call: callReq}}, nil
+}
+
+// Context sets a passed context to the request.
+func (req UserPasswdRequest) Context(ctx context.Context) UserPasswdRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserPasswdResponse represents the response to a user passwd request.
@@ -258,7 +288,7 @@ func (u *SchemaUser) Passwd(ctx context.Context, args ...string) error {
 		return err
 	}
 
-	req.Context(ctx)
+	req = req.Context(ctx)
 
 	resp := &UserPasswdResponse{}
 
@@ -275,7 +305,7 @@ func (u *SchemaUser) Passwd(ctx context.Context, args ...string) error {
 
 // UserInfoRequest represents a request to get a user's info in Tarantool.
 type UserInfoRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserInfoRequest creates a new request to get user privileges.
@@ -283,8 +313,14 @@ func NewUserInfoRequest(username string) UserInfoRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.info").Args([]interface{}{username})
 
 	return UserInfoRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserInfoRequest) Context(ctx context.Context) UserInfoRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // PrivilegeType is a struct based on privilege object types list
@@ -472,7 +508,7 @@ type UserGrantOptions struct {
 
 // UserGrantRequest wraps a Tarantool call request for granting user permissions.
 type UserGrantRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserGrantRequest creates a new UserGrantRequest based on provided parameters.
@@ -483,7 +519,13 @@ func NewUserGrantRequest(username string, privilege Privilege,
 	// Create a new call request for the box.schema.user.grant method with the given args.
 	callReq := tarantool.NewCallRequest("box.schema.user.grant").Args(args)
 
-	return UserGrantRequest{callReq} // Return the UserGrantRequest.
+	return UserGrantRequest{baseCallRequest: baseCallRequest{call: callReq}}
+}
+
+// Context sets a passed context to the request.
+func (req UserGrantRequest) Context(ctx context.Context) UserGrantRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserGrantResponse represents the response from a user grant request.
@@ -512,7 +554,7 @@ type UserRevokeOptions struct {
 
 // UserRevokeRequest wraps a Tarantool call request for revoking user permissions.
 type UserRevokeRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // UserRevokeResponse represents the response from a user revoke request.
@@ -526,7 +568,13 @@ func NewUserRevokeRequest(username string, privilege Privilege,
 	// Create a new call request for the box.schema.user.revoke method with the given args.
 	callReq := tarantool.NewCallRequest("box.schema.user.revoke").Args(args)
 
-	return UserRevokeRequest{callReq}
+	return UserRevokeRequest{baseCallRequest: baseCallRequest{call: callReq}}
+}
+
+// Context sets a passed context to the request.
+func (req UserRevokeRequest) Context(ctx context.Context) UserRevokeRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Revoke executes the user revoke operation in Tarantool, returning an error if it fails.

--- a/box/session.go
+++ b/box/session.go
@@ -23,7 +23,7 @@ func (b *Box) Session() *Session {
 
 // SessionSuRequest struct wraps a Tarantool call request specifically for session switching.
 type SessionSuRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewSessionSuRequest creates a new SessionSuRequest for switching session to a specified username.
@@ -31,12 +31,17 @@ type SessionSuRequest struct {
 func NewSessionSuRequest(username string) (SessionSuRequest, error) {
 	args := []interface{}{username} // Create args slice with the username.
 
-	// Create a new call request for the box.session.su method with the given args.
-	callReq := tarantool.NewCallRequest("box.session.su").Args(args)
-
 	return SessionSuRequest{
-		callReq, // Return the new SessionSuRequest containing the call request.
+		baseCallRequest: baseCallRequest{
+			call: tarantool.NewCallRequest("box.session.su").Args(args),
+		},
 	}, nil
+}
+
+// Context sets a passed context to the request.
+func (req SessionSuRequest) Context(ctx context.Context) SessionSuRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Su method is used to switch the session to the specified username.
@@ -48,7 +53,7 @@ func (s *Session) Su(ctx context.Context, username string) error {
 		return err // Return any errors encountered while creating the request.
 	}
 
-	req.Context(ctx) // Attach the context to the request for cancellation and timeout.
+	req = req.Context(ctx) // Attach the context to the request.
 
 	// Execute the request and return the future response, or an error.
 	fut := s.conn.Do(req)

--- a/crud/common.go
+++ b/crud/common.go
@@ -63,11 +63,13 @@ import (
 )
 
 type baseRequest struct {
-	impl *tarantool.CallRequest
+	impl tarantool.CallRequest
 }
 
-func newCall(method string) *tarantool.CallRequest {
-	return tarantool.NewCall17Request(method)
+func newBaseRequest(method string) baseRequest {
+	return baseRequest{
+		impl: tarantool.NewCall17Request(method),
+	}
 }
 
 // Type returns IPROTO type for CRUD request.
@@ -86,12 +88,9 @@ func (req baseRequest) Async() bool {
 }
 
 // Response creates a response for the baseRequest.
-func (req baseRequest) Response(header tarantool.Header,
-	body io.Reader) (tarantool.Response, error) {
+func (req baseRequest) Response(
+	header tarantool.Header,
+	body io.Reader,
+) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
-}
-
-type spaceRequest struct {
-	baseRequest
-	space string
 }

--- a/crud/count.go
+++ b/crud/count.go
@@ -68,7 +68,8 @@ func (opts CountOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // CountRequest helps you to create request object to call `crud.count`
 // for execution by a Connection.
 type CountRequest struct {
-	spaceRequest
+	baseRequest
+	space      string
 	conditions []Condition
 	opts       CountOpts
 }
@@ -82,12 +83,11 @@ type countArgs struct {
 
 // MakeCountRequest returns a new empty CountRequest.
 func MakeCountRequest(space string) CountRequest {
-	req := CountRequest{}
-	req.impl = newCall("crud.count")
-	req.space = space
-	req.conditions = nil
-	req.opts = CountOpts{}
-	return req
+	return CountRequest{
+		baseRequest: newBaseRequest("crud.count"),
+		space:       space,
+		opts:        CountOpts{},
+	}
 }
 
 // Conditions sets the conditions for the CountRequest request.

--- a/crud/delete.go
+++ b/crud/delete.go
@@ -14,9 +14,10 @@ type DeleteOpts = SimpleOperationOpts
 // DeleteRequest helps you to create request object to call `crud.delete`
 // for execution by a Connection.
 type DeleteRequest struct {
-	spaceRequest
-	key  Tuple
-	opts DeleteOpts
+	baseRequest
+	space string
+	key   Tuple
+	opts  DeleteOpts
 }
 
 type deleteArgs struct {
@@ -28,11 +29,11 @@ type deleteArgs struct {
 
 // MakeDeleteRequest returns a new empty DeleteRequest.
 func MakeDeleteRequest(space string) DeleteRequest {
-	req := DeleteRequest{}
-	req.impl = newCall("crud.delete")
-	req.space = space
-	req.opts = DeleteOpts{}
-	return req
+	return DeleteRequest{
+		baseRequest: newBaseRequest("crud.delete"),
+		space:       space,
+		opts:        DeleteOpts{},
+	}
 }
 
 // Key sets the key for the DeleteRequest request.

--- a/crud/get.go
+++ b/crud/get.go
@@ -61,9 +61,10 @@ func (opts GetOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // GetRequest helps you to create request object to call `crud.get`
 // for execution by a Connection.
 type GetRequest struct {
-	spaceRequest
-	key  Tuple
-	opts GetOpts
+	baseRequest
+	space string
+	key   Tuple
+	opts  GetOpts
 }
 
 type getArgs struct {
@@ -75,11 +76,11 @@ type getArgs struct {
 
 // MakeGetRequest returns a new empty GetRequest.
 func MakeGetRequest(space string) GetRequest {
-	req := GetRequest{}
-	req.impl = newCall("crud.get")
-	req.space = space
-	req.opts = GetOpts{}
-	return req
+	return GetRequest{
+		baseRequest: newBaseRequest("crud.get"),
+		space:       space,
+		opts:        GetOpts{},
+	}
 }
 
 // Key sets the key for the GetRequest request.

--- a/crud/insert.go
+++ b/crud/insert.go
@@ -14,7 +14,8 @@ type InsertOpts = SimpleOperationOpts
 // InsertRequest helps you to create request object to call `crud.insert`
 // for execution by a Connection.
 type InsertRequest struct {
-	spaceRequest
+	baseRequest
+	space string
 	tuple Tuple
 	opts  InsertOpts
 }
@@ -28,11 +29,11 @@ type insertArgs struct {
 
 // MakeInsertRequest returns a new empty InsertRequest.
 func MakeInsertRequest(space string) InsertRequest {
-	req := InsertRequest{}
-	req.impl = newCall("crud.insert")
-	req.space = space
-	req.opts = InsertOpts{}
-	return req
+	return InsertRequest{
+		baseRequest: newBaseRequest("crud.insert"),
+		space:       space,
+		opts:        InsertOpts{},
+	}
 }
 
 // Tuple sets the tuple for the InsertRequest request.
@@ -72,7 +73,8 @@ type InsertObjectOpts = SimpleOperationObjectOpts
 // InsertObjectRequest helps you to create request object to call
 // `crud.insert_object` for execution by a Connection.
 type InsertObjectRequest struct {
-	spaceRequest
+	baseRequest
+	space  string
 	object Object
 	opts   InsertObjectOpts
 }
@@ -86,11 +88,11 @@ type insertObjectArgs struct {
 
 // MakeInsertObjectRequest returns a new empty InsertObjectRequest.
 func MakeInsertObjectRequest(space string) InsertObjectRequest {
-	req := InsertObjectRequest{}
-	req.impl = newCall("crud.insert_object")
-	req.space = space
-	req.opts = InsertObjectOpts{}
-	return req
+	return InsertObjectRequest{
+		baseRequest: newBaseRequest("crud.insert_object"),
+		space:       space,
+		opts:        InsertObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the InsertObjectRequest request.

--- a/crud/insert_many.go
+++ b/crud/insert_many.go
@@ -14,7 +14,8 @@ type InsertManyOpts = OperationManyOpts
 // InsertManyRequest helps you to create request object to call
 // `crud.insert_many` for execution by a Connection.
 type InsertManyRequest struct {
-	spaceRequest
+	baseRequest
+	space  string
 	tuples Tuples
 	opts   InsertManyOpts
 }
@@ -28,11 +29,11 @@ type insertManyArgs struct {
 
 // MakeInsertManyRequest returns a new empty InsertManyRequest.
 func MakeInsertManyRequest(space string) InsertManyRequest {
-	req := InsertManyRequest{}
-	req.impl = newCall("crud.insert_many")
-	req.space = space
-	req.opts = InsertManyOpts{}
-	return req
+	return InsertManyRequest{
+		baseRequest: newBaseRequest("crud.insert_many"),
+		space:       space,
+		opts:        InsertManyOpts{},
+	}
 }
 
 // Tuples sets the tuples for the InsertManyRequest request.
@@ -72,7 +73,8 @@ type InsertObjectManyOpts = OperationObjectManyOpts
 // InsertObjectManyRequest helps you to create request object to call
 // `crud.insert_object_many` for execution by a Connection.
 type InsertObjectManyRequest struct {
-	spaceRequest
+	baseRequest
+	space   string
 	objects Objects
 	opts    InsertObjectManyOpts
 }
@@ -86,11 +88,11 @@ type insertObjectManyArgs struct {
 
 // MakeInsertObjectManyRequest returns a new empty InsertObjectManyRequest.
 func MakeInsertObjectManyRequest(space string) InsertObjectManyRequest {
-	req := InsertObjectManyRequest{}
-	req.impl = newCall("crud.insert_object_many")
-	req.space = space
-	req.opts = InsertObjectManyOpts{}
-	return req
+	return InsertObjectManyRequest{
+		baseRequest: newBaseRequest("crud.insert_object_many"),
+		space:       space,
+		opts:        InsertObjectManyOpts{},
+	}
 }
 
 // Objects sets the objects for the InsertObjectManyRequest request.

--- a/crud/len.go
+++ b/crud/len.go
@@ -17,8 +17,9 @@ type LenOpts = BaseOpts
 // LenRequest helps you to create request object to call `crud.len`
 // for execution by a Connection.
 type LenRequest struct {
-	spaceRequest
-	opts LenOpts
+	baseRequest
+	space string
+	opts  LenOpts
 }
 
 type lenArgs struct {
@@ -29,11 +30,11 @@ type lenArgs struct {
 
 // MakeLenRequest returns a new empty LenRequest.
 func MakeLenRequest(space string) LenRequest {
-	req := LenRequest{}
-	req.impl = newCall("crud.len")
-	req.space = space
-	req.opts = LenOpts{}
-	return req
+	return LenRequest{
+		baseRequest: newBaseRequest("crud.len"),
+		space:       space,
+		opts:        LenOpts{},
+	}
 }
 
 // Opts sets the options for the LenRequest request.

--- a/crud/max.go
+++ b/crud/max.go
@@ -14,7 +14,8 @@ type MaxOpts = BorderOpts
 // MaxRequest helps you to create request object to call `crud.max`
 // for execution by a Connection.
 type MaxRequest struct {
-	spaceRequest
+	baseRequest
+	space string
 	index interface{}
 	opts  MaxOpts
 }
@@ -28,11 +29,11 @@ type maxArgs struct {
 
 // MakeMaxRequest returns a new empty MaxRequest.
 func MakeMaxRequest(space string) MaxRequest {
-	req := MaxRequest{}
-	req.impl = newCall("crud.max")
-	req.space = space
-	req.opts = MaxOpts{}
-	return req
+	return MaxRequest{
+		baseRequest: newBaseRequest("crud.max"),
+		space:       space,
+		opts:        MaxOpts{},
+	}
 }
 
 // Index sets the index name/id for the MaxRequest request.

--- a/crud/min.go
+++ b/crud/min.go
@@ -14,7 +14,8 @@ type MinOpts = BorderOpts
 // MinRequest helps you to create request object to call `crud.min`
 // for execution by a Connection.
 type MinRequest struct {
-	spaceRequest
+	baseRequest
+	space string
 	index interface{}
 	opts  MinOpts
 }
@@ -28,11 +29,11 @@ type minArgs struct {
 
 // MakeMinRequest returns a new empty MinRequest.
 func MakeMinRequest(space string) MinRequest {
-	req := MinRequest{}
-	req.impl = newCall("crud.min")
-	req.space = space
-	req.opts = MinOpts{}
-	return req
+	return MinRequest{
+		baseRequest: newBaseRequest("crud.min"),
+		space:       space,
+		opts:        MinOpts{},
+	}
 }
 
 // Index sets the index name/id for the MinRequest request.

--- a/crud/replace.go
+++ b/crud/replace.go
@@ -14,7 +14,8 @@ type ReplaceOpts = SimpleOperationOpts
 // ReplaceRequest helps you to create request object to call `crud.replace`
 // for execution by a Connection.
 type ReplaceRequest struct {
-	spaceRequest
+	baseRequest
+	space string
 	tuple Tuple
 	opts  ReplaceOpts
 }
@@ -28,11 +29,11 @@ type replaceArgs struct {
 
 // MakeReplaceRequest returns a new empty ReplaceRequest.
 func MakeReplaceRequest(space string) ReplaceRequest {
-	req := ReplaceRequest{}
-	req.impl = newCall("crud.replace")
-	req.space = space
-	req.opts = ReplaceOpts{}
-	return req
+	return ReplaceRequest{
+		baseRequest: newBaseRequest("crud.replace"),
+		space:       space,
+		opts:        ReplaceOpts{},
+	}
 }
 
 // Tuple sets the tuple for the ReplaceRequest request.
@@ -72,7 +73,8 @@ type ReplaceObjectOpts = SimpleOperationObjectOpts
 // ReplaceObjectRequest helps you to create request object to call
 // `crud.replace_object` for execution by a Connection.
 type ReplaceObjectRequest struct {
-	spaceRequest
+	baseRequest
+	space  string
 	object Object
 	opts   ReplaceObjectOpts
 }
@@ -86,11 +88,11 @@ type replaceObjectArgs struct {
 
 // MakeReplaceObjectRequest returns a new empty ReplaceObjectRequest.
 func MakeReplaceObjectRequest(space string) ReplaceObjectRequest {
-	req := ReplaceObjectRequest{}
-	req.impl = newCall("crud.replace_object")
-	req.space = space
-	req.opts = ReplaceObjectOpts{}
-	return req
+	return ReplaceObjectRequest{
+		baseRequest: newBaseRequest("crud.replace_object"),
+		space:       space,
+		opts:        ReplaceObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the ReplaceObjectRequest request.

--- a/crud/replace_many.go
+++ b/crud/replace_many.go
@@ -14,7 +14,8 @@ type ReplaceManyOpts = OperationManyOpts
 // ReplaceManyRequest helps you to create request object to call
 // `crud.replace_many` for execution by a Connection.
 type ReplaceManyRequest struct {
-	spaceRequest
+	baseRequest
+	space  string
 	tuples Tuples
 	opts   ReplaceManyOpts
 }
@@ -28,11 +29,11 @@ type replaceManyArgs struct {
 
 // MakeReplaceManyRequest returns a new empty ReplaceManyRequest.
 func MakeReplaceManyRequest(space string) ReplaceManyRequest {
-	req := ReplaceManyRequest{}
-	req.impl = newCall("crud.replace_many")
-	req.space = space
-	req.opts = ReplaceManyOpts{}
-	return req
+	return ReplaceManyRequest{
+		baseRequest: newBaseRequest("crud.replace_many"),
+		space:       space,
+		opts:        ReplaceManyOpts{},
+	}
 }
 
 // Tuples sets the tuples for the ReplaceManyRequest request.
@@ -72,7 +73,8 @@ type ReplaceObjectManyOpts = OperationObjectManyOpts
 // ReplaceObjectManyRequest helps you to create request object to call
 // `crud.replace_object_many` for execution by a Connection.
 type ReplaceObjectManyRequest struct {
-	spaceRequest
+	baseRequest
+	space   string
 	objects Objects
 	opts    ReplaceObjectManyOpts
 }
@@ -86,11 +88,11 @@ type replaceObjectManyArgs struct {
 
 // MakeReplaceObjectManyRequest returns a new empty ReplaceObjectManyRequest.
 func MakeReplaceObjectManyRequest(space string) ReplaceObjectManyRequest {
-	req := ReplaceObjectManyRequest{}
-	req.impl = newCall("crud.replace_object_many")
-	req.space = space
-	req.opts = ReplaceObjectManyOpts{}
-	return req
+	return ReplaceObjectManyRequest{
+		baseRequest: newBaseRequest("crud.replace_object_many"),
+		space:       space,
+		opts:        ReplaceObjectManyOpts{},
+	}
 }
 
 // Objects sets the tuple for the ReplaceObjectManyRequest request.

--- a/crud/schema.go
+++ b/crud/schema.go
@@ -52,9 +52,9 @@ type SchemaRequest struct {
 
 // MakeSchemaRequest returns a new empty SchemaRequest.
 func MakeSchemaRequest() SchemaRequest {
-	req := SchemaRequest{}
-	req.impl = newCall("crud.schema")
-	return req
+	return SchemaRequest{
+		baseRequest: newBaseRequest("crud.schema"),
+	}
 }
 
 // Space sets the space name for the SchemaRequest request.

--- a/crud/select.go
+++ b/crud/select.go
@@ -85,7 +85,8 @@ func (opts SelectOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // SelectRequest helps you to create request object to call `crud.select`
 // for execution by a Connection.
 type SelectRequest struct {
-	spaceRequest
+	baseRequest
+	space      string
 	conditions []Condition
 	opts       SelectOpts
 }
@@ -99,12 +100,11 @@ type selectArgs struct {
 
 // MakeSelectRequest returns a new empty SelectRequest.
 func MakeSelectRequest(space string) SelectRequest {
-	req := SelectRequest{}
-	req.impl = newCall("crud.select")
-	req.space = space
-	req.conditions = nil
-	req.opts = SelectOpts{}
-	return req
+	return SelectRequest{
+		baseRequest: newBaseRequest("crud.select"),
+		space:       space,
+		opts:        SelectOpts{},
+	}
 }
 
 // Conditions sets the conditions for the SelectRequest request.

--- a/crud/stats.go
+++ b/crud/stats.go
@@ -18,9 +18,9 @@ type StatsRequest struct {
 
 // MakeStatsRequest returns a new empty StatsRequest.
 func MakeStatsRequest() StatsRequest {
-	req := StatsRequest{}
-	req.impl = newCall("crud.stats")
-	return req
+	return StatsRequest{
+		baseRequest: newBaseRequest("crud.stats"),
+	}
 }
 
 // Space sets the space name for the StatsRequest request.

--- a/crud/storage_info.go
+++ b/crud/storage_info.go
@@ -104,10 +104,10 @@ type storageInfoArgs struct {
 
 // MakeStorageInfoRequest returns a new empty StorageInfoRequest.
 func MakeStorageInfoRequest() StorageInfoRequest {
-	req := StorageInfoRequest{}
-	req.impl = newCall("crud.storage_info")
-	req.opts = StorageInfoOpts{}
-	return req
+	return StorageInfoRequest{
+		baseRequest: newBaseRequest("crud.storage_info"),
+		opts:        StorageInfoOpts{},
+	}
 }
 
 // Opts sets the options for the torageInfoRequest request.

--- a/crud/truncate.go
+++ b/crud/truncate.go
@@ -17,8 +17,9 @@ type TruncateOpts = BaseOpts
 // TruncateRequest helps you to create request object to call `crud.truncate`
 // for execution by a Connection.
 type TruncateRequest struct {
-	spaceRequest
-	opts TruncateOpts
+	baseRequest
+	space string
+	opts  TruncateOpts
 }
 
 type truncateArgs struct {
@@ -29,11 +30,11 @@ type truncateArgs struct {
 
 // MakeTruncateRequest returns a new empty TruncateRequest.
 func MakeTruncateRequest(space string) TruncateRequest {
-	req := TruncateRequest{}
-	req.impl = newCall("crud.truncate")
-	req.space = space
-	req.opts = TruncateOpts{}
-	return req
+	return TruncateRequest{
+		baseRequest: newBaseRequest("crud.truncate"),
+		space:       space,
+		opts:        TruncateOpts{},
+	}
 }
 
 // Opts sets the options for the TruncateRequest request.

--- a/crud/update.go
+++ b/crud/update.go
@@ -14,7 +14,8 @@ type UpdateOpts = SimpleOperationOpts
 // UpdateRequest helps you to create request object to call `crud.update`
 // for execution by a Connection.
 type UpdateRequest struct {
-	spaceRequest
+	baseRequest
+	space      string
 	key        Tuple
 	operations []Operation
 	opts       UpdateOpts
@@ -30,12 +31,12 @@ type updateArgs struct {
 
 // MakeUpdateRequest returns a new empty UpdateRequest.
 func MakeUpdateRequest(space string) UpdateRequest {
-	req := UpdateRequest{}
-	req.impl = newCall("crud.update")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpdateOpts{}
-	return req
+	return UpdateRequest{
+		baseRequest: newBaseRequest("crud.update"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpdateOpts{},
+	}
 }
 
 // Key sets the key for the UpdateRequest request.

--- a/crud/upsert.go
+++ b/crud/upsert.go
@@ -14,7 +14,8 @@ type UpsertOpts = SimpleOperationOpts
 // UpsertRequest helps you to create request object to call `crud.upsert`
 // for execution by a Connection.
 type UpsertRequest struct {
-	spaceRequest
+	baseRequest
+	space      string
 	tuple      Tuple
 	operations []Operation
 	opts       UpsertOpts
@@ -30,12 +31,12 @@ type upsertArgs struct {
 
 // MakeUpsertRequest returns a new empty UpsertRequest.
 func MakeUpsertRequest(space string) UpsertRequest {
-	req := UpsertRequest{}
-	req.impl = newCall("crud.upsert")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpsertOpts{}
-	return req
+	return UpsertRequest{
+		baseRequest: newBaseRequest("crud.upsert"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpsertOpts{},
+	}
 }
 
 // Tuple sets the tuple for the UpsertRequest request.
@@ -83,7 +84,8 @@ type UpsertObjectOpts = SimpleOperationOpts
 // UpsertObjectRequest helps you to create request object to call
 // `crud.upsert_object` for execution by a Connection.
 type UpsertObjectRequest struct {
-	spaceRequest
+	baseRequest
+	space      string
 	object     Object
 	operations []Operation
 	opts       UpsertObjectOpts
@@ -99,12 +101,12 @@ type upsertObjectArgs struct {
 
 // MakeUpsertObjectRequest returns a new empty UpsertObjectRequest.
 func MakeUpsertObjectRequest(space string) UpsertObjectRequest {
-	req := UpsertObjectRequest{}
-	req.impl = newCall("crud.upsert_object")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpsertObjectOpts{}
-	return req
+	return UpsertObjectRequest{
+		baseRequest: newBaseRequest("crud.upsert_object"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpsertObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the UpsertObjectRequest request.

--- a/crud/upsert_many.go
+++ b/crud/upsert_many.go
@@ -21,7 +21,8 @@ type TupleOperationsData struct {
 // UpsertManyRequest helps you to create request object to call
 // `crud.upsert_many` for execution by a Connection.
 type UpsertManyRequest struct {
-	spaceRequest
+	baseRequest
+	space                string
 	tuplesOperationsData []TupleOperationsData
 	opts                 UpsertManyOpts
 }
@@ -35,12 +36,12 @@ type upsertManyArgs struct {
 
 // MakeUpsertManyRequest returns a new empty UpsertManyRequest.
 func MakeUpsertManyRequest(space string) UpsertManyRequest {
-	req := UpsertManyRequest{}
-	req.impl = newCall("crud.upsert_many")
-	req.space = space
-	req.tuplesOperationsData = []TupleOperationsData{}
-	req.opts = UpsertManyOpts{}
-	return req
+	return UpsertManyRequest{
+		baseRequest:          newBaseRequest("crud.upsert_many"),
+		space:                space,
+		tuplesOperationsData: []TupleOperationsData{},
+		opts:                 UpsertManyOpts{},
+	}
 }
 
 // TuplesOperationsData sets tuples and operations for
@@ -87,7 +88,8 @@ type ObjectOperationsData struct {
 // UpsertObjectManyRequest helps you to create request object to call
 // `crud.upsert_object_many` for execution by a Connection.
 type UpsertObjectManyRequest struct {
-	spaceRequest
+	baseRequest
+	space                 string
 	objectsOperationsData []ObjectOperationsData
 	opts                  UpsertObjectManyOpts
 }
@@ -101,12 +103,12 @@ type upsertObjectManyArgs struct {
 
 // MakeUpsertObjectManyRequest returns a new empty UpsertObjectManyRequest.
 func MakeUpsertObjectManyRequest(space string) UpsertObjectManyRequest {
-	req := UpsertObjectManyRequest{}
-	req.impl = newCall("crud.upsert_object_many")
-	req.space = space
-	req.objectsOperationsData = []ObjectOperationsData{}
-	req.opts = UpsertObjectManyOpts{}
-	return req
+	return UpsertObjectManyRequest{
+		baseRequest:           newBaseRequest("crud.upsert_object_many"),
+		space:                 space,
+		objectsOperationsData: []ObjectOperationsData{},
+		opts:                  UpsertObjectManyOpts{},
+	}
 }
 
 // ObjectOperationsData sets objects and operations

--- a/example_test.go
+++ b/example_test.go
@@ -245,8 +245,7 @@ func ExampleSelectRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewSelectRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewSelectRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {
@@ -359,8 +358,7 @@ func ExampleDeleteRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewDeleteRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewDeleteRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {
@@ -473,8 +471,7 @@ func ExampleUpdateRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewUpdateRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewUpdateRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {

--- a/prepared.go
+++ b/prepared.go
@@ -53,15 +53,15 @@ type PrepareRequest struct {
 }
 
 // NewPrepareRequest returns a new empty PrepareRequest.
-func NewPrepareRequest(expr string) *PrepareRequest {
-	req := new(PrepareRequest)
-	req.rtype = iproto.IPROTO_PREPARE
-	req.expr = expr
-	return req
+func NewPrepareRequest(expr string) PrepareRequest {
+	return PrepareRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PREPARE},
+		expr:        expr,
+	}
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -79,13 +79,13 @@ func (req *PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *PrepareRequest) Context(ctx context.Context) *PrepareRequest {
+func (req PrepareRequest) Context(ctx context.Context) PrepareRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the PrepareRequest.
-func (req *PrepareRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req PrepareRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -102,20 +102,20 @@ type UnprepareRequest struct {
 }
 
 // NewUnprepareRequest returns a new empty UnprepareRequest.
-func NewUnprepareRequest(stmt *Prepared) *UnprepareRequest {
-	req := new(UnprepareRequest)
-	req.rtype = iproto.IPROTO_PREPARE
-	req.stmt = stmt
-	return req
+func NewUnprepareRequest(stmt *Prepared) UnprepareRequest {
+	return UnprepareRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PREPARE},
+		stmt:        stmt,
+	}
 }
 
 // Conn returns the Connection object the request belongs to.
-func (req *UnprepareRequest) Conn() *Connection {
+func (req UnprepareRequest) Conn() *Connection {
 	return req.stmt.Conn
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (req *UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UnprepareRequest) Context(ctx context.Context) *UnprepareRequest {
+func (req UnprepareRequest) Context(ctx context.Context) UnprepareRequest {
 	req.ctx = ctx
 	return req
 }
@@ -147,28 +147,28 @@ type ExecutePreparedRequest struct {
 }
 
 // NewExecutePreparedRequest returns a new empty preparedExecuteRequest.
-func NewExecutePreparedRequest(stmt *Prepared) *ExecutePreparedRequest {
-	req := new(ExecutePreparedRequest)
-	req.rtype = iproto.IPROTO_EXECUTE
-	req.stmt = stmt
-	req.args = []interface{}{}
-	return req
+func NewExecutePreparedRequest(stmt *Prepared) ExecutePreparedRequest {
+	return ExecutePreparedRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EXECUTE},
+		stmt:        stmt,
+		args:        []interface{}{},
+	}
 }
 
 // Conn returns the Connection object the request belongs to.
-func (req *ExecutePreparedRequest) Conn() *Connection {
+func (req ExecutePreparedRequest) Conn() *Connection {
 	return req.stmt.Conn
 }
 
 // Args sets the args for execute the prepared request.
 // Note: default value is empty.
-func (req *ExecutePreparedRequest) Args(args interface{}) *ExecutePreparedRequest {
+func (req ExecutePreparedRequest) Args(args interface{}) ExecutePreparedRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -194,13 +194,13 @@ func (req *ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ExecutePreparedRequest) Context(ctx context.Context) *ExecutePreparedRequest {
+func (req ExecutePreparedRequest) Context(ctx context.Context) ExecutePreparedRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the ExecutePreparedRequest.
-func (req *ExecutePreparedRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req ExecutePreparedRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err

--- a/protocol.go
+++ b/protocol.go
@@ -71,15 +71,15 @@ type IdRequest struct {
 }
 
 // NewIdRequest returns a new IdRequest.
-func NewIdRequest(protocolInfo ProtocolInfo) *IdRequest {
-	req := new(IdRequest)
-	req.rtype = iproto.IPROTO_ID
-	req.protocolInfo = protocolInfo.Clone()
-	return req
+func NewIdRequest(protocolInfo ProtocolInfo) IdRequest {
+	return IdRequest{
+		baseRequest:  baseRequest{rtype: iproto.IPROTO_ID},
+		protocolInfo: protocolInfo.Clone(),
+	}
 }
 
 // Body fills an msgpack.Encoder with the id request body.
-func (req *IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (req *IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *IdRequest) Context(ctx context.Context) *IdRequest {
+func (req IdRequest) Context(ctx context.Context) IdRequest {
 	req.ctx = ctx
 	return req
 }

--- a/request.go
+++ b/request.go
@@ -274,32 +274,23 @@ type baseRequest struct {
 }
 
 // Type returns a IPROTO type for the request.
-func (req *baseRequest) Type() iproto.Type {
+func (req baseRequest) Type() iproto.Type {
 	return req.rtype
 }
 
 // Async returns true if the request does not require a response.
-func (req *baseRequest) Async() bool {
+func (req baseRequest) Async() bool {
 	return req.async
 }
 
 // Ctx returns a context of the request.
-func (req *baseRequest) Ctx() context.Context {
+func (req baseRequest) Ctx() context.Context {
 	return req.ctx
 }
 
 // Response creates a response for the baseRequest.
-func (req *baseRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req baseRequest) Response(header Header, body io.Reader) (Response, error) {
 	return DecodeBaseResponse(header, body)
-}
-
-type spaceRequest struct {
-	baseRequest
-	space interface{}
-}
-
-func (req *spaceRequest) setSpace(space interface{}) {
-	req.space = space
 }
 
 func EncodeSpace(res SchemaResolver, enc *msgpack.Encoder, space interface{}) error {
@@ -311,15 +302,6 @@ func EncodeSpace(res SchemaResolver, enc *msgpack.Encoder, space interface{}) er
 		return err
 	}
 	return nil
-}
-
-type spaceIndexRequest struct {
-	spaceRequest
-	index interface{}
-}
-
-func (req *spaceIndexRequest) setIndex(index interface{}) {
-	req.index = index
 }
 
 // authRequest implements IPROTO_AUTH request.
@@ -413,14 +395,14 @@ type PingRequest struct {
 }
 
 // NewPingRequest returns a new PingRequest.
-func NewPingRequest() *PingRequest {
-	req := new(PingRequest)
-	req.rtype = iproto.IPROTO_PING
-	return req
+func NewPingRequest() PingRequest {
+	return PingRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PING},
+	}
 }
 
 // Body fills an msgpack.Encoder with the ping request body.
-func (req *PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
@@ -430,7 +412,7 @@ func (req *PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *PingRequest) Context(ctx context.Context) *PingRequest {
+func (req PingRequest) Context(ctx context.Context) PingRequest {
 	req.ctx = ctx
 	return req
 }
@@ -438,7 +420,8 @@ func (req *PingRequest) Context(ctx context.Context) *PingRequest {
 // SelectRequest allows you to create a select request object for execution
 // by a Connection.
 type SelectRequest struct {
-	spaceIndexRequest
+	baseRequest
+	space, index            interface{}
 	isIteratorSet, fetchPos bool
 	offset, limit           uint32
 	iterator                Iter
@@ -446,43 +429,40 @@ type SelectRequest struct {
 }
 
 // NewSelectRequest returns a new empty SelectRequest.
-func NewSelectRequest(space interface{}) *SelectRequest {
-	req := new(SelectRequest)
-	req.rtype = iproto.IPROTO_SELECT
-	req.setSpace(space)
-	req.isIteratorSet = false
-	req.fetchPos = false
-	req.iterator = IterAll
-	req.key = []interface{}{}
-	req.after = nil
-	req.limit = 0xFFFFFFFF
-	return req
+func NewSelectRequest(space interface{}) SelectRequest {
+	return SelectRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_SELECT},
+		space:       space,
+		iterator:    IterAll,
+		key:         []interface{}{},
+		limit:       0xFFFFFFFF,
+	}
 }
 
 // Index sets the index for the select request.
 // Note: default value is 0.
-func (req *SelectRequest) Index(index interface{}) *SelectRequest {
-	req.setIndex(index)
+func (req SelectRequest) Index(index interface{}) SelectRequest {
+	req.index = index
 	return req
 }
 
 // Offset sets the offset for the select request.
 // Note: default value is 0.
-func (req *SelectRequest) Offset(offset uint32) *SelectRequest {
+func (req SelectRequest) Offset(offset uint32) SelectRequest {
 	req.offset = offset
 	return req
 }
 
 // Limit sets the limit for the select request.
 // Note: default value is 0xFFFFFFFF.
-func (req *SelectRequest) Limit(limit uint32) *SelectRequest {
+func (req SelectRequest) Limit(limit uint32) SelectRequest {
 	req.limit = limit
 	return req
 }
 
 // Iterator set the iterator for the select request.
 // Note: default value is IterAll if key is not set or IterEq otherwise.
-func (req *SelectRequest) Iterator(iterator Iter) *SelectRequest {
+func (req SelectRequest) Iterator(iterator Iter) SelectRequest {
 	req.iterator = iterator
 	req.isIteratorSet = true
 	return req
@@ -490,7 +470,7 @@ func (req *SelectRequest) Iterator(iterator Iter) *SelectRequest {
 
 // Key set the key for the select request.
 // Note: default value is empty.
-func (req *SelectRequest) Key(key interface{}) *SelectRequest {
+func (req SelectRequest) Key(key interface{}) SelectRequest {
 	req.key = key
 	if !req.isIteratorSet {
 		req.iterator = IterEq
@@ -506,7 +486,7 @@ func (req *SelectRequest) Key(key interface{}) *SelectRequest {
 // Requires Tarantool >= 2.11.
 //
 // Since 1.11.0.
-func (req *SelectRequest) FetchPos(fetch bool) *SelectRequest {
+func (req SelectRequest) FetchPos(fetch bool) SelectRequest {
 	req.fetchPos = fetch
 	return req
 }
@@ -519,13 +499,13 @@ func (req *SelectRequest) FetchPos(fetch bool) *SelectRequest {
 // Requires Tarantool >= 2.11.
 //
 // Since 1.11.0.
-func (req *SelectRequest) After(after interface{}) *SelectRequest {
+func (req SelectRequest) After(after interface{}) SelectRequest {
 	req.after = after
 	return req
 }
 
 // Body fills an encoder with the select request body.
-func (req *SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -615,13 +595,13 @@ func (req *SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *SelectRequest) Context(ctx context.Context) *SelectRequest {
+func (req SelectRequest) Context(ctx context.Context) SelectRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the SelectRequest.
-func (req *SelectRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req SelectRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -633,28 +613,29 @@ func (req *SelectRequest) Response(header Header, body io.Reader) (Response, err
 // InsertRequest helps you to create an insert request object for execution
 // by a Connection.
 type InsertRequest struct {
-	spaceRequest
+	baseRequest
+	space interface{}
 	tuple interface{}
 }
 
 // NewInsertRequest returns a new empty InsertRequest.
-func NewInsertRequest(space interface{}) *InsertRequest {
-	req := new(InsertRequest)
-	req.rtype = iproto.IPROTO_INSERT
-	req.setSpace(space)
-	req.tuple = []interface{}{}
-	return req
+func NewInsertRequest(space interface{}) InsertRequest {
+	return InsertRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_INSERT},
+		space:       space,
+		tuple:       []interface{}{},
+	}
 }
 
 // Tuple sets the tuple for insertion the insert request.
 // Note: default value is nil.
-func (req *InsertRequest) Tuple(tuple interface{}) *InsertRequest {
+func (req InsertRequest) Tuple(tuple interface{}) InsertRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Body fills an msgpack.Encoder with the insert request body.
-func (req *InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -681,7 +662,7 @@ func (req *InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *InsertRequest) Context(ctx context.Context) *InsertRequest {
+func (req InsertRequest) Context(ctx context.Context) InsertRequest {
 	req.ctx = ctx
 	return req
 }
@@ -689,28 +670,29 @@ func (req *InsertRequest) Context(ctx context.Context) *InsertRequest {
 // ReplaceRequest helps you to create a replace request object for execution
 // by a Connection.
 type ReplaceRequest struct {
-	spaceRequest
+	baseRequest
+	space interface{}
 	tuple interface{}
 }
 
 // NewReplaceRequest returns a new empty ReplaceRequest.
-func NewReplaceRequest(space interface{}) *ReplaceRequest {
-	req := new(ReplaceRequest)
-	req.rtype = iproto.IPROTO_REPLACE
-	req.setSpace(space)
-	req.tuple = []interface{}{}
-	return req
+func NewReplaceRequest(space interface{}) ReplaceRequest {
+	return ReplaceRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_REPLACE},
+		space:       space,
+		tuple:       []interface{}{},
+	}
 }
 
 // Tuple sets the tuple for replace by the replace request.
 // Note: default value is nil.
-func (req *ReplaceRequest) Tuple(tuple interface{}) *ReplaceRequest {
+func (req ReplaceRequest) Tuple(tuple interface{}) ReplaceRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Body fills an msgpack.Encoder with the replace request body.
-func (req *ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -737,7 +719,7 @@ func (req *ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ReplaceRequest) Context(ctx context.Context) *ReplaceRequest {
+func (req ReplaceRequest) Context(ctx context.Context) ReplaceRequest {
 	req.ctx = ctx
 	return req
 }
@@ -745,35 +727,36 @@ func (req *ReplaceRequest) Context(ctx context.Context) *ReplaceRequest {
 // DeleteRequest helps you to create a delete request object for execution
 // by a Connection.
 type DeleteRequest struct {
-	spaceIndexRequest
-	key interface{}
+	baseRequest
+	space, index interface{}
+	key          interface{}
 }
 
 // NewDeleteRequest returns a new empty DeleteRequest.
-func NewDeleteRequest(space interface{}) *DeleteRequest {
-	req := new(DeleteRequest)
-	req.rtype = iproto.IPROTO_DELETE
-	req.setSpace(space)
-	req.key = []interface{}{}
-	return req
+func NewDeleteRequest(space interface{}) DeleteRequest {
+	return DeleteRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_DELETE},
+		space:       space,
+		key:         []interface{}{},
+	}
 }
 
 // Index sets the index for the delete request.
 // Note: default value is 0.
-func (req *DeleteRequest) Index(index interface{}) *DeleteRequest {
-	req.setIndex(index)
+func (req DeleteRequest) Index(index interface{}) DeleteRequest {
+	req.index = index
 	return req
 }
 
 // Key sets the key of tuple for the delete request.
 // Note: default value is empty.
-func (req *DeleteRequest) Key(key interface{}) *DeleteRequest {
+func (req DeleteRequest) Key(key interface{}) DeleteRequest {
 	req.key = key
 	return req
 }
 
 // Body fills an msgpack.Encoder with the delete request body.
-func (req *DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -797,7 +780,7 @@ func (req *DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *DeleteRequest) Context(ctx context.Context) *DeleteRequest {
+func (req DeleteRequest) Context(ctx context.Context) DeleteRequest {
 	req.ctx = ctx
 	return req
 }
@@ -805,43 +788,44 @@ func (req *DeleteRequest) Context(ctx context.Context) *DeleteRequest {
 // UpdateRequest helps you to create an update request object for execution
 // by a Connection.
 type UpdateRequest struct {
-	spaceIndexRequest
-	key interface{}
-	ops *Operations
+	baseRequest
+	space, index interface{}
+	key          interface{}
+	ops          *Operations
 }
 
 // NewUpdateRequest returns a new empty UpdateRequest.
-func NewUpdateRequest(space interface{}) *UpdateRequest {
-	req := new(UpdateRequest)
-	req.rtype = iproto.IPROTO_UPDATE
-	req.setSpace(space)
-	req.key = []interface{}{}
-	return req
+func NewUpdateRequest(space interface{}) UpdateRequest {
+	return UpdateRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_UPDATE},
+		space:       space,
+		key:         []interface{}{},
+	}
 }
 
 // Index sets the index for the update request.
 // Note: default value is 0.
-func (req *UpdateRequest) Index(index interface{}) *UpdateRequest {
-	req.setIndex(index)
+func (req UpdateRequest) Index(index interface{}) UpdateRequest {
+	req.index = index
 	return req
 }
 
 // Key sets the key of tuple for the update request.
 // Note: default value is empty.
-func (req *UpdateRequest) Key(key interface{}) *UpdateRequest {
+func (req UpdateRequest) Key(key interface{}) UpdateRequest {
 	req.key = key
 	return req
 }
 
 // Operations sets operations to be performed on update.
 // Note: default value is empty.
-func (req *UpdateRequest) Operations(ops *Operations) *UpdateRequest {
+func (req UpdateRequest) Operations(ops *Operations) UpdateRequest {
 	req.ops = ops
 	return req
 }
 
 // Body fills an msgpack.Encoder with the update request body.
-func (req *UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -877,7 +861,7 @@ func (req *UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UpdateRequest) Context(ctx context.Context) *UpdateRequest {
+func (req UpdateRequest) Context(ctx context.Context) UpdateRequest {
 	req.ctx = ctx
 	return req
 }
@@ -885,36 +869,37 @@ func (req *UpdateRequest) Context(ctx context.Context) *UpdateRequest {
 // UpsertRequest helps you to create an upsert request object for execution
 // by a Connection.
 type UpsertRequest struct {
-	spaceRequest
+	baseRequest
+	space interface{}
 	tuple interface{}
 	ops   *Operations
 }
 
 // NewUpsertRequest returns a new empty UpsertRequest.
-func NewUpsertRequest(space interface{}) *UpsertRequest {
-	req := new(UpsertRequest)
-	req.rtype = iproto.IPROTO_UPSERT
-	req.setSpace(space)
-	req.tuple = []interface{}{}
-	return req
+func NewUpsertRequest(space interface{}) UpsertRequest {
+	return UpsertRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_UPSERT},
+		space:       space,
+		tuple:       []interface{}{},
+	}
 }
 
 // Tuple sets the tuple for insertion or update by the upsert request.
 // Note: default value is empty.
-func (req *UpsertRequest) Tuple(tuple interface{}) *UpsertRequest {
+func (req UpsertRequest) Tuple(tuple interface{}) UpsertRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Operations sets operations to be performed on update case by the upsert request.
 // Note: default value is empty.
-func (req *UpsertRequest) Operations(ops *Operations) *UpsertRequest {
+func (req UpsertRequest) Operations(ops *Operations) UpsertRequest {
 	req.ops = ops
 	return req
 }
 
 // Body fills an msgpack.Encoder with the upsert request body.
-func (req *UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -953,7 +938,7 @@ func (req *UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UpsertRequest) Context(ctx context.Context) *UpsertRequest {
+func (req UpsertRequest) Context(ctx context.Context) UpsertRequest {
 	req.ctx = ctx
 	return req
 }
@@ -968,22 +953,22 @@ type CallRequest struct {
 
 // NewCallRequest returns a new empty CallRequest. It uses request code for
 // Tarantool >= 1.7.
-func NewCallRequest(function string) *CallRequest {
-	req := new(CallRequest)
-	req.rtype = iproto.IPROTO_CALL
-	req.function = function
-	return req
+func NewCallRequest(function string) CallRequest {
+	return CallRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_CALL},
+		function:    function,
+	}
 }
 
 // Args sets the args for the call request.
 // Note: default value is empty.
-func (req *CallRequest) Args(args interface{}) *CallRequest {
+func (req CallRequest) Args(args interface{}) CallRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an encoder with the call request body.
-func (req *CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1013,7 +998,7 @@ func (req *CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *CallRequest) Context(ctx context.Context) *CallRequest {
+func (req CallRequest) Context(ctx context.Context) CallRequest {
 	req.ctx = ctx
 	return req
 }
@@ -1021,18 +1006,20 @@ func (req *CallRequest) Context(ctx context.Context) *CallRequest {
 // NewCall16Request returns a new empty Call16Request. It uses request code for
 // Tarantool 1.6.
 // Deprecated since Tarantool 1.7.2.
-func NewCall16Request(function string) *CallRequest {
-	req := NewCallRequest(function)
-	req.rtype = iproto.IPROTO_CALL_16
-	return req
+func NewCall16Request(function string) CallRequest {
+	return CallRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_CALL_16},
+		function:    function,
+	}
 }
 
 // NewCall17Request returns a new empty CallRequest. It uses request code for
 // Tarantool >= 1.7.
-func NewCall17Request(function string) *CallRequest {
-	req := NewCallRequest(function)
-	req.rtype = iproto.IPROTO_CALL
-	return req
+func NewCall17Request(function string) CallRequest {
+	return CallRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_CALL},
+		function:    function,
+	}
 }
 
 // EvalRequest helps you to create an eval request object for execution
@@ -1044,23 +1031,23 @@ type EvalRequest struct {
 }
 
 // NewEvalRequest returns a new empty EvalRequest.
-func NewEvalRequest(expr string) *EvalRequest {
-	req := new(EvalRequest)
-	req.rtype = iproto.IPROTO_EVAL
-	req.expr = expr
-	req.args = []interface{}{}
-	return req
+func NewEvalRequest(expr string) EvalRequest {
+	return EvalRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EVAL},
+		expr:        expr,
+		args:        []interface{}{},
+	}
 }
 
 // Args sets the args for the eval request.
 // Note: default value is empty.
-func (req *EvalRequest) Args(args interface{}) *EvalRequest {
+func (req EvalRequest) Args(args interface{}) EvalRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the eval request body.
-func (req *EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1090,7 +1077,7 @@ func (req *EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *EvalRequest) Context(ctx context.Context) *EvalRequest {
+func (req EvalRequest) Context(ctx context.Context) EvalRequest {
 	req.ctx = ctx
 	return req
 }
@@ -1104,23 +1091,23 @@ type ExecuteRequest struct {
 }
 
 // NewExecuteRequest returns a new empty ExecuteRequest.
-func NewExecuteRequest(expr string) *ExecuteRequest {
-	req := new(ExecuteRequest)
-	req.rtype = iproto.IPROTO_EXECUTE
-	req.expr = expr
-	req.args = []interface{}{}
-	return req
+func NewExecuteRequest(expr string) ExecuteRequest {
+	return ExecuteRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EXECUTE},
+		expr:        expr,
+		args:        []interface{}{},
+	}
 }
 
 // Args sets the args for the execute request.
 // Note: default value is empty.
-func (req *ExecuteRequest) Args(args interface{}) *ExecuteRequest {
+func (req ExecuteRequest) Args(args interface{}) ExecuteRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1146,13 +1133,13 @@ func (req *ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ExecuteRequest) Context(ctx context.Context) *ExecuteRequest {
+func (req ExecuteRequest) Context(ctx context.Context) ExecuteRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the ExecuteRequest.
-func (req *ExecuteRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req ExecuteRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -1169,15 +1156,15 @@ type WatchOnceRequest struct {
 }
 
 // NewWatchOnceRequest returns a new watchOnceRequest.
-func NewWatchOnceRequest(key string) *WatchOnceRequest {
-	req := new(WatchOnceRequest)
-	req.rtype = iproto.IPROTO_WATCH_ONCE
-	req.key = key
-	return req
+func NewWatchOnceRequest(key string) WatchOnceRequest {
+	return WatchOnceRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_WATCH_ONCE},
+		key:         key,
+	}
 }
 
 // Body fills an msgpack.Encoder with the watchOnce request body.
-func (req *WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -1190,7 +1177,7 @@ func (req *WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error 
 }
 
 // Context sets a passed context to the request.
-func (req *WatchOnceRequest) Context(ctx context.Context) *WatchOnceRequest {
+func (req WatchOnceRequest) Context(ctx context.Context) WatchOnceRequest {
 	req.ctx = ctx
 	return req
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -117,8 +117,7 @@ func TestGetSchema_index_select_error(t *testing.T) {
 func TestResolverCalledWithoutNameSupport(t *testing.T) {
 	resolver := ValidSchemeResolver{nameUseSupported: false}
 
-	req := tarantool.NewSelectRequest("valid")
-	req.Index("valid")
+	req := tarantool.NewSelectRequest("valid").Index("valid")
 
 	var reqBuf bytes.Buffer
 	reqEnc := msgpack.NewEncoder(&reqBuf)
@@ -141,8 +140,7 @@ func TestResolverCalledWithoutNameSupport(t *testing.T) {
 func TestResolverNotCalledWithNameSupport(t *testing.T) {
 	resolver := ValidSchemeResolver{nameUseSupported: true}
 
-	req := tarantool.NewSelectRequest("valid")
-	req.Index("valid")
+	req := tarantool.NewSelectRequest("valid").Index("valid")
 
 	var reqBuf bytes.Buffer
 	reqEnc := msgpack.NewEncoder(&reqBuf)

--- a/settings/request.go
+++ b/settings/request.go
@@ -70,11 +70,11 @@ import (
 
 // SetRequest helps to set session settings.
 type SetRequest struct {
-	impl *tarantool.UpdateRequest
+	impl tarantool.UpdateRequest
 }
 
-func newSetRequest(setting string, value interface{}) *SetRequest {
-	return &SetRequest{
+func newSetRequest(setting string, value interface{}) SetRequest {
+	return SetRequest{
 		impl: tarantool.NewUpdateRequest(sessionSettingsSpace).
 			Key(tarantool.StringKey{S: setting}).
 			Operations(tarantool.NewOperations().Assign(sessionSettingValueField, value)),
@@ -82,45 +82,45 @@ func newSetRequest(setting string, value interface{}) *SetRequest {
 }
 
 // Context sets a passed context to set session settings request.
-func (req *SetRequest) Context(ctx context.Context) *SetRequest {
+func (req SetRequest) Context(ctx context.Context) SetRequest {
 	req.impl = req.impl.Context(ctx)
 
 	return req
 }
 
 // Type returns IPROTO type for set session settings request.
-func (req *SetRequest) Type() iproto.Type {
+func (req SetRequest) Type() iproto.Type {
 	return req.impl.Type()
 }
 
 // Body fills an encoder with set session settings request body.
-func (req *SetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (req SetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	return req.impl.Body(res, enc)
 }
 
 // Ctx returns a context of set session settings request.
-func (req *SetRequest) Ctx() context.Context {
+func (req SetRequest) Ctx() context.Context {
 	return req.impl.Ctx()
 }
 
 // Async returns is set session settings request expects a response.
-func (req *SetRequest) Async() bool {
+func (req SetRequest) Async() bool {
 	return req.impl.Async()
 }
 
 // Response creates a response for the SetRequest.
-func (req *SetRequest) Response(header tarantool.Header,
+func (req SetRequest) Response(header tarantool.Header,
 	body io.Reader) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
 }
 
 // GetRequest helps to get session settings.
 type GetRequest struct {
-	impl *tarantool.SelectRequest
+	impl tarantool.SelectRequest
 }
 
-func newGetRequest(setting string) *GetRequest {
-	return &GetRequest{
+func newGetRequest(setting string) GetRequest {
+	return GetRequest{
 		impl: tarantool.NewSelectRequest(sessionSettingsSpace).
 			Key(tarantool.StringKey{S: setting}).
 			Limit(1),
@@ -128,162 +128,162 @@ func newGetRequest(setting string) *GetRequest {
 }
 
 // Context sets a passed context to get session settings request.
-func (req *GetRequest) Context(ctx context.Context) *GetRequest {
+func (req GetRequest) Context(ctx context.Context) GetRequest {
 	req.impl = req.impl.Context(ctx)
 
 	return req
 }
 
 // Type returns IPROTO type for get session settings request.
-func (req *GetRequest) Type() iproto.Type {
+func (req GetRequest) Type() iproto.Type {
 	return req.impl.Type()
 }
 
 // Body fills an encoder with get session settings request body.
-func (req *GetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (req GetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	return req.impl.Body(res, enc)
 }
 
 // Ctx returns a context of get session settings request.
-func (req *GetRequest) Ctx() context.Context {
+func (req GetRequest) Ctx() context.Context {
 	return req.impl.Ctx()
 }
 
 // Async returns is get session settings request expects a response.
-func (req *GetRequest) Async() bool {
+func (req GetRequest) Async() bool {
 	return req.impl.Async()
 }
 
 // Response creates a response for the GetRequest.
-func (req *GetRequest) Response(header tarantool.Header,
+func (req GetRequest) Response(header tarantool.Header,
 	body io.Reader) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
 }
 
 // NewErrorMarshalingEnabledSetRequest creates a request to
 // update current session ErrorMarshalingEnabled setting.
-func NewErrorMarshalingEnabledSetRequest(value bool) *SetRequest {
+func NewErrorMarshalingEnabledSetRequest(value bool) SetRequest {
 	return newSetRequest(errorMarshalingEnabled, value)
 }
 
 // NewErrorMarshalingEnabledGetRequest creates a request to get
 // current session ErrorMarshalingEnabled setting in tuple format.
-func NewErrorMarshalingEnabledGetRequest() *GetRequest {
+func NewErrorMarshalingEnabledGetRequest() GetRequest {
 	return newGetRequest(errorMarshalingEnabled)
 }
 
 // NewSQLDefaultEngineSetRequest creates a request to
 // update current session SQLDefaultEngine setting.
-func NewSQLDefaultEngineSetRequest(value string) *SetRequest {
+func NewSQLDefaultEngineSetRequest(value string) SetRequest {
 	return newSetRequest(sqlDefaultEngine, value)
 }
 
 // NewSQLDefaultEngineGetRequest creates a request to get
 // current session SQLDefaultEngine setting in tuple format.
-func NewSQLDefaultEngineGetRequest() *GetRequest {
+func NewSQLDefaultEngineGetRequest() GetRequest {
 	return newGetRequest(sqlDefaultEngine)
 }
 
 // NewSQLDeferForeignKeysSetRequest creates a request to
 // update current session SQLDeferForeignKeys setting.
-func NewSQLDeferForeignKeysSetRequest(value bool) *SetRequest {
+func NewSQLDeferForeignKeysSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlDeferForeignKeys, value)
 }
 
 // NewSQLDeferForeignKeysGetRequest creates a request to get
 // current session SQLDeferForeignKeys setting in tuple format.
-func NewSQLDeferForeignKeysGetRequest() *GetRequest {
+func NewSQLDeferForeignKeysGetRequest() GetRequest {
 	return newGetRequest(sqlDeferForeignKeys)
 }
 
 // NewSQLFullColumnNamesSetRequest creates a request to
 // update current session SQLFullColumnNames setting.
-func NewSQLFullColumnNamesSetRequest(value bool) *SetRequest {
+func NewSQLFullColumnNamesSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlFullColumnNames, value)
 }
 
 // NewSQLFullColumnNamesGetRequest creates a request to get
 // current session SQLFullColumnNames setting in tuple format.
-func NewSQLFullColumnNamesGetRequest() *GetRequest {
+func NewSQLFullColumnNamesGetRequest() GetRequest {
 	return newGetRequest(sqlFullColumnNames)
 }
 
 // NewSQLFullMetadataSetRequest creates a request to
 // update current session SQLFullMetadata setting.
-func NewSQLFullMetadataSetRequest(value bool) *SetRequest {
+func NewSQLFullMetadataSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlFullMetadata, value)
 }
 
 // NewSQLFullMetadataGetRequest creates a request to get
 // current session SQLFullMetadata setting in tuple format.
-func NewSQLFullMetadataGetRequest() *GetRequest {
+func NewSQLFullMetadataGetRequest() GetRequest {
 	return newGetRequest(sqlFullMetadata)
 }
 
 // NewSQLParserDebugSetRequest creates a request to
 // update current session SQLParserDebug setting.
-func NewSQLParserDebugSetRequest(value bool) *SetRequest {
+func NewSQLParserDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlParserDebug, value)
 }
 
 // NewSQLParserDebugGetRequest creates a request to get
 // current session SQLParserDebug setting in tuple format.
-func NewSQLParserDebugGetRequest() *GetRequest {
+func NewSQLParserDebugGetRequest() GetRequest {
 	return newGetRequest(sqlParserDebug)
 }
 
 // NewSQLRecursiveTriggersSetRequest creates a request to
 // update current session SQLRecursiveTriggers setting.
-func NewSQLRecursiveTriggersSetRequest(value bool) *SetRequest {
+func NewSQLRecursiveTriggersSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlRecursiveTriggers, value)
 }
 
 // NewSQLRecursiveTriggersGetRequest creates a request to get
 // current session SQLRecursiveTriggers setting in tuple format.
-func NewSQLRecursiveTriggersGetRequest() *GetRequest {
+func NewSQLRecursiveTriggersGetRequest() GetRequest {
 	return newGetRequest(sqlRecursiveTriggers)
 }
 
 // NewSQLReverseUnorderedSelectsSetRequest creates a request to
 // update current session SQLReverseUnorderedSelects setting.
-func NewSQLReverseUnorderedSelectsSetRequest(value bool) *SetRequest {
+func NewSQLReverseUnorderedSelectsSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlReverseUnorderedSelects, value)
 }
 
 // NewSQLReverseUnorderedSelectsGetRequest creates a request to get
 // current session SQLReverseUnorderedSelects setting in tuple format.
-func NewSQLReverseUnorderedSelectsGetRequest() *GetRequest {
+func NewSQLReverseUnorderedSelectsGetRequest() GetRequest {
 	return newGetRequest(sqlReverseUnorderedSelects)
 }
 
 // NewSQLSelectDebugSetRequest creates a request to
 // update current session SQLSelectDebug setting.
-func NewSQLSelectDebugSetRequest(value bool) *SetRequest {
+func NewSQLSelectDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlSelectDebug, value)
 }
 
 // NewSQLSelectDebugGetRequest creates a request to get
 // current session SQLSelectDebug setting in tuple format.
-func NewSQLSelectDebugGetRequest() *GetRequest {
+func NewSQLSelectDebugGetRequest() GetRequest {
 	return newGetRequest(sqlSelectDebug)
 }
 
 // NewSQLVDBEDebugSetRequest creates a request to
 // update current session SQLVDBEDebug setting.
-func NewSQLVDBEDebugSetRequest(value bool) *SetRequest {
+func NewSQLVDBEDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlVDBEDebug, value)
 }
 
 // NewSQLVDBEDebugGetRequest creates a request to get
 // current session SQLVDBEDebug setting in tuple format.
-func NewSQLVDBEDebugGetRequest() *GetRequest {
+func NewSQLVDBEDebugGetRequest() GetRequest {
 	return newGetRequest(sqlVDBEDebug)
 }
 
 // NewSessionSettingsGetRequest creates a request to get all
 // current session settings in tuple format.
-func NewSessionSettingsGetRequest() *GetRequest {
-	return &GetRequest{
+func NewSessionSettingsGetRequest() GetRequest {
+	return GetRequest{
 		impl: tarantool.NewSelectRequest(sessionSettingsSpace).
 			Limit(selectAllLimit),
 	}

--- a/settings/request_test.go
+++ b/settings/request_test.go
@@ -75,7 +75,7 @@ func TestRequestsAPI(t *testing.T) {
 func TestRequestsCtx(t *testing.T) {
 	// tarantool.Request interface doesn't have Context()
 	getTests := []struct {
-		req *GetRequest
+		req GetRequest
 	}{
 		{req: NewErrorMarshalingEnabledGetRequest()},
 		{req: NewSQLDefaultEngineGetRequest()},
@@ -96,7 +96,7 @@ func TestRequestsCtx(t *testing.T) {
 	}
 
 	setTests := []struct {
-		req *SetRequest
+		req SetRequest
 	}{
 		{req: NewErrorMarshalingEnabledSetRequest(false)},
 		{req: NewSQLDefaultEngineSetRequest("memtx")},

--- a/stream.go
+++ b/stream.go
@@ -47,35 +47,35 @@ type BeginRequest struct {
 }
 
 // NewBeginRequest returns a new BeginRequest.
-func NewBeginRequest() *BeginRequest {
-	req := new(BeginRequest)
-	req.rtype = iproto.IPROTO_BEGIN
-	req.txnIsolation = DefaultIsolationLevel
-	return req
+func NewBeginRequest() BeginRequest {
+	return BeginRequest{
+		baseRequest:  baseRequest{rtype: iproto.IPROTO_BEGIN},
+		txnIsolation: DefaultIsolationLevel,
+	}
 }
 
 // TxnIsolation sets the the transaction isolation level for transaction manager.
 // By default, the isolation level of Tarantool is serializable.
-func (req *BeginRequest) TxnIsolation(txnIsolation TxnIsolationLevel) *BeginRequest {
+func (req BeginRequest) TxnIsolation(txnIsolation TxnIsolationLevel) BeginRequest {
 	req.txnIsolation = txnIsolation
 	return req
 }
 
 // Timeout allows to set up a timeout for call BeginRequest.
-func (req *BeginRequest) Timeout(timeout time.Duration) *BeginRequest {
+func (req BeginRequest) Timeout(timeout time.Duration) BeginRequest {
 	req.timeout = timeout
 	return req
 }
 
 // IsSync allows to set up a IsSync flag for call BeginRequest.
-func (req *BeginRequest) IsSync(isSync bool) *BeginRequest {
+func (req BeginRequest) IsSync(isSync bool) BeginRequest {
 	req.isSync = isSync
 	req.isSyncSet = true
 	return req
 }
 
 // Body fills an msgpack.Encoder with the begin request body.
-func (req *BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	var (
 		mapLen            = 0
 		hasTimeout        = req.timeout > 0
@@ -137,7 +137,7 @@ func (req *BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *BeginRequest) Context(ctx context.Context) *BeginRequest {
+func (req BeginRequest) Context(ctx context.Context) BeginRequest {
 	req.ctx = ctx
 	return req
 }
@@ -153,21 +153,21 @@ type CommitRequest struct {
 }
 
 // NewCommitRequest returns a new CommitRequest.
-func NewCommitRequest() *CommitRequest {
-	req := new(CommitRequest)
-	req.rtype = iproto.IPROTO_COMMIT
-	return req
+func NewCommitRequest() CommitRequest {
+	return CommitRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_COMMIT},
+	}
 }
 
 // IsSync allows to set up a IsSync flag for call BeginRequest.
-func (req *CommitRequest) IsSync(isSync bool) *CommitRequest {
+func (req CommitRequest) IsSync(isSync bool) CommitRequest {
 	req.isSync = isSync
 	req.isSyncSet = true
 	return req
 }
 
 // Body fills an msgpack.Encoder with the commit request body.
-func (req *CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	var (
 		mapLen = 0
 	)
@@ -199,7 +199,7 @@ func (req *CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *CommitRequest) Context(ctx context.Context) *CommitRequest {
+func (req CommitRequest) Context(ctx context.Context) CommitRequest {
 	req.ctx = ctx
 	return req
 }
@@ -212,14 +212,14 @@ type RollbackRequest struct {
 }
 
 // NewRollbackRequest returns a new RollbackRequest.
-func NewRollbackRequest() *RollbackRequest {
-	req := new(RollbackRequest)
-	req.rtype = iproto.IPROTO_ROLLBACK
-	return req
+func NewRollbackRequest() RollbackRequest {
+	return RollbackRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_ROLLBACK},
+	}
 }
 
 // Body fills an msgpack.Encoder with the rollback request body.
-func (req *RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
@@ -229,7 +229,7 @@ func (req *RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *RollbackRequest) Context(ctx context.Context) *RollbackRequest {
+func (req RollbackRequest) Context(ctx context.Context) RollbackRequest {
 	req.ctx = ctx
 	return req
 }

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -1568,8 +1568,7 @@ func TestConnection_SetSchema_Changes(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := NewInsertRequest(spaceName)
-	req.Tuple([]interface{}{uint(1010), "Tarantool"})
+	req := NewInsertRequest(spaceName).Tuple([]interface{}{uint(1010), "Tarantool"})
 	_, err := conn.Do(req).Get()
 	if err != nil {
 		t.Fatalf("Failed to Insert: %s", err)
@@ -1585,8 +1584,7 @@ func TestConnection_SetSchema_Changes(t *testing.T) {
 	// connection schema.
 	s.Spaces[spaceName] = Space{}
 
-	reqS := NewSelectRequest(spaceName)
-	reqS.Key([]interface{}{uint(1010)})
+	reqS := NewSelectRequest(spaceName).Key([]interface{}{uint(1010)})
 	data, err := conn.Do(reqS).Get()
 	if err != nil {
 		t.Fatalf("failed to Select: %s", err)

--- a/watch.go
+++ b/watch.go
@@ -11,53 +11,53 @@ import (
 // BroadcastRequest helps to send broadcast messages. See:
 // https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_events/broadcast/
 type BroadcastRequest struct {
-	call *CallRequest
+	call CallRequest
 	key  string
 }
 
 // NewBroadcastRequest returns a new broadcast request for a specified key.
-func NewBroadcastRequest(key string) *BroadcastRequest {
-	req := new(BroadcastRequest)
-	req.key = key
-	req.call = NewCallRequest("box.broadcast").Args([]interface{}{key})
-	return req
+func NewBroadcastRequest(key string) BroadcastRequest {
+	return BroadcastRequest{
+		call: NewCallRequest("box.broadcast").Args([]interface{}{key}),
+		key:  key,
+	}
 }
 
 // Value sets the value for the broadcast request.
 // Note: default value is nil.
-func (req *BroadcastRequest) Value(value interface{}) *BroadcastRequest {
+func (req BroadcastRequest) Value(value interface{}) BroadcastRequest {
 	req.call = req.call.Args([]interface{}{req.key, value})
 	return req
 }
 
 // Context sets a passed context to the broadcast request.
-func (req *BroadcastRequest) Context(ctx context.Context) *BroadcastRequest {
+func (req BroadcastRequest) Context(ctx context.Context) BroadcastRequest {
 	req.call = req.call.Context(ctx)
 	return req
 }
 
 // Code returns IPROTO code for the broadcast request.
-func (req *BroadcastRequest) Type() iproto.Type {
+func (req BroadcastRequest) Type() iproto.Type {
 	return req.call.Type()
 }
 
 // Body fills an msgpack.Encoder with the broadcast request body.
-func (req *BroadcastRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req BroadcastRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return req.call.Body(res, enc)
 }
 
 // Ctx returns a context of the broadcast request.
-func (req *BroadcastRequest) Ctx() context.Context {
+func (req BroadcastRequest) Ctx() context.Context {
 	return req.call.Ctx()
 }
 
 // Async returns is the broadcast request expects a response.
-func (req *BroadcastRequest) Async() bool {
+func (req BroadcastRequest) Async() bool {
 	return req.call.Async()
 }
 
 // Response creates a response for a BroadcastRequest.
-func (req *BroadcastRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req BroadcastRequest) Response(header Header, body io.Reader) (Response, error) {
 	return DecodeBaseResponse(header, body)
 }
 


### PR DESCRIPTION
All `New*Request()`/`Make*Request()` constructors now return values instead of pointers. All methods on request types use value receivers and return values, enabling immutable builder-style chaining.

Removed intermediate `spaceRequest`, `spaceIndexRequest` types from the tarantool package and `spaceRequest` from the crud package — space and index fields are inlined directly into each request struct.

Converted all constructors to composite literal style.

Applied the same pattern to `arrow/` and `settings/` packages.

In the `box/` subpackage, request types no longer embed `tarantool.CallRequest`. They store it as a private field via `baseCallRequest` and implement their own `Context()` method returning the wrapper type.