### PR TITLE
tests: fix flaky TestConnectionHandlerUpdateError

### DIFF
--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -1277,13 +1277,9 @@ func TestConnectionHandlerUpdateError(t *testing.T) {
 	require.NoErrorf(t, err, "failed to get ConnectedNow()")
 	require.Truef(t, connected, "should be connected")
 
-	for i := 0; i < len(poolServers); i++ {
-		_, err = connPool.Do(tarantool.NewCall17Request("box.cfg").
-			Args([]interface{}{map[string]bool{
-				"read_only": true,
-			}}), pool.RW).Get()
-		require.NoErrorf(t, err, "failed to make ro")
-	}
+	roles = []bool{true, true}
+	err = test_helpers.SetClusterRO(ctx, makeDialers(poolServers), connOpts, roles)
+	require.NoErrorf(t, err, "failed to make ro")
 
 	for i := 0; i < 100; i++ {
 		// Wait for updates done.


### PR DESCRIPTION
The test set servers to read_only one-by-one via pool connections with pool.RW mode, but the background checker (with 100µs timeout) could detect the role change and close the connection before the next iteration found an RW server, causing "connection closed by client" errors.

Now SetClusterRO is used to set both servers read_only directly, bypassing the pool and avoiding the race.
