### PR TITLE
tests: migrate pool package to testify

### DIFF
--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -323,13 +322,10 @@ func TestConnErrorAfterCtxCancel(t *testing.T) {
 	cancel()
 	connPool, err = pool.Connect(ctx, makeInstances(servers, connLongReconnectOpts))
 
-	if connPool != nil || err == nil {
-		t.Fatalf("ConnectionPool was created after cancel")
-	}
-	if !strings.Contains(err.Error(), "context canceled") {
-		t.Fatalf("Unexpected error, expected to contain %s, got %v",
-			"operation was canceled", err)
-	}
+	require.Nil(t, connPool, "ConnectionPool was created after cancel")
+	require.Error(t, err, "ConnectionPool was created after cancel")
+	require.Contains(t, err.Error(), "context canceled",
+		"Unexpected error, expected to contain %s", "operation was canceled")
 }
 
 type mockClosingDialer struct {
@@ -1168,9 +1164,7 @@ func TestConnectionHandlerOpenUpdateClose(t *testing.T) {
 		time.Sleep(poolOpts.CheckTimeout)
 	}
 
-	for _, err := range h.errs {
-		t.Errorf("Unexpected error: %s", err)
-	}
+	assert.Empty(t, h.errs, "Unexpected errors")
 	connected, err := connPool.ConnectedNow(pool.ANY)
 	require.NoErrorf(t, err, "failed to get connected state")
 	require.Falsef(t, connected, "connection pool still be connected")
@@ -2960,50 +2954,30 @@ func TestNewPrepared(t *testing.T) {
 	unprepareReq := tarantool.NewUnprepareRequest(stmt)
 
 	resp, err := connPool.Do(executeReq.Args([]interface{}{1, "test"}), pool.ANY).GetResponse()
-	if err != nil {
-		t.Fatalf("failed to execute prepared: %v", err)
-	}
-	if resp == nil {
-		t.Fatalf("nil response")
-	}
+	require.NoError(t, err, "failed to execute prepared")
+	require.NotNil(t, resp, "nil response")
 	data, err := resp.Decode()
-	if err != nil {
-		t.Fatalf("failed to Decode: %s", err.Error())
-	}
-	if reflect.DeepEqual(data[0], []interface{}{1, "test"}) {
-		t.Error("Select with named arguments failed")
-	}
+	require.NoError(t, err, "failed to Decode")
+	assert.NotEqual(t, []interface{}{1, "test"}, data[0], "Select with named arguments failed")
 	prepResp, ok := resp.(*tarantool.ExecuteResponse)
-	if !ok {
-		t.Fatalf("Not a Prepare response")
-	}
+	require.True(t, ok, "Not a Prepare response")
 	metaData, err := prepResp.MetaData()
-	if err != nil {
-		t.Errorf("Error while getting MetaData: %s", err.Error())
-	}
-	if metaData[0].FieldType != "unsigned" ||
-		metaData[0].FieldName != "NAME0" ||
-		metaData[1].FieldType != "string" ||
-		metaData[1].FieldName != "NAME1" {
-		t.Error("Wrong metadata")
-	}
+	require.NoError(t, err, "Error while getting MetaData")
+	assert.Equal(t, "unsigned", metaData[0].FieldType)
+	assert.Equal(t, "NAME0", metaData[0].FieldName)
+	assert.Equal(t, "string", metaData[1].FieldType)
+	assert.Equal(t, "NAME1", metaData[1].FieldName)
 
 	// the second argument for unprepare request is unused - it already belongs to some connection
 	_, err = connPool.Do(unprepareReq, pool.ANY).Get()
-	if err != nil {
-		t.Errorf("failed to unprepare prepared statement: %v", err)
-	}
+	require.NoError(t, err, "failed to unprepare prepared statement")
 
 	_, err = connPool.Do(unprepareReq, pool.ANY).Get()
-	if err == nil {
-		t.Errorf("the statement must be already unprepared")
-	}
+	require.Error(t, err, "the statement must be already unprepared")
 	require.Contains(t, err.Error(), "Prepared statement with id")
 
 	_, err = connPool.Do(executeReq, pool.ANY).Get()
-	if err == nil {
-		t.Errorf("the statement must be already unprepared")
-	}
+	require.Error(t, err, "the statement must be already unprepared")
 	require.Contains(t, err.Error(), "Prepared statement with id")
 }
 
@@ -3028,12 +3002,8 @@ func TestDoWithStrangerConn(t *testing.T) {
 	req := test_helpers.NewMockRequest()
 
 	_, err = connPool.Do(req, pool.ANY).Get()
-	if err == nil {
-		t.Fatalf("nil error caught")
-	}
-	if err.Error() != expectedErr.Error() {
-		t.Fatalf("Unexpected error caught")
-	}
+	require.Error(t, err, "nil error caught")
+	require.EqualError(t, err, expectedErr.Error(), "Unexpected error caught")
 }
 
 func TestStream_Commit(t *testing.T) {
@@ -3328,7 +3298,7 @@ func TestConnectionPool_NewWatcher_no_watchers(t *testing.T) {
 	case <-time.After(time.Second):
 		break
 	case <-ch:
-		t.Fatalf("watcher was created for connection that doesn't support it")
+		require.Fail(t, "watcher was created for connection that doesn't support it")
 	}
 }
 
@@ -3393,17 +3363,15 @@ func TestConnectionPool_NewWatcher_modes(t *testing.T) {
 						testMap[addr] = 1
 					}
 				case <-time.After(time.Second):
-					t.Errorf("Failed to get a watch event.")
+					assert.Fail(t, "Failed to get a watch event.")
 					break
 				}
 			}
 
 			for _, server := range expectedServers {
-				if val, ok := testMap[server]; !ok {
-					t.Errorf("Server not found: %s", server)
-				} else if val != 1 {
-					t.Errorf("Too many events %d for server %s", val, server)
-				}
+				val, ok := testMap[server]
+				assert.True(t, ok, "Server not found: %s", server)
+				assert.Equal(t, 1, val, "Too many events for server %s", server)
 			}
 		})
 	}
