### PR TITLE
tests: MockDoer refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,19 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Method String() for type decimal.Decimal (#322).
 * New `T` interface compatible with testing.T methods
   to make testing easier, `test_helpers` updated with it (#474).
+* New `MockDoer` interface for custom `Doer` testing with builder pattern
+  methods: `AddResponse`, `AddResponseRaw`, `AddResponseError`, `Requests`.
+* New `MockRequestNamed` type for verifying specific requests in tests.
 
 ### Changed
 
 * Required Go version is `1.24` now (#456).
+* `test_helpers.MockDoer` is now an interface instead of a struct. The
+  `Requests` field became a method `Requests()`. The `NewMockDoer()`
+  constructor now returns the interface and uses a builder pattern.
+  Old `NewMockDoer(t, ...interface{})` is removed. Use `NewMockDoer(t)`,
+  then chain `AddResponseRaw()`, `AddResponseError()`, `AddResponse()`
+  to configure responses.
 * `box.New` returns an error instead of panic (#448).
 * Now cases of `<-ctx.Done()` returns wrapped error provided by `ctx.Cause()`.
   Allows you compare it using `errors.Is/As` (#457).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -363,3 +363,24 @@ The subpackage has been deleted. You could use `pool` instead.
 ### test_helpers package
 
 * Renamed `StrangerResponse` to `MockResponse`.
+* `MockDoer` is now an interface instead of a struct. Use `NewMockDoer(t)` to
+  create an instance, then chain `AddResponseRaw()`, `AddResponseError()`,
+  `AddResponse()` to configure responses. The `Requests` field is now a
+  method `Requests()` that returns recorded requests.
+
+  Before:
+  ```Go
+  mock := test_helpers.NewMockDoer(t,
+      test_helpers.NewMockResponse(t, []interface{}{"data"}),
+      errors.New("some error"),
+  )
+  requests := mock.Requests
+  ```
+
+  After:
+  ```Go
+  mock := test_helpers.NewMockDoer(t).
+      AddResponseRaw([]interface{}{"data"}).
+      AddResponseError(errors.New("some error"))
+  requests := mock.Requests()
+  ```

--- a/box/box_test.go
+++ b/box/box_test.go
@@ -29,17 +29,16 @@ func TestMustNew(t *testing.T) {
 func TestMocked_BoxNew(t *testing.T) {
 	t.Parallel()
 
-	mock := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, "valid"),
-	)
+	mock := test_helpers.NewMockDoer(t).
+		AddResponseRaw("valid")
 
-	b, err := box.New(&mock)
+	b, err := box.New(mock)
 	require.NoError(t, err)
 	require.NotNil(t, b)
 
-	assert.Empty(t, mock.Requests)
+	assert.Empty(t, mock.Requests())
 	_, _ = b.Schema().User().Exists(box.NewInfoRequest().Ctx(), "")
-	require.Len(t, mock.Requests, 1)
+	require.Len(t, mock.Requests(), 1)
 }
 
 func TestMocked_BoxInfo(t *testing.T) {
@@ -57,10 +56,9 @@ func TestMocked_BoxInfo(t *testing.T) {
 			"replication": nil,
 		},
 	}
-	mock := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, data),
-	)
-	b := box.MustNew(&mock)
+	mock := test_helpers.NewMockDoer(t).
+		AddResponseRaw(data)
+	b := box.MustNew(mock)
 
 	info, err := b.Info()
 	require.NoError(t, err)
@@ -77,10 +75,9 @@ func TestMocked_BoxSchemaUserInfo(t *testing.T) {
 			[]interface{}{"read,write,execute", "universe", ""},
 		},
 	}
-	mock := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, data),
-	)
-	b := box.MustNew(&mock)
+	mock := test_helpers.NewMockDoer(t).
+		AddResponseRaw(data)
+	b := box.MustNew(mock)
 
 	privs, err := b.Schema().User().Info(context.Background(), "username")
 	require.NoError(t, err)
