### PR TITLE
tests: fix arrow.TestInsert_invalid

### DIFF
--- a/arrow/tarantool_test.go
+++ b/arrow/tarantool_test.go
@@ -30,6 +30,9 @@ var opts = tarantool.Opts{
 	Timeout: 5 * time.Second,
 }
 
+// Invalid Arrow request results in CustomError with errcode = 4.
+const invalidArrowCode = 4
+
 // TestInsert uses Arrow sequence from Tarantool's test.
 // See: https://github.com/tarantool/tarantool/blob/d628b71bc537a75b69c253f45ec790462cf1a5cd/test/box-luatest/gh_10508_iproto_insert_arrow_test.lua#L56
 func TestInsert_invalid(t *testing.T) {
@@ -39,11 +42,11 @@ func TestInsert_invalid(t *testing.T) {
 	}{
 		{
 			"",
-			[]iproto.Error{iproto.ER_INVALID_MSGPACK},
+			[]iproto.Error{invalidArrowCode, iproto.ER_INVALID_MSGPACK},
 		},
 		{
 			"00",
-			[]iproto.Error{iproto.ER_INVALID_MSGPACK},
+			[]iproto.Error{invalidArrowCode, iproto.ER_INVALID_MSGPACK},
 		},
 		{
 			"ffffffff70000000040000009effffff0400010004000000" +


### PR DESCRIPTION
The handling of incorrect Arrow data changed in Tarantool [1], now a `CustomError` with the code 4 is returned instead of `ClientError` with the code 20 (`ER_INVALID_MSGPACK`). Need to update the test.


[1]: https://github.com/tarantool/tarantool/pull/12482