@@ -3456,7 +3424,7 @@ func TestConnectionPool_NewWatcher_update(t *testing.T) {
 				testMap[addr] = 1
 			}
 		case <-time.After(poolOpts.CheckTimeout * 2):
-			t.Errorf("Failed to get a watch init event.")
+			assert.Fail(t, "Failed to get a watch init event.")
 			break
 		}
 	}
@@ -3482,18 +3450,16 @@ func TestConnectionPool_NewWatcher_update(t *testing.T) {
 				testMap[addr] = 1
 			}
 		case <-time.After(time.Second):
-			t.Errorf("Failed to get a watch update event.")
+			assert.Fail(t, "Failed to get a watch update event.")
 			break
 		}
 	}
 
 	// Check that all an event happen for an each connection.
 	for _, server := range servers {
-		if val, ok := testMap[server]; !ok {
-			t.Errorf("Server not found: %s", server)
-		} else {
-			require.Equalf(t, 1, val, "for server %s", server)
-		}
+		val, ok := testMap[server]
+		assert.True(t, ok, "Server not found: %s", server)
+		require.Equalf(t, 1, val, "for server %s", server)
 	}
 }
 
@@ -3530,7 +3496,7 @@ func TestWatcher_Unregister(t *testing.T) {
 		select {
 		case <-events:
 		case <-time.After(time.Second):
-			t.Fatalf("Failed to skip initial events.")
+			require.Fail(t, "Failed to skip initial events.")
 		}
 	}
 	watcher.Unregister()
@@ -3543,7 +3509,7 @@ func TestWatcher_Unregister(t *testing.T) {
 
 	select {
 	case event := <-events:
-		t.Fatalf("Get unexpected event: %v", event)
+		require.Fail(t, "Get unexpected event", "event: %v", event)
 	case <-time.After(time.Second):
 	}
 
@@ -3584,9 +3550,7 @@ func TestConnectionPool_NewWatcher_concurrent(t *testing.T) {
 			defer wg.Done()
 
 			watcher, err := connPool.NewWatcher(key, callback, mode)
-			if err != nil {
-				t.Errorf("Failed to create a watcher: %s", err)
-			} else {
+			if assert.NoError(t, err, "Failed to create a watcher") {
 				watcher.Unregister()
 			}
 		}()

--- a/pool/round_robin_test.go
+++ b/pool/round_robin_test.go
@@ -3,6 +3,8 @@ package pool
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tarantool/go-tarantool/v3"
 )
 
@@ -23,12 +25,10 @@ func TestRoundRobinAddDelete(t *testing.T) {
 
 	for i, addr := range addrs {
 		if conn := rr.DeleteConnection(addr); conn != conns[i] {
-			t.Errorf("Unexpected connection on address %s", addr)
+			assert.Equal(t, conns[i], conn, "Unexpected connection on address %s", addr)
 		}
 	}
-	if !rr.IsEmpty() {
-		t.Errorf("RoundRobin does not empty")
-	}
+	assert.True(t, rr.IsEmpty(), "RoundRobin does not empty")
 }
 
 func TestRoundRobinAddDuplicateDelete(t *testing.T) {
@@ -40,15 +40,9 @@ func TestRoundRobinAddDuplicateDelete(t *testing.T) {
 	rr.AddConnection(validAddr1, conn1)
 	rr.AddConnection(validAddr1, conn2)
 
-	if rr.DeleteConnection(validAddr1) != conn2 {
-		t.Errorf("Unexpected deleted connection")
-	}
-	if !rr.IsEmpty() {
-		t.Errorf("RoundRobin does not empty")
-	}
-	if rr.DeleteConnection(validAddr1) != nil {
-		t.Errorf("Unexpected value after second deletion")
-	}
+	assert.Equal(t, conn2, rr.DeleteConnection(validAddr1), "Unexpected deleted connection")
+	assert.True(t, rr.IsEmpty(), "RoundRobin does not empty")
+	assert.Nil(t, rr.DeleteConnection(validAddr1), "Unexpected value after second deletion")
 }
 
 func TestRoundRobinGetNextConnection(t *testing.T) {
@@ -63,9 +57,7 @@ func TestRoundRobinGetNextConnection(t *testing.T) {
 
 	expectedConns := []*tarantool.Connection{conns[0], conns[1], conns[0], conns[1]}
 	for i, expected := range expectedConns {
-		if rr.GetNextConnection() != expected {
-			t.Errorf("Unexpected connection on %d call", i)
-		}
+		assert.Equal(t, expected, rr.GetNextConnection(), "Unexpected connection on %d call", i)
 	}
 }
 
@@ -83,8 +75,6 @@ func TestRoundRobinStrategy_GetConnections(t *testing.T) {
 	rrConns := rr.GetConnections()
 
 	for i, addr := range addrs {
-		if conns[i] != rrConns[addr] {
-			t.Errorf("Unexpected connection on %s addr", addr)
-		}
+		assert.Equal(t, conns[i], rrConns[addr], "Unexpected connection on %s addr", addr)
 	}
 }


### PR DESCRIPTION
The pool tests used a mix of standard testing package
(t.Error, t.Fatal) and testify. This inconsistency made
the codebase harder to maintain and provided less helpful
failure messages.

Migrated all assertions to use testify/assert and
testify/require for better error messages and consistency
with the rest of the codebase.