@@ -101,11 +98,10 @@ func TestMocked_BoxSchemaUserInfo(t *testing.T) {
 func TestMocked_BoxSessionSu(t *testing.T) {
 	t.Parallel()
 
-	mock := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, []interface{}{}),
-		errors.New("user not found or supplied credentials are invalid"),
-	)
-	b := box.MustNew(&mock)
+	mock := test_helpers.NewMockDoer(t).
+		AddResponseRaw([]interface{}{}).
+		AddResponseError(errors.New("user not found or supplied credentials are invalid"))
+	b := box.MustNew(mock)
 
 	err := b.Session().Su(context.Background(), "admin")
 	require.NoError(t, err)

--- a/box/session_test.go
+++ b/box/session_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBox_Session(t *testing.T) {
-	b := box.MustNew(th.Ptr(th.NewMockDoer(t)))
+	b := box.MustNew(th.NewMockDoer(t))
 	require.NotNil(t, b.Session())
 }
 

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tarantool/go-iproto v1.1.0 h1:HULVOIHsiehI+FnHfM7wMDntuzUddO09DKqu2WnFQ5A=
 github.com/tarantool/go-iproto v1.1.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
-github.com/tarantool/go-option v1.0.0 h1:+Etw0i3TjsXvADTo5rfZNCfsXe3BfHOs+iVfIrl0Nlo=
-github.com/tarantool/go-option v1.0.0/go.mod h1:lXzzeZtL+rPUtLOCDP6ny3FemFBjruG9aHKzNN2bS08=
 github.com/tarantool/go-option v1.1.0 h1:ShoOhNsdL41sRpm4hXCRDjV8H0WzPkd4UnKhLKbW//w=
 github.com/tarantool/go-option v1.1.0/go.mod h1:hMr9z2JXOWlgdCBpCPSL2nwp8718GKYvNBJ+ZuzJbCo=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/schema_test.go
+++ b/schema_test.go
@@ -43,8 +43,8 @@ func TestGetSchema_ok(t *testing.T) {
 		FieldsById: make(map[uint32]tarantool.Field),
 	}
 
-	mockDoer := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, [][]interface{}{
+	mockDoer := test_helpers.NewMockDoer(t).
+		AddResponseRaw([][]interface{}{
 			{
 				uint32(1),
 				"skip",
@@ -59,8 +59,8 @@ func TestGetSchema_ok(t *testing.T) {
 				"",
 				0,
 			},
-		}),
-		test_helpers.NewMockResponse(t, [][]interface{}{
+		}).
+		AddResponseRaw([][]interface{}{
 			{
 				uint32(2),
 				uint32(1),
@@ -69,8 +69,7 @@ func TestGetSchema_ok(t *testing.T) {
 				uint8(1),
 				uint8(0),
 			},
-		}),
-	)
+		})
 
 	expectedSchema := tarantool.Schema{
 		SpacesById: map[uint32]tarantool.Space{
@@ -83,33 +82,35 @@ func TestGetSchema_ok(t *testing.T) {
 		},
 	}
 
-	schema, err := tarantool.GetSchema(&mockDoer)
+	schema, err := tarantool.GetSchema(mockDoer)
 	require.NoError(t, err)
 	require.Equal(t, expectedSchema, schema)
 }
 
 func TestGetSchema_spaces_select_error(t *testing.T) {
-	mockDoer := test_helpers.NewMockDoer(t, fmt.Errorf("some error"))
+	mockDoer := test_helpers.NewMockDoer(t).
+		AddResponseError(fmt.Errorf("some error"))
 
-	schema, err := tarantool.GetSchema(&mockDoer)
+	schema, err := tarantool.GetSchema(mockDoer)
 	require.EqualError(t, err, "some error")
 	require.Equal(t, tarantool.Schema{}, schema)
 }
 
 func TestGetSchema_index_select_error(t *testing.T) {
-	mockDoer := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, [][]interface{}{
-			{
-				uint32(1),
-				"skip",
-				"name1",
-				"",
-				0,
-			},
-		}),
-		fmt.Errorf("some error"))
+	mockDoer := test_helpers.NewMockDoer(t).
+		AddResponseRaw(
+			[][]interface{}{
+				{
+					uint32(1),
+					"skip",
+					"name1",
+					"",
+					0,
+				},
+			}).
+		AddResponseError(fmt.Errorf("some error"))
 
-	schema, err := tarantool.GetSchema(&mockDoer)
+	schema, err := tarantool.GetSchema(mockDoer)
 	require.EqualError(t, err, "some error")
 	require.Equal(t, tarantool.Schema{}, schema)
 }

--- a/test_helpers/doer.go
+++ b/test_helpers/doer.go
@@ -2,59 +2,96 @@ package test_helpers
 
 import (
 	"bytes"
+	"io"
 
 	"github.com/tarantool/go-tarantool/v3"
 )
+
+// MockDoer is an interface for a mock doer used for custom testing.
+// It allows building a sequence of responses and inspecting requests
+// that were sent via Do calls.
+type MockDoer interface {
+	// AddResponse adds a response with a custom header and a body
+	// packed inside an io.Reader and returns the MockDoer for chaining.
+	AddResponse(header tarantool.Header, body io.Reader) MockDoer
+	// AddResponseRaw adds a response with an empty header and the given
+	// data, which is encoded with msgpack, and returns the MockDoer for
+	// chaining.
+	AddResponseRaw(data interface{}) MockDoer
+	// AddResponseError adds an error response and returns the MockDoer for
+	// chaining.
+	AddResponseError(err error) MockDoer
+	// Requests returns a slice of requests received via Do calls.
+	Requests() []tarantool.Request
+	// Do processes the request and returns a Future with the next
+	// configured response or error. It calls Fatalf on the test if
+	// no responses are configured.
+	Do(req tarantool.Request) tarantool.Future
+}
 
 type doerResponse struct {
 	resp *MockResponse
 	err  error
 }
 
-// MockDoer is an implementation of the Doer interface
+// mockDoer is an implementation of the MockDoer interface
 // used for testing purposes.
-type MockDoer struct {
-	// Requests is a slice of received requests.
+type mockDoer struct {
+	// requests is a slice of received requests.
 	// It could be used to compare incoming requests with expected.
-	Requests  []tarantool.Request
+	requests  []tarantool.Request
 	responses []doerResponse
 	t         T
 }
 
-// NewMockDoer creates a MockDoer by given responses.
-// Each response could be one of two types: MockResponse or error.
-func NewMockDoer(t T, responses ...interface{}) MockDoer {
+var _ MockDoer = (*mockDoer)(nil)
+
+func (m *mockDoer) Requests() []tarantool.Request {
+	return m.requests
+}
+
+func (m *mockDoer) AddResponse(header tarantool.Header, data io.Reader) MockDoer {
+	resp, err := CreateMockResponse(header, data)
+	if err != nil {
+		m.t.Fatalf("failed to create mock response: %v", err)
+	}
+
+	m.responses = append(m.responses, doerResponse{resp: resp})
+	return m
+}
+
+func (m *mockDoer) AddResponseRaw(data interface{}) MockDoer {
+	m.responses = append(m.responses, doerResponse{resp: NewMockResponse(m.t, data)})
+	return m
+}
+
+func (m *mockDoer) AddResponseError(err error) MockDoer {
+	m.responses = append(m.responses, doerResponse{err: err})
+	return m
+}
+
+// NewMockDoer creates a MockDoer for testing. Use AddResponse, AddResponseRaw,
+// and AddResponseError methods to configure the sequence of responses.
+func NewMockDoer(t T) MockDoer {
 	t.Helper()
 
-	mockDoer := MockDoer{t: t}
-	for _, response := range responses {
-		doerResp := doerResponse{}
-
-		switch resp := response.(type) {
-		case *MockResponse:
-			doerResp.resp = resp
-		case error:
-			doerResp.err = resp
-		default:
-			t.Fatalf("unsupported type: %T", response)
-		}
-
-		mockDoer.responses = append(mockDoer.responses, doerResp)
-	}
-	return mockDoer
+	return &mockDoer{t: t}
 }
 
 // Do returns a future with the current response or an error.
 // It saves the current request into MockDoer.Requests.
-func (doer *MockDoer) Do(req tarantool.Request) tarantool.Future {
-	doer.Requests = append(doer.Requests, req)
-
+func (doer *mockDoer) Do(req tarantool.Request) tarantool.Future {
 	mockReq := NewMockRequest()
 	var fut tarantool.Future
 
 	if len(doer.responses) == 0 {
-		doer.t.Fatalf("list of responses is empty")
+		doer.t.Fatalf("MockDoer.Do: no responses configured, %d Do() calls were made",
+			len(doer.requests))
+
+		return fut
 	}
+
+	doer.requests = append(doer.requests, req)
 	response := doer.responses[0]
 
 	if response.err != nil {

--- a/test_helpers/example_test.go
+++ b/test_helpers/example_test.go
@@ -1,23 +1,25 @@
 package test_helpers_test
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/tarantool/go-tarantool/v3"
 	"github.com/tarantool/go-tarantool/v3/test_helpers"
 )
 
-func TestExampleMockDoer(t *testing.T) {
-	mockDoer := test_helpers.NewMockDoer(t,
-		test_helpers.NewMockResponse(t, []interface{}{"some data"}),
-		fmt.Errorf("some error"),
-		test_helpers.NewMockResponse(t, "some typed data"),
-		fmt.Errorf("some error"),
-	)
+func TestExampleMockDoer_Responses(t *testing.T) {
+	mockDoer := test_helpers.NewMockDoer(t).
+		AddResponseRaw([]interface{}{"some data"}).
+		AddResponseError(fmt.Errorf("some error")).
+		AddResponseRaw("some typed data").
+		AddResponseError(fmt.Errorf("some error"))
 
 	data, err := mockDoer.Do(tarantool.NewPingRequest()).Get()
 	require.NoError(t, err)
@@ -35,4 +37,58 @@ func TestExampleMockDoer(t *testing.T) {
 	err = mockDoer.Do(tarantool.NewPrepareRequest("expr")).GetTyped(&stringData)
 	require.EqualError(t, err, "some error")
 	assert.Nil(t, data)
+}
+
+func TestExampleMockDoer_AddResponseWithRequests(t *testing.T) {
+	mockDoer := test_helpers.NewMockDoer(t)
+
+	header := tarantool.Header{RequestId: 123}
+	dataStr := "v3"
+
+	buf := bytes.NewBuffer([]byte{})
+	enc := msgpack.NewEncoder(buf)
+	require.NoError(t, enc.Encode(dataStr))
+
+	mockDoer.AddResponse(header, bytes.NewBuffer(buf.Bytes()))
+
+	resp, err := mockDoer.Do(test_helpers.NewMockRequestNamed("bar")).GetResponse()
+	require.NoError(t, err)
+	assert.Equal(t, header, resp.Header())
+
+	var stringData string
+	err = resp.DecodeTyped(&stringData)
+	require.NoError(t, err)
+	assert.Equal(t, dataStr, stringData)
+
+	require.Len(t, mockDoer.Requests(), 1)
+	assert.Equal(t, "bar", mockDoer.Requests()[0].(*test_helpers.MockRequestNamed).Name)
+}
+
+func ExampleMockDoer_noResponses() {
+	// This example demonstrates that MockDoer calls Fatalf on the test
+	// when Do() is called more times than responses were configured.
+	mockDoer := test_helpers.NewMockDoer(testingAdapter{}).
+		AddResponseRaw([]interface{}{"first"})
+
+	data, err := mockDoer.Do(tarantool.NewPingRequest()).Get()
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("first response:", data)
+
+	mockDoer.Do(tarantool.NewPingRequest())
+
+	// Output:
+	// first response: [first]
+	// MockDoer.Do: no responses configured, 1 Do() calls were made
+}
+
+type testingAdapter struct {
+	test_helpers.T
+}
+
+func (testingAdapter) Helper() {}
+func (testingAdapter) Fatalf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stdout, format, args...)
 }

--- a/test_helpers/request.go
+++ b/test_helpers/request.go
@@ -50,3 +50,18 @@ func (req *MockRequest) Response(header tarantool.Header,
 	resp, err := CreateMockResponse(header, body)
 	return resp, err
 }
+
+// MockRequestNamed is a mock request with a name used for testing purposes.
+// It is useful for verifying that a specific request was sent via the
+// MockDoer by checking the Name field of recorded requests.
+type MockRequestNamed struct {
+	MockRequest
+	Name string
+}
+
+var _ tarantool.Request = (*MockRequestNamed)(nil)
+
+// NewMockRequestNamed creates a MockRequestNamed with the given name.
+func NewMockRequestNamed(name string) *MockRequestNamed {
+	return &MockRequestNamed{Name: name}
+}


### PR DESCRIPTION
MockDoer become interface that allows controlling and testing response and request flows.

Closes #487

