### PR TITLE
api: rename pool package public API for Go idiomatic naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Rename `pool.Pool.DoInstance()` to `pool.Pool.DoOn()`.
 * Rename `pool.Connect()` to `pool.New()`, `pool.ConnectWithOpts()` to
   `pool.NewWithOpts()`.
+* Rename `pool` enum constants to use prefix: `ANY` → `ModeAny`, `RW` →
+  `ModeRW`, `RO` → `ModeRO`, `PreferRW` → `ModePreferRW`, `PreferRO` →
+  `ModePreferRO`, `UnknownRole` → `RoleUnknown`, `MasterRole` → `RoleMaster`,
+  `ReplicaRole` → `RoleReplica`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `pool.Handler`, `pool.ConnectionInfo` to `pool.Info`, `pool.ConnectionInfo.ConnRole`
   to `pool.Info.Role`.
 * Rename `pool.Pool.GetInfo()` to `pool.Pool.Info()`.
+* Rename `pool.Pool.DoInstance()` to `pool.Pool.DoOn()`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * Rename `pool.ConnectionPool` to `pool.Pool`, `pool.ConnectionHandler` to
   `pool.Handler`, `pool.ConnectionInfo` to `pool.Info`, `pool.ConnectionInfo.ConnRole`
   to `pool.Info.Role`.
+* Rename `pool.Pool.GetInfo()` to `pool.Pool.Info()`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   to `pool.Info.Role`.
 * Rename `pool.Pool.GetInfo()` to `pool.Pool.Info()`.
 * Rename `pool.Pool.DoInstance()` to `pool.Pool.DoOn()`.
+* Rename `pool.Connect()` to `pool.New()`, `pool.ConnectWithOpts()` to
+  `pool.NewWithOpts()`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `pool.ConnectionHandler` to track connection availability instead of
   `tarantool.Opts.Notify`. All validation errors are combined using
   `errors.Join` and can be checked with `errors.Is`.
+* Rename `pool.ConnectionPool` to `pool.Pool`, `pool.ConnectionHandler` to
+  `pool.Handler`, `pool.ConnectionInfo` to `pool.Info`, `pool.ConnectionInfo.ConnRole`
+  to `pool.Info.Role`.
 
 ### Removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -71,7 +71,7 @@ TODO
 * `pool.ConnectionPool` renamed to `pool.Pool`.
 * `pool.ConnectionHandler` renamed to `pool.Handler`.
 * `pool.ConnectionInfo` renamed to `pool.Info`, field `ConnRole` renamed to `Role`.
-* `pool.ConnectionInfo` renamed to `pool.Info`.
+* `pool.Pool.GetInfo()` renamed to `pool.Pool.Info()`.
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -68,6 +68,10 @@ TODO
   }
   connPool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
   ```
+* `pool.ConnectionPool` renamed to `pool.Pool`.
+* `pool.ConnectionHandler` renamed to `pool.Handler`.
+* `pool.ConnectionInfo` renamed to `pool.Info`, field `ConnRole` renamed to `Role`.
+* `pool.ConnectionInfo` renamed to `pool.Info`.
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -73,6 +73,8 @@ TODO
 * `pool.ConnectionInfo` renamed to `pool.Info`, field `ConnRole` renamed to `Role`.
 * `pool.Pool.GetInfo()` renamed to `pool.Pool.Info()`.
 * `pool.Pool.DoInstance()` renamed to `pool.Pool.DoOn()`.
+* `pool.Connect()` renamed to `pool.New()`, `pool.ConnectWithOpts()` renamed to
+  `pool.NewWithOpts()`.
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -75,6 +75,10 @@ TODO
 * `pool.Pool.DoInstance()` renamed to `pool.Pool.DoOn()`.
 * `pool.Connect()` renamed to `pool.New()`, `pool.ConnectWithOpts()` renamed to
   `pool.NewWithOpts()`.
+* `pool` enum constants renamed to use prefix: `ANY` → `ModeAny`, `RW` →
+  `ModeRW`, `RO` → `ModeRO`, `PreferRW` → `ModePreferRW`, `PreferRO` →
+  `ModePreferRO`, `UnknownRole` → `RoleUnknown`, `MasterRole` → `RoleMaster`,
+  `ReplicaRole` → `RoleReplica`.
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -72,6 +72,7 @@ TODO
 * `pool.ConnectionHandler` renamed to `pool.Handler`.
 * `pool.ConnectionInfo` renamed to `pool.Info`, field `ConnRole` renamed to `Role`.
 * `pool.Pool.GetInfo()` renamed to `pool.Pool.Info()`.
+* `pool.Pool.DoInstance()` renamed to `pool.Pool.DoOn()`.
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/pool/connector_test.go
+++ b/pool/connector_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/tarantool/go-tarantool/v3/pool"
 )
 
-var testMode Mode = RW
+var testMode Mode = ModeRW
 
 type connectedNowMock struct {
 	Pooler

--- a/pool/const.go
+++ b/pool/const.go
@@ -11,31 +11,31 @@ package pool
 //	| eval    | no default  |
 //	| execute | no default  |
 //	| ping    | no default  |
-//	| insert  | RW          |
-//	| delete  | RW          |
-//	| replace | RW          |
-//	| update  | RW          |
-//	| upsert  | RW          |
-//	| select  | ANY         |
-//	| get     | ANY         |
+//	| insert  | ModeRW      |
+//	| delete  | ModeRW      |
+//	| replace | ModeRW      |
+//	| update  | ModeRW      |
+//	| upsert  | ModeRW      |
+//	| select  | ModeAny     |
+//	| get     | ModeAny     |
 type Mode uint32
 
 const (
-	ANY      Mode = iota // The request can be executed on any instance (master or replica).
-	RW                   // The request can only be executed on master.
-	RO                   // The request can only be executed on replica.
-	PreferRW             // If there is one, otherwise fallback to a writeable one (master).
-	PreferRO             // If there is one, otherwise fallback to a read only one (replica).
+	ModeAny      Mode = iota // The request can be executed on any instance (master or replica).
+	ModeRW                   // The request can only be executed on master.
+	ModeRO                   // The request can only be executed on replica.
+	ModePreferRW             // If there is one, otherwise fallback to a writeable one (master).
+	ModePreferRO             // If there is one, otherwise fallback to a read only one (replica).
 )
 
 // Role describes a role of an instance by its mode.
 type Role uint32
 
 const (
-	// UnknownRole - the connection pool was unable to detect the instance mode.
-	UnknownRole Role = iota // unknown
-	// MasterRole - the instance is in read-write mode.
-	MasterRole // master
-	// ReplicaRole - the instance is in read-only mode.
-	ReplicaRole // replica
+	// RoleUnknown - the connection pool was unable to detect the instance mode.
+	RoleUnknown Role = iota // unknown
+	// RoleMaster - the instance is in read-write mode.
+	RoleMaster // master
+	// RoleReplica - the instance is in read-only mode.
+	RoleReplica // replica
 )

--- a/pool/const_test.go
+++ b/pool/const_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRole_String(t *testing.T) {
-	require.Equal(t, "unknown", UnknownRole.String())
-	require.Equal(t, "master", MasterRole.String())
-	require.Equal(t, "replica", ReplicaRole.String())
+	require.Equal(t, "unknown", RoleUnknown.String())
+	require.Equal(t, "master", RoleMaster.String())
+	require.Equal(t, "replica", RoleReplica.String())
 }

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -30,7 +30,7 @@ func examplePool(roles []bool,
 	if err != nil {
 		return nil, fmt.Errorf("Pool is not established")
 	}
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	if err != nil || connPool == nil {
 		return nil, fmt.Errorf("Pool is not established")
 	}
@@ -62,7 +62,7 @@ func exampleFeaturesPool(roles []bool, connOpts tarantool.Opts,
 	if err != nil {
 		return nil, fmt.Errorf("Pool is not established")
 	}
-	connPool, err := pool.Connect(ctx, poolInstances)
+	connPool, err := pool.New(ctx, poolInstances)
 	if err != nil || connPool == nil {
 		return nil, fmt.Errorf("Pool is not established")
 	}
@@ -504,7 +504,7 @@ func ExampleConnect_invalidOpts() {
 		},
 	}
 
-	connPool, err := pool.ConnectWithOpts(ctx, instances, pool.Opts{
+	connPool, err := pool.NewWithOpts(ctx, instances, pool.Opts{
 		CheckTimeout: time.Second,
 	})
 	if err != nil {

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -78,11 +78,11 @@ func ExamplePool_Do() {
 	defer func() { _ = connPool.Close() }()
 
 	modes := []pool.Mode{
-		pool.ANY,
-		pool.RW,
-		pool.RO,
-		pool.PreferRW,
-		pool.PreferRO,
+		pool.ModeAny,
+		pool.ModeRW,
+		pool.ModeRO,
+		pool.ModePreferRW,
+		pool.ModePreferRO,
 	}
 	for _, m := range modes {
 		// It could be any request object.
@@ -105,7 +105,7 @@ func ExamplePool_NewPrepared() {
 	}
 	defer func() { _ = connPool.Close() }()
 
-	stmt, err := connPool.NewPrepared("SELECT 1", pool.ANY)
+	stmt, err := connPool.NewPrepared("SELECT 1", pool.ModeAny)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -113,11 +113,11 @@ func ExamplePool_NewPrepared() {
 	executeReq := tarantool.NewExecutePreparedRequest(stmt)
 	unprepareReq := tarantool.NewUnprepareRequest(stmt)
 
-	_, err = connPool.Do(executeReq, pool.ANY).Get()
+	_, err = connPool.Do(executeReq, pool.ModeAny).Get()
 	if err != nil {
 		fmt.Printf("Failed to execute prepared stmt")
 	}
-	_, err = connPool.Do(unprepareReq, pool.ANY).Get()
+	_, err = connPool.Do(unprepareReq, pool.ModeAny).Get()
 	if err != nil {
 		fmt.Printf("Failed to prepare")
 	}
@@ -138,7 +138,7 @@ func ExamplePool_NewWatcher() {
 		fmt.Printf("event key: %s\n", event.Key)
 		fmt.Printf("event value: %v\n", event.Value)
 	}
-	mode := pool.ANY
+	mode := pool.ModeAny
 	watcher, err := connPool.NewWatcher(key, callback, mode)
 	if err != nil {
 		fmt.Printf("Unexpected error: %s\n", err)
@@ -179,7 +179,7 @@ func ExampleCommitRequest() {
 	defer func() { _ = connPool.Close() }()
 
 	// example pool has only one rw instance
-	stream, err := connPool.NewStream(pool.RW)
+	stream, err := connPool.NewStream(pool.ModeRW)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -212,7 +212,7 @@ func ExampleCommitRequest() {
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key([]interface{}{"example_commit_key"})
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -238,7 +238,7 @@ func ExampleCommitRequest() {
 
 	// Select outside of transaction
 	// example pool has only one rw instance
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -264,7 +264,7 @@ func ExampleRollbackRequest() {
 	}
 	defer func() { _ = connPool.Close() }()
 
-	stream, err := connPool.NewStream(pool.RW)
+	stream, err := connPool.NewStream(pool.ModeRW)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -297,7 +297,7 @@ func ExampleRollbackRequest() {
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key([]interface{}{"example_rollback_key"})
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -323,7 +323,7 @@ func ExampleRollbackRequest() {
 
 	// Select outside of transaction
 	// example pool has only one rw instance
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -349,7 +349,7 @@ func ExampleBeginRequest_TxnIsolation() {
 	}
 	defer func() { _ = connPool.Close() }()
 
-	stream, err := connPool.NewStream(pool.RW)
+	stream, err := connPool.NewStream(pool.ModeRW)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -384,7 +384,7 @@ func ExampleBeginRequest_TxnIsolation() {
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key([]interface{}{"isolation_level_key"})
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -410,7 +410,7 @@ func ExampleBeginRequest_TxnIsolation() {
 
 	// Select outside of transaction
 	// example pool has only one rw instance
-	data, err = connPool.Do(selectReq, pool.RW).Get()
+	data, err = connPool.Do(selectReq, pool.ModeRW).Get()
 	if err != nil {
 		fmt.Printf("Failed to Select: %s", err.Error())
 		return
@@ -425,10 +425,10 @@ func ExampleConnectorAdapter() {
 	}
 	defer func() { _ = connPool.Close() }()
 
-	adapter := pool.NewConnectorAdapter(connPool, pool.RW)
+	adapter := pool.NewConnectorAdapter(connPool, pool.ModeRW)
 	var connector tarantool.Connector = adapter
 
-	// Ping an RW instance to check connection.
+	// Ping an ModeRW instance to check connection.
 	data, err := connector.Do(tarantool.NewPingRequest()).Get()
 	fmt.Println("Ping Data", data)
 	fmt.Println("Ping Error", err)
@@ -451,7 +451,7 @@ func ExamplePool_CloseGraceful_force() {
 	fiber.sleep(time)
 `
 	req := tarantool.NewEvalRequest(eval).Args([]interface{}{10})
-	fut := connPool.Do(req, pool.ANY)
+	fut := connPool.Do(req, pool.ModeAny)
 
 	done := make(chan struct{})
 	go func() {

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -23,23 +23,23 @@ type Tuple struct {
 var testRoles = []bool{true, true, false, true, true}
 
 func examplePool(roles []bool,
-	connOpts tarantool.Opts) (*pool.ConnectionPool, error) {
+	connOpts tarantool.Opts) (*pool.Pool, error) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	if err != nil {
-		return nil, fmt.Errorf("ConnectionPool is not established")
+		return nil, fmt.Errorf("Pool is not established")
 	}
 	connPool, err := pool.Connect(ctx, instances)
 	if err != nil || connPool == nil {
-		return nil, fmt.Errorf("ConnectionPool is not established")
+		return nil, fmt.Errorf("Pool is not established")
 	}
 
 	return connPool, nil
 }
 
 func exampleFeaturesPool(roles []bool, connOpts tarantool.Opts,
-	requiredProtocol tarantool.ProtocolInfo) (*pool.ConnectionPool, error) {
+	requiredProtocol tarantool.ProtocolInfo) (*pool.Pool, error) {
 	poolInstances := []pool.Instance{}
 	poolDialers := []tarantool.Dialer{}
 	for _, server := range servers {
@@ -60,17 +60,17 @@ func exampleFeaturesPool(roles []bool, connOpts tarantool.Opts,
 	defer cancel()
 	err := test_helpers.SetClusterRO(ctx, poolDialers, connOpts, roles)
 	if err != nil {
-		return nil, fmt.Errorf("ConnectionPool is not established")
+		return nil, fmt.Errorf("Pool is not established")
 	}
 	connPool, err := pool.Connect(ctx, poolInstances)
 	if err != nil || connPool == nil {
-		return nil, fmt.Errorf("ConnectionPool is not established")
+		return nil, fmt.Errorf("Pool is not established")
 	}
 
 	return connPool, nil
 }
 
-func ExampleConnectionPool_Do() {
+func ExamplePool_Do() {
 	connPool, err := examplePool(testRoles, connOpts)
 	if err != nil {
 		fmt.Println(err)
@@ -98,7 +98,7 @@ func ExampleConnectionPool_Do() {
 	// Ping Error <nil>
 }
 
-func ExampleConnectionPool_NewPrepared() {
+func ExamplePool_NewPrepared() {
 	connPool, err := examplePool(testRoles, connOpts)
 	if err != nil {
 		fmt.Println(err)
@@ -123,7 +123,7 @@ func ExampleConnectionPool_NewPrepared() {
 	}
 }
 
-func ExampleConnectionPool_NewWatcher() {
+func ExamplePool_NewWatcher() {
 	const key = "foo"
 	const value = "bar"
 
@@ -437,9 +437,9 @@ func ExampleConnectorAdapter() {
 	// Ping Error <nil>
 }
 
-// ExampleConnectionPool_CloseGraceful_force demonstrates how to force close
+// ExamplePool_CloseGraceful_force demonstrates how to force close
 // a connection pool with graceful close in progress after a while.
-func ExampleConnectionPool_CloseGraceful_force() {
+func ExamplePool_CloseGraceful_force() {
 	connPool, err := examplePool(testRoles, connOpts)
 	if err != nil {
 		fmt.Println(err)
@@ -462,13 +462,13 @@ func ExampleConnectionPool_CloseGraceful_force() {
 			fmt.Println(err)
 			return
 		}
-		fmt.Println("ConnectionPool.CloseGraceful() done!")
+		fmt.Println("Pool.CloseGraceful() done!")
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(3 * time.Second):
-		fmt.Println("Force ConnectionPool.Close()!")
+		fmt.Println("Force Pool.Close()!")
 		_ = connPool.Close()
 	}
 	<-done
@@ -476,8 +476,8 @@ func ExampleConnectionPool_CloseGraceful_force() {
 	fmt.Println("Result:")
 	fmt.Println(fut.Get())
 	// Output:
-	// Force ConnectionPool.Close()!
-	// ConnectionPool.CloseGraceful() done!
+	// Force Pool.Close()!
+	// Pool.CloseGraceful() done!
 	// Result:
 	// [] connection closed by client (0x4001)
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -593,8 +593,8 @@ func (p *Pool) Do(req tarantool.Request, userMode Mode) tarantool.Future {
 	return conn.Do(req)
 }
 
-// DoInstance sends the request into a target instance and returns a future.
-func (p *Pool) DoInstance(req tarantool.Request, name string) tarantool.Future {
+// DoOn sends the request into a target instance and returns a future.
+func (p *Pool) DoOn(req tarantool.Request, name string) tarantool.Future {
 	conn := p.anyPool.GetConnection(name)
 	if conn == nil {
 		return tarantool.NewFutureWithErr(nil, ErrNoHealthyInstance)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -181,7 +181,7 @@ func newEndpoint(name string, dialer tarantool.Dialer, opts tarantool.Opts) *end
 		opts:     opts,
 		notify:   make(chan tarantool.ConnEvent, 100),
 		conn:     nil,
-		role:     UnknownRole,
+		role:     RoleUnknown,
 		shutdown: make(chan struct{}),
 		close:    make(chan struct{}),
 		closed:   make(chan struct{}),
@@ -286,15 +286,15 @@ func (p *Pool) ConnectedNow(mode Mode) (bool, error) {
 		return false, nil
 	}
 	switch mode {
-	case ANY:
+	case ModeAny:
 		return !p.anyPool.IsEmpty(), nil
-	case RW:
+	case ModeRW:
 		return !p.rwPool.IsEmpty(), nil
-	case RO:
+	case ModeRO:
 		return !p.roPool.IsEmpty(), nil
-	case PreferRW:
+	case ModePreferRW:
 		fallthrough
-	case PreferRO:
+	case ModePreferRO:
 		return !p.rwPool.IsEmpty() || !p.roPool.IsEmpty(), nil
 	default:
 		return false, ErrNoHealthyInstance
@@ -472,7 +472,7 @@ func (p *Pool) Info() map[string]Info {
 
 		connInfo := Info{
 			ConnectedNow: false,
-			Role:         UnknownRole,
+			Role:         RoleUnknown,
 			Instance: Instance{
 				Name:   name,
 				Dialer: end.dialer,
@@ -546,9 +546,9 @@ func (p *Pool) NewWatcher(key string,
 	watcher.container.add(watcher)
 
 	rr := p.anyPool
-	if mode == RW {
+	if mode == ModeRW {
 		rr = p.rwPool
-	} else if mode == RO {
+	} else if mode == ModeRO {
 		rr = p.roPool
 	}
 
@@ -623,50 +623,50 @@ func (p *Pool) getConnectionRole(conn *tarantool.Connection) (Role, error) {
 	}
 
 	if err != nil {
-		return UnknownRole, err
+		return RoleUnknown, err
 	}
 	if len(data) < 1 {
-		return UnknownRole, ErrIncorrectResponse
+		return RoleUnknown, ErrIncorrectResponse
 	}
 
 	respFields, ok := data[0].(map[interface{}]interface{})
 	if !ok {
-		return UnknownRole, ErrIncorrectResponse
+		return RoleUnknown, ErrIncorrectResponse
 	}
 
 	instanceStatus, ok := respFields["status"]
 	if !ok {
-		return UnknownRole, ErrIncorrectResponse
+		return RoleUnknown, ErrIncorrectResponse
 	}
 	if instanceStatus != "running" {
-		return UnknownRole, ErrIncorrectStatus
+		return RoleUnknown, ErrIncorrectStatus
 	}
 
 	replicaRole, ok := respFields[roFieldName]
 	if !ok {
-		return UnknownRole, ErrIncorrectResponse
+		return RoleUnknown, ErrIncorrectResponse
 	}
 
 	switch replicaRole {
 	case false:
-		return MasterRole, nil
+		return RoleMaster, nil
 	case true:
-		return ReplicaRole, nil
+		return RoleReplica, nil
 	}
 
-	return UnknownRole, nil
+	return RoleUnknown, nil
 }
 
 func (p *Pool) getConnectionFromPool(name string) (*tarantool.Connection, Role) {
 	if conn := p.rwPool.GetConnection(name); conn != nil {
-		return conn, MasterRole
+		return conn, RoleMaster
 	}
 
 	if conn := p.roPool.GetConnection(name); conn != nil {
-		return conn, ReplicaRole
+		return conn, RoleReplica
 	}
 
-	return p.anyPool.GetConnection(name), UnknownRole
+	return p.anyPool.GetConnection(name), RoleUnknown
 }
 
 func (p *Pool) deleteConnection(name string) {
@@ -696,10 +696,10 @@ func (p *Pool) addConnection(name string,
 		err := p.watcherContainer.foreach(func(watcher *poolWatcher) error {
 			var watch bool
 			switch watcher.mode {
-			case RW:
-				watch = role == MasterRole
-			case RO:
-				watch = role == ReplicaRole
+			case ModeRW:
+				watch = role == RoleMaster
+			case ModeRO:
+				watch = role == RoleReplica
 			default:
 				watch = true
 			}
@@ -723,9 +723,9 @@ func (p *Pool) addConnection(name string,
 	p.anyPool.AddConnection(name, conn)
 
 	switch role {
-	case MasterRole:
+	case RoleMaster:
 		p.rwPool.AddConnection(name, conn)
-	case ReplicaRole:
+	case RoleReplica:
 		p.roPool.AddConnection(name, conn)
 	}
 	return nil
@@ -804,7 +804,7 @@ func (p *Pool) updateConnection(e *endpoint) {
 			if !opened {
 				_ = e.conn.Close()
 				e.conn = nil
-				e.role = UnknownRole
+				e.role = RoleUnknown
 				return
 			}
 
@@ -815,7 +815,7 @@ func (p *Pool) updateConnection(e *endpoint) {
 				_ = e.conn.Close()
 				p.handlerDeactivated(e.name, e.conn, role)
 				e.conn = nil
-				e.role = UnknownRole
+				e.role = RoleUnknown
 				return
 			}
 
@@ -825,7 +825,7 @@ func (p *Pool) updateConnection(e *endpoint) {
 				_ = e.conn.Close()
 				p.handlerDeactivated(e.name, e.conn, role)
 				e.conn = nil
-				e.role = UnknownRole
+				e.role = RoleUnknown
 				return
 			}
 			e.role = role
@@ -839,14 +839,14 @@ func (p *Pool) updateConnection(e *endpoint) {
 		_ = e.conn.Close()
 		p.handlerDeactivated(e.name, e.conn, e.role)
 		e.conn = nil
-		e.role = UnknownRole
+		e.role = RoleUnknown
 		return
 	}
 }
 
 func (p *Pool) tryConnect(ctx context.Context, e *endpoint) error {
 	e.conn = nil
-	e.role = UnknownRole
+	e.role = RoleUnknown
 
 	connOpts := e.opts
 	connOpts.Notify = e.notify
@@ -915,7 +915,7 @@ func (p *Pool) reconnect(ctx context.Context, e *endpoint) {
 
 	p.handlerDeactivated(e.name, e.conn, e.role)
 	e.conn = nil
-	e.role = UnknownRole
+	e.role = RoleUnknown
 
 	if err := p.tryConnect(ctx, e); err != nil {
 		log.Printf("tarantool: reconnect to %s failed: %s\n", e.name, err)
@@ -997,7 +997,7 @@ func (p *Pool) controller(ctx context.Context, e *endpoint) {
 							p.poolsMutex.Unlock()
 							p.handlerDeactivated(e.name, e.conn, e.role)
 							e.conn = nil
-							e.role = UnknownRole
+							e.role = RoleUnknown
 						} else {
 							p.poolsMutex.Unlock()
 						}
@@ -1025,28 +1025,28 @@ func (p *Pool) controller(ctx context.Context, e *endpoint) {
 
 func (p *Pool) getNextConnection(mode Mode) (*tarantool.Connection, error) {
 	switch mode {
-	case ANY:
+	case ModeAny:
 		if next := p.anyPool.GetNextConnection(); next != nil {
 			return next, nil
 		}
-	case RW:
+	case ModeRW:
 		if next := p.rwPool.GetNextConnection(); next != nil {
 			return next, nil
 		}
 		return nil, ErrNoRwInstance
-	case RO:
+	case ModeRO:
 		if next := p.roPool.GetNextConnection(); next != nil {
 			return next, nil
 		}
 		return nil, ErrNoRoInstance
-	case PreferRW:
+	case ModePreferRW:
 		if next := p.rwPool.GetNextConnection(); next != nil {
 			return next, nil
 		}
 		if next := p.roPool.GetNextConnection(); next != nil {
 			return next, nil
 		}
-	case PreferRO:
+	case ModePreferRO:
 		if next := p.roPool.GetNextConnection(); next != nil {
 			return next, nil
 		}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -98,7 +98,7 @@ type Instance struct {
 	Opts tarantool.Opts
 }
 
-// Opts provides additional options (configurable via ConnectWithOpts).
+// Opts provides additional options (configurable via NewWithOpts).
 type Opts struct {
 	// Timeout for timer to reopen connections that have been closed by some
 	// events and to relocate connection between subpools if ro/rw role has
@@ -189,9 +189,9 @@ func newEndpoint(name string, dialer tarantool.Dialer, opts tarantool.Opts) *end
 	}
 }
 
-// ConnectWithOpts creates pool for instances with specified instances and
+// NewWithOpts creates pool for instances with specified instances and
 // opts. Instances must have unique names.
-func ConnectWithOpts(ctx context.Context, instances []Instance,
+func NewWithOpts(ctx context.Context, instances []Instance,
 	opts Opts) (*Pool, error) {
 	unique := make(map[string]bool)
 	for _, instance := range instances {
@@ -268,13 +268,13 @@ func ConnectWithOpts(ctx context.Context, instances []Instance,
 	return p, nil
 }
 
-// Connect creates pool for instances with specified instances. Instances must
+// New creates pool for instances with specified instances. Instances must
 // have unique names.
-func Connect(ctx context.Context, instances []Instance) (*Pool, error) {
+func New(ctx context.Context, instances []Instance) (*Pool, error) {
 	opts := Opts{
 		CheckTimeout: 1 * time.Second,
 	}
-	return ConnectWithOpts(ctx, instances, opts)
+	return NewWithOpts(ctx, instances, opts)
 }
 
 // ConnectedNow gets connected status of pool.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -59,9 +59,9 @@ var (
 		"tarantool.Opts.Notify must not be used with ConnectionPool")
 )
 
-// ConnectionHandler provides callbacks for components interested in handling
-// changes of connections in a ConnectionPool.
-type ConnectionHandler interface {
+// Handler provides callbacks for components interested in handling
+// changes of connections in a Pool.
+type Handler interface {
 	// Discovered is called when a connection with a role has been detected
 	// (for the first time or when a role of a connection has been changed),
 	// but is not yet available to send requests. It allows for a client to
@@ -104,31 +104,31 @@ type Opts struct {
 	// events and to relocate connection between subpools if ro/rw role has
 	// been updated.
 	CheckTimeout time.Duration
-	// ConnectionHandler provides an ability to handle connection updates.
-	ConnectionHandler ConnectionHandler
+	// Handler provides an ability to handle connection updates.
+	Handler Handler
 }
 
 /*
-ConnectionInfo structure for information about connection statuses:
+Info structure for information about connection statuses:
 
 - ConnectedNow reports if connection is established at the moment.
 
-- ConnRole reports master/replica role of instance.
+- Role reports master/replica role of instance.
 */
-type ConnectionInfo struct {
+type Info struct {
 	ConnectedNow bool
-	ConnRole     Role
+	Role         Role
 	Instance     Instance
 }
 
-// ConnectionPool is a connection pool for a Tarantool cluster.
+// Pool is a connection pool for a Tarantool cluster.
 //
 // Main features:
 //
 // - Return available connection from pool according to round-robin strategy.
 //
 // - Automatic master discovery by mode parameter.
-type ConnectionPool struct {
+type Pool struct {
 	ends      map[string]*endpoint
 	endsMutex sync.RWMutex
 
@@ -143,7 +143,7 @@ type ConnectionPool struct {
 	watcherContainer watcherContainer
 }
 
-var _ Pooler = (*ConnectionPool)(nil)
+var _ Pooler = (*Pool)(nil)
 
 type endpoint struct {
 	name   string
@@ -192,7 +192,7 @@ func newEndpoint(name string, dialer tarantool.Dialer, opts tarantool.Opts) *end
 // ConnectWithOpts creates pool for instances with specified instances and
 // opts. Instances must have unique names.
 func ConnectWithOpts(ctx context.Context, instances []Instance,
-	opts Opts) (*ConnectionPool, error) {
+	opts Opts) (*Pool, error) {
 	unique := make(map[string]bool)
 	for _, instance := range instances {
 		if _, ok := unique[instance.Name]; ok {
@@ -218,7 +218,7 @@ func ConnectWithOpts(ctx context.Context, instances []Instance,
 	roPool := newRoundRobinStrategy(size)
 	anyPool := newRoundRobinStrategy(size)
 
-	p := &ConnectionPool{
+	p := &Pool{
 		ends:    make(map[string]*endpoint),
 		opts:    opts,
 		state:   connectedState,
@@ -270,7 +270,7 @@ func ConnectWithOpts(ctx context.Context, instances []Instance,
 
 // Connect creates pool for instances with specified instances. Instances must
 // have unique names.
-func Connect(ctx context.Context, instances []Instance) (*ConnectionPool, error) {
+func Connect(ctx context.Context, instances []Instance) (*Pool, error) {
 	opts := Opts{
 		CheckTimeout: 1 * time.Second,
 	}
@@ -278,7 +278,7 @@ func Connect(ctx context.Context, instances []Instance) (*ConnectionPool, error)
 }
 
 // ConnectedNow gets connected status of pool.
-func (p *ConnectionPool) ConnectedNow(mode Mode) (bool, error) {
+func (p *Pool) ConnectedNow(mode Mode) (bool, error) {
 	p.poolsMutex.RLock()
 	defer p.poolsMutex.RUnlock()
 
@@ -302,7 +302,7 @@ func (p *ConnectionPool) ConnectedNow(mode Mode) (bool, error) {
 }
 
 // ConfiguredTimeout gets timeout of current connection.
-func (p *ConnectionPool) ConfiguredTimeout(mode Mode) (time.Duration, error) {
+func (p *Pool) ConfiguredTimeout(mode Mode) (time.Duration, error) {
 	conn, err := p.getNextConnection(mode)
 	if err != nil {
 		return 0, err
@@ -317,7 +317,7 @@ func (p *ConnectionPool) ConfiguredTimeout(mode Mode) (time.Duration, error) {
 // The function may return an error and don't add the instance into the pool
 // if the context has been cancelled or on concurrent Close()/CloseGraceful()
 // call.
-func (p *ConnectionPool) Add(ctx context.Context, instance Instance) error {
+func (p *Pool) Add(ctx context.Context, instance Instance) error {
 	if err := errors.Join(validateInstanceOpts(instance.Opts)...); err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func (p *ConnectionPool) Add(ctx context.Context, instance Instance) error {
 
 // Remove removes an endpoint with the name from the pool. The call
 // closes an active connection gracefully.
-func (p *ConnectionPool) Remove(name string) error {
+func (p *Pool) Remove(name string) error {
 	p.endsMutex.Lock()
 	endpoint, ok := p.ends[name]
 	if !ok {
@@ -405,7 +405,7 @@ func (p *ConnectionPool) Remove(name string) error {
 	return nil
 }
 
-func (p *ConnectionPool) waitClose() error {
+func (p *Pool) waitClose() error {
 	p.endsMutex.RLock()
 	endpoints := make([]*endpoint, 0, len(p.ends))
 	for _, e := range p.ends {
@@ -424,8 +424,8 @@ func (p *ConnectionPool) waitClose() error {
 	return errors.Join(errs...)
 }
 
-// Close closes connections in the ConnectionPool.
-func (p *ConnectionPool) Close() error {
+// Close closes connections in the Pool.
+func (p *Pool) Close() error {
 	if p.state.cas(connectedState, closedState) ||
 		p.state.cas(shutdownState, closedState) {
 		p.endsMutex.RLock()
@@ -439,9 +439,9 @@ func (p *ConnectionPool) Close() error {
 	return p.waitClose()
 }
 
-// CloseGraceful closes connections in the ConnectionPool gracefully. It waits
+// CloseGraceful closes connections in the Pool gracefully. It waits
 // for all requests to complete.
-func (p *ConnectionPool) CloseGraceful() error {
+func (p *Pool) CloseGraceful() error {
 	if p.state.cas(connectedState, shutdownState) {
 		p.endsMutex.RLock()
 		for _, s := range p.ends {
@@ -455,8 +455,8 @@ func (p *ConnectionPool) CloseGraceful() error {
 }
 
 // GetInfo gets information of connections (connected status, ro/rw role).
-func (p *ConnectionPool) GetInfo() map[string]ConnectionInfo {
-	info := make(map[string]ConnectionInfo)
+func (p *Pool) GetInfo() map[string]Info {
+	info := make(map[string]Info)
 
 	p.endsMutex.RLock()
 	defer p.endsMutex.RUnlock()
@@ -470,9 +470,9 @@ func (p *ConnectionPool) GetInfo() map[string]ConnectionInfo {
 	for name, end := range p.ends {
 		conn, role := p.getConnectionFromPool(name)
 
-		connInfo := ConnectionInfo{
+		connInfo := Info{
 			ConnectedNow: false,
-			ConnRole:     UnknownRole,
+			Role:         UnknownRole,
 			Instance: Instance{
 				Name:   name,
 				Dialer: end.dialer,
@@ -481,7 +481,7 @@ func (p *ConnectionPool) GetInfo() map[string]ConnectionInfo {
 		}
 
 		if conn != nil {
-			connInfo.ConnRole = role
+			connInfo.Role = role
 			connInfo.ConnectedNow = conn.ConnectedNow()
 		}
 
@@ -498,7 +498,7 @@ func (p *ConnectionPool) GetInfo() map[string]ConnectionInfo {
 // To use interactive transactions, memtx_use_mvcc_engine box option should be set to true.
 //
 // Since 1.7.0.
-func (p *ConnectionPool) NewStream(userMode Mode) (*tarantool.Stream, error) {
+func (p *Pool) NewStream(userMode Mode) (*tarantool.Stream, error) {
 	conn, err := p.getNextConnection(userMode)
 	if err != nil {
 		return nil, err
@@ -507,7 +507,7 @@ func (p *ConnectionPool) NewStream(userMode Mode) (*tarantool.Stream, error) {
 }
 
 // NewPrepared passes a sql statement to Tarantool for preparation synchronously.
-func (p *ConnectionPool) NewPrepared(expr string, userMode Mode) (*tarantool.Prepared, error) {
+func (p *Pool) NewPrepared(expr string, userMode Mode) (*tarantool.Prepared, error) {
 	conn, err := p.getNextConnection(userMode)
 	if err != nil {
 		return nil, err
@@ -532,7 +532,7 @@ func (p *ConnectionPool) NewPrepared(expr string, userMode Mode) (*tarantool.Pre
 // https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_events/#box-watchers
 //
 // Since 1.10.0.
-func (p *ConnectionPool) NewWatcher(key string,
+func (p *Pool) NewWatcher(key string,
 	callback tarantool.WatchCallback, mode Mode) (tarantool.Watcher, error) {
 	watcher := &poolWatcher{
 		container:    &p.watcherContainer,
@@ -569,7 +569,7 @@ func (p *ConnectionPool) NewWatcher(key string,
 // Do sends the request and returns a future.
 // For requests that belong to the only one connection (e.g. Unprepare or ExecutePrepared)
 // the argument of type Mode is unused.
-func (p *ConnectionPool) Do(req tarantool.Request, userMode Mode) tarantool.Future {
+func (p *Pool) Do(req tarantool.Request, userMode Mode) tarantool.Future {
 	if connectedReq, ok := req.(tarantool.ConnectedRequest); ok {
 		conns := p.anyPool.GetConnections()
 		isOurConnection := false
@@ -594,7 +594,7 @@ func (p *ConnectionPool) Do(req tarantool.Request, userMode Mode) tarantool.Futu
 }
 
 // DoInstance sends the request into a target instance and returns a future.
-func (p *ConnectionPool) DoInstance(req tarantool.Request, name string) tarantool.Future {
+func (p *Pool) DoInstance(req tarantool.Request, name string) tarantool.Future {
 	conn := p.anyPool.GetConnection(name)
 	if conn == nil {
 		return tarantool.NewFutureWithErr(nil, ErrNoHealthyInstance)
@@ -607,7 +607,7 @@ func (p *ConnectionPool) DoInstance(req tarantool.Request, name string) tarantoo
 // private
 //
 
-func (p *ConnectionPool) getConnectionRole(conn *tarantool.Connection) (Role, error) {
+func (p *Pool) getConnectionRole(conn *tarantool.Connection) (Role, error) {
 	var (
 		roFieldName string
 		data        []interface{}
@@ -657,7 +657,7 @@ func (p *ConnectionPool) getConnectionRole(conn *tarantool.Connection) (Role, er
 	return UnknownRole, nil
 }
 
-func (p *ConnectionPool) getConnectionFromPool(name string) (*tarantool.Connection, Role) {
+func (p *Pool) getConnectionFromPool(name string) (*tarantool.Connection, Role) {
 	if conn := p.rwPool.GetConnection(name); conn != nil {
 		return conn, MasterRole
 	}
@@ -669,7 +669,7 @@ func (p *ConnectionPool) getConnectionFromPool(name string) (*tarantool.Connecti
 	return p.anyPool.GetConnection(name), UnknownRole
 }
 
-func (p *ConnectionPool) deleteConnection(name string) {
+func (p *Pool) deleteConnection(name string) {
 	if conn := p.anyPool.DeleteConnection(name); conn != nil {
 		if conn := p.rwPool.DeleteConnection(name); conn == nil {
 			p.roPool.DeleteConnection(name)
@@ -685,7 +685,7 @@ func (p *ConnectionPool) deleteConnection(name string) {
 	}
 }
 
-func (p *ConnectionPool) addConnection(name string,
+func (p *Pool) addConnection(name string,
 	conn *tarantool.Connection, role Role) error {
 	// The internal connection initialization.
 	p.watcherContainer.mutex.RLock()
@@ -731,11 +731,11 @@ func (p *ConnectionPool) addConnection(name string,
 	return nil
 }
 
-func (p *ConnectionPool) handlerDiscovered(name string, conn *tarantool.Connection,
+func (p *Pool) handlerDiscovered(name string, conn *tarantool.Connection,
 	role Role) bool {
 	var err error
-	if p.opts.ConnectionHandler != nil {
-		err = p.opts.ConnectionHandler.Discovered(name, conn, role)
+	if p.opts.Handler != nil {
+		err = p.opts.Handler.Discovered(name, conn, role)
 	}
 
 	if err != nil {
@@ -745,11 +745,11 @@ func (p *ConnectionPool) handlerDiscovered(name string, conn *tarantool.Connecti
 	return true
 }
 
-func (p *ConnectionPool) handlerDeactivated(name string, conn *tarantool.Connection,
+func (p *Pool) handlerDeactivated(name string, conn *tarantool.Connection,
 	role Role) {
 	var err error
-	if p.opts.ConnectionHandler != nil {
-		err = p.opts.ConnectionHandler.Deactivated(name, conn, role)
+	if p.opts.Handler != nil {
+		err = p.opts.Handler.Deactivated(name, conn, role)
 	}
 
 	if err != nil {
@@ -758,7 +758,7 @@ func (p *ConnectionPool) handlerDeactivated(name string, conn *tarantool.Connect
 	}
 }
 
-func (p *ConnectionPool) fillPools(ctx context.Context, instances []Instance) <-chan error {
+func (p *Pool) fillPools(ctx context.Context, instances []Instance) <-chan error {
 	done := make(chan error, len(instances))
 
 	// It is called before controller() goroutines, so we don't expect
@@ -786,7 +786,7 @@ func (p *ConnectionPool) fillPools(ctx context.Context, instances []Instance) <-
 	return done
 }
 
-func (p *ConnectionPool) updateConnection(e *endpoint) {
+func (p *Pool) updateConnection(e *endpoint) {
 	p.poolsMutex.Lock()
 
 	if p.state.get() != connectedState {
@@ -844,7 +844,7 @@ func (p *ConnectionPool) updateConnection(e *endpoint) {
 	}
 }
 
-func (p *ConnectionPool) tryConnect(ctx context.Context, e *endpoint) error {
+func (p *Pool) tryConnect(ctx context.Context, e *endpoint) error {
 	e.conn = nil
 	e.role = UnknownRole
 
@@ -902,7 +902,7 @@ func (p *ConnectionPool) tryConnect(ctx context.Context, e *endpoint) error {
 	return err
 }
 
-func (p *ConnectionPool) reconnect(ctx context.Context, e *endpoint) {
+func (p *Pool) reconnect(ctx context.Context, e *endpoint) {
 	p.poolsMutex.Lock()
 
 	if p.state.get() != connectedState {
@@ -922,7 +922,7 @@ func (p *ConnectionPool) reconnect(ctx context.Context, e *endpoint) {
 	}
 }
 
-func (p *ConnectionPool) controller(ctx context.Context, e *endpoint) {
+func (p *Pool) controller(ctx context.Context, e *endpoint) {
 	timer := time.NewTicker(p.opts.CheckTimeout)
 	defer timer.Stop()
 
@@ -1023,7 +1023,7 @@ func (p *ConnectionPool) controller(ctx context.Context, e *endpoint) {
 	}
 }
 
-func (p *ConnectionPool) getNextConnection(mode Mode) (*tarantool.Connection, error) {
+func (p *Pool) getNextConnection(mode Mode) (*tarantool.Connection, error) {
 	switch mode {
 	case ANY:
 		if next := p.anyPool.GetNextConnection(); next != nil {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -454,8 +454,8 @@ func (p *Pool) CloseGraceful() error {
 	return p.waitClose()
 }
 
-// GetInfo gets information of connections (connected status, ro/rw role).
-func (p *Pool) GetInfo() map[string]Info {
+// Info gets information of connections (connected status, ro/rw role).
+func (p *Pool) Info() map[string]Info {
 	info := make(map[string]Info)
 
 	p.endsMutex.RLock()

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -343,7 +343,7 @@ func TestConnSuccessfully(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: true,
@@ -372,7 +372,7 @@ func TestConn_no_execute_supported(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: true,
@@ -411,7 +411,7 @@ func TestConn_no_execute_unsupported(t *testing.T) {
 			"'box.info' is denied for user '%s'", servers[0], userNoExec))
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: false,
@@ -467,11 +467,11 @@ func TestConnect_unavailable(t *testing.T) {
 
 	require.NoError(t, err, "failed to create a pool")
 	require.NotNilf(t, connPool, "pool is nil after Connect")
-	require.Equal(t, map[string]pool.ConnectionInfo{
-		servers[0]: pool.ConnectionInfo{
-			ConnectedNow: false, ConnRole: pool.UnknownRole, Instance: insts[0]},
-		servers[1]: pool.ConnectionInfo{
-			ConnectedNow: false, ConnRole: pool.UnknownRole, Instance: insts[1]},
+	require.Equal(t, map[string]pool.Info{
+		servers[0]: pool.Info{
+			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+		servers[1]: pool.Info{
+			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
 	}, connPool.GetInfo())
 }
 
@@ -512,11 +512,11 @@ func TestConnect_server_hang(t *testing.T) {
 
 	require.NoError(t, err, "failed to create a pool")
 	require.NotNil(t, connPool, "pool is nil after Connect")
-	require.Equal(t, map[string]pool.ConnectionInfo{
-		servers[0]: pool.ConnectionInfo{
-			ConnectedNow: false, ConnRole: pool.UnknownRole, Instance: insts[0]},
-		servers[1]: pool.ConnectionInfo{
-			ConnectedNow: true, ConnRole: pool.MasterRole, Instance: insts[1]},
+	require.Equal(t, map[string]pool.Info{
+		servers[0]: pool.Info{
+			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+		servers[1]: pool.Info{
+			ConnectedNow: true, Role: pool.MasterRole, Instance: insts[1]},
 	}, connPool.GetInfo())
 }
 
@@ -527,14 +527,14 @@ func TestConnErrorAfterCtxCancel(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	var connPool *pool.ConnectionPool
+	var connPool *pool.Pool
 	var err error
 
 	cancel()
 	connPool, err = pool.Connect(ctx, makeInstances(servers, longTimeoutOpts))
 
-	require.Nil(t, connPool, "ConnectionPool was created after cancel")
-	require.Error(t, err, "ConnectionPool was created after cancel")
+	require.Nil(t, connPool, "Pool was created after cancel")
+	require.Error(t, err, "Pool was created after cancel")
 	require.Contains(t, err.Error(), "context canceled",
 		"Unexpected error, expected to contain %s", "operation was canceled")
 }
@@ -610,7 +610,7 @@ func TestConnSuccessfullyDuplicates(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{"c0", "c1", "c2", "c3"},
 		ExpectedPoolStatus: true,
@@ -640,7 +640,7 @@ func TestReconnect(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(helpInstances[0])
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server},
 		ExpectedPoolStatus: true,
@@ -658,7 +658,7 @@ func TestReconnect(t *testing.T) {
 	require.NoErrorf(t, err, "failed to restart tarantool")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server},
 		ExpectedPoolStatus: true,
@@ -688,7 +688,7 @@ func TestDisconnect_withReconnect(t *testing.T) {
 	// Test.
 	test_helpers.StopTarantoolWithCleanup(helpInstances[serverId])
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{servers[serverId]},
 		ExpectedPoolStatus: false,
@@ -707,7 +707,7 @@ func TestDisconnect_withReconnect(t *testing.T) {
 	require.NoErrorf(t, err, "failed to restart tarantool")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{servers[serverId]},
 		ExpectedPoolStatus: true,
@@ -738,7 +738,7 @@ func TestDisconnectAll(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(helpInstances[1])
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
@@ -760,7 +760,7 @@ func TestDisconnectAll(t *testing.T) {
 	require.NoErrorf(t, err, "failed to restart tarantool")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
@@ -794,7 +794,7 @@ func TestAdd(t *testing.T) {
 	}
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -919,7 +919,7 @@ func TestAdd_exist(t *testing.T) {
 	require.Equal(t, pool.ErrExists, err)
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -957,7 +957,7 @@ func TestAdd_unreachable(t *testing.T) {
 	require.NoError(t, err)
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1065,7 +1065,7 @@ func TestRemove(t *testing.T) {
 	}
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1096,7 +1096,7 @@ func TestRemove_double(t *testing.T) {
 	require.ErrorContains(t, err, "endpoint not exist")
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1125,7 +1125,7 @@ func TestRemove_unknown(t *testing.T) {
 	require.ErrorContains(t, err, "endpoint not exist")
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1177,7 +1177,7 @@ func TestRemove_concurrent(t *testing.T) {
 	assert.Equal(t, uint32(concurrency-1), errs)
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1247,7 +1247,7 @@ func TestClose(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
@@ -1263,7 +1263,7 @@ func TestClose(t *testing.T) {
 	_ = connPool.Close()
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
@@ -1291,7 +1291,7 @@ func TestCloseGraceful(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
@@ -1328,7 +1328,7 @@ func TestCloseGraceful(t *testing.T) {
 	require.NoErrorf(t, err, "sleep request no error")
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
@@ -1416,7 +1416,7 @@ func (h *testHandler) Deactivated(name string, conn *tarantool.Connection,
 	return nil
 }
 
-func TestConnectionHandlerOpenUpdateClose(t *testing.T) {
+func TestHandlerOpenUpdateClose(t *testing.T) {
 	poolServers := []string{servers[0], servers[1]}
 	poolInstances := makeInstances(poolServers, connOpts)
 	roles := []bool{false, true}
@@ -1429,8 +1429,8 @@ func TestConnectionHandlerOpenUpdateClose(t *testing.T) {
 
 	h := &testHandler{}
 	poolOpts := pool.Opts{
-		CheckTimeout:      100 * time.Millisecond,
-		ConnectionHandler: h,
+		CheckTimeout: 100 * time.Millisecond,
+		Handler:      h,
 	}
 	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
@@ -1498,13 +1498,13 @@ func (h *testAddErrorHandler) Deactivated(name string, conn *tarantool.Connectio
 	return nil
 }
 
-func TestConnectionHandlerOpenError(t *testing.T) {
+func TestHandlerOpenError(t *testing.T) {
 	poolServers := []string{servers[0], servers[1]}
 
 	h := &testAddErrorHandler{}
 	poolOpts := pool.Opts{
-		CheckTimeout:      100 * time.Microsecond,
-		ConnectionHandler: h,
+		CheckTimeout: 100 * time.Microsecond,
+		Handler:      h,
 	}
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
@@ -1516,11 +1516,11 @@ func TestConnectionHandlerOpenError(t *testing.T) {
 	}
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "pool expected")
-	require.Equal(t, map[string]pool.ConnectionInfo{
-		servers[0]: pool.ConnectionInfo{
-			ConnectedNow: false, ConnRole: pool.UnknownRole, Instance: insts[0]},
-		servers[1]: pool.ConnectionInfo{
-			ConnectedNow: false, ConnRole: pool.UnknownRole, Instance: insts[1]},
+	require.Equal(t, map[string]pool.Info{
+		servers[0]: pool.Info{
+			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+		servers[1]: pool.Info{
+			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
 	}, connPool.GetInfo())
 	_ = connPool.Close()
 
@@ -1551,7 +1551,7 @@ func (h *testUpdateErrorHandler) Deactivated(name string, conn *tarantool.Connec
 	return nil
 }
 
-func TestConnectionHandlerUpdateError(t *testing.T) {
+func TestHandlerUpdateError(t *testing.T) {
 	poolServers := []string{servers[0], servers[1]}
 	poolInstances := makeInstances(poolServers, connOpts)
 	roles := []bool{false, false}
@@ -1564,8 +1564,8 @@ func TestConnectionHandlerUpdateError(t *testing.T) {
 
 	h := &testUpdateErrorHandler{}
 	poolOpts := pool.Opts{
-		CheckTimeout:      100 * time.Microsecond,
-		ConnectionHandler: h,
+		CheckTimeout: 100 * time.Microsecond,
+		Handler:      h,
 	}
 	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
@@ -1624,7 +1624,7 @@ func (h *testDeactivatedErrorHandler) Deactivated(name string, conn *tarantool.C
 	return nil
 }
 
-func TestConnectionHandlerDeactivated_on_remove(t *testing.T) {
+func TestHandlerDeactivated_on_remove(t *testing.T) {
 	poolServers := []string{servers[0], servers[1]}
 	poolInstances := makeInstances(poolServers, connOpts)
 	roles := []bool{false, false}
@@ -1637,8 +1637,8 @@ func TestConnectionHandlerDeactivated_on_remove(t *testing.T) {
 
 	h := &testDeactivatedErrorHandler{}
 	poolOpts := pool.Opts{
-		CheckTimeout:      100 * time.Millisecond,
-		ConnectionHandler: h,
+		CheckTimeout: 100 * time.Millisecond,
+		Handler:      h,
 	}
 	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
@@ -1646,7 +1646,7 @@ func TestConnectionHandlerDeactivated_on_remove(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
@@ -1664,7 +1664,7 @@ func TestConnectionHandlerDeactivated_on_remove(t *testing.T) {
 	}
 
 	args = test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            servers,
 		ExpectedPoolStatus: false,
@@ -1693,7 +1693,7 @@ func TestRequestOnClosed(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(helpInstances[1])
 
 	args := test_helpers.CheckStatusesArgs{
-		ConnPool:           connPool,
+		Pool:               connPool,
 		Mode:               pool.ANY,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
@@ -1952,7 +1952,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.ANY,
 	}
 
@@ -1963,7 +1963,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RW,
 	}
 
@@ -1974,7 +1974,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RO,
 	}
 
@@ -1985,7 +1985,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRW,
 	}
 
@@ -1996,7 +1996,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRO,
 	}
 
@@ -2040,7 +2040,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.ANY,
 	}
 
@@ -2051,7 +2051,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RW,
 	}
 
@@ -2062,7 +2062,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRW,
 	}
 
@@ -2073,7 +2073,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRO,
 	}
 
@@ -2117,7 +2117,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.ANY,
 	}
 
@@ -2128,7 +2128,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RO,
 	}
 
@@ -2139,7 +2139,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRW,
 	}
 
@@ -2150,7 +2150,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRO,
 	}
 
@@ -2198,7 +2198,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.ANY,
 	}
 
@@ -2209,7 +2209,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RW,
 	}
 
@@ -2220,7 +2220,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RO,
 	}
 
@@ -2231,7 +2231,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRW,
 	}
 
@@ -2242,7 +2242,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRO,
 	}
 
@@ -2271,7 +2271,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.ANY,
 	}
 
@@ -2285,7 +2285,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RW,
 	}
 
@@ -2299,7 +2299,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.RO,
 	}
 
@@ -2313,7 +2313,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRW,
 	}
 
@@ -2327,7 +2327,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
-		ConnPool:      connPool,
+		Pool:          connPool,
 		Mode:          pool.PreferRO,
 	}
 
@@ -3446,10 +3446,10 @@ func TestStream_TxnIsolationLevel(t *testing.T) {
 	}
 }
 
-func TestConnectionPool_NewWatcher_no_watchers(t *testing.T) {
+func TestPool_NewWatcher_no_watchers(t *testing.T) {
 	test_helpers.SkipIfWatchersSupported(t)
 
-	const key = "TestConnectionPool_NewWatcher_no_watchers"
+	const key = "TestPool_NewWatcher_no_watchers"
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
@@ -3471,10 +3471,10 @@ func TestConnectionPool_NewWatcher_no_watchers(t *testing.T) {
 	}
 }
 
-func TestConnectionPool_NewWatcher_modes(t *testing.T) {
+func TestPool_NewWatcher_modes(t *testing.T) {
 	test_helpers.SkipIfWatchersUnsupported(t)
 
-	const key = "TestConnectionPool_NewWatcher_modes"
+	const key = "TestPool_NewWatcher_modes"
 
 	roles := []bool{true, false, false, true, true}
 
@@ -3546,10 +3546,10 @@ func TestConnectionPool_NewWatcher_modes(t *testing.T) {
 	}
 }
 
-func TestConnectionPool_NewWatcher_update(t *testing.T) {
+func TestPool_NewWatcher_update(t *testing.T) {
 	test_helpers.SkipIfWatchersUnsupported(t)
 
-	const key = "TestConnectionPool_NewWatcher_update"
+	const key = "TestPool_NewWatcher_update"
 	const mode = pool.RW
 	const initCnt = 2
 	roles := []bool{true, false, false, true, true}
@@ -3690,11 +3690,11 @@ func TestWatcher_Unregister(t *testing.T) {
 	}
 }
 
-func TestConnectionPool_NewWatcher_concurrent(t *testing.T) {
+func TestPool_NewWatcher_concurrent(t *testing.T) {
 	test_helpers.SkipIfWatchersUnsupported(t)
 
 	const testConcurrency = 1000
-	const key = "TestConnectionPool_NewWatcher_concurrent"
+	const key = "TestPool_NewWatcher_concurrent"
 
 	roles := []bool{true, false, false, true, true}
 
@@ -3809,7 +3809,7 @@ func runTestMain(m *testing.M) int {
 	return m.Run()
 }
 
-func TestConnectionPool_GetInfo_equal_instance_info(t *testing.T) {
+func TestPool_GetInfo_equal_instance_info(t *testing.T) {
 	var tCases [][]pool.Instance
 
 	tCases = append(tCases, makeInstances([]string{servers[0], servers[1]}, connOpts))

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -344,7 +344,7 @@ func TestConnSuccessfully(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -373,7 +373,7 @@ func TestConn_no_execute_supported(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -384,7 +384,7 @@ func TestConn_no_execute_supported(t *testing.T) {
 	err = test_helpers.CheckPoolStatuses(args)
 	require.NoError(t, err)
 
-	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ANY).Get()
+	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeAny).Get()
 	require.NoError(t, err)
 }
 
@@ -412,7 +412,7 @@ func TestConn_no_execute_unsupported(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{healthyServ},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -423,7 +423,7 @@ func TestConn_no_execute_unsupported(t *testing.T) {
 	err = test_helpers.CheckPoolStatuses(args)
 	require.NoError(t, err)
 
-	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ANY).Get()
+	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeAny).Get()
 	require.Error(t, err)
 	require.Equal(t, "can't find healthy instance in pool", err.Error())
 }
@@ -469,9 +469,9 @@ func TestNew_unavailable(t *testing.T) {
 	require.NotNilf(t, connPool, "pool is nil after Connect")
 	require.Equal(t, map[string]pool.Info{
 		servers[0]: pool.Info{
-			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+			ConnectedNow: false, Role: pool.RoleUnknown, Instance: insts[0]},
 		servers[1]: pool.Info{
-			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
+			ConnectedNow: false, Role: pool.RoleUnknown, Instance: insts[1]},
 	}, connPool.Info())
 }
 
@@ -514,9 +514,9 @@ func TestNew_server_hang(t *testing.T) {
 	require.NotNil(t, connPool, "pool is nil after Connect")
 	require.Equal(t, map[string]pool.Info{
 		servers[0]: pool.Info{
-			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+			ConnectedNow: false, Role: pool.RoleUnknown, Instance: insts[0]},
 		servers[1]: pool.Info{
-			ConnectedNow: true, Role: pool.MasterRole, Instance: insts[1]},
+			ConnectedNow: true, Role: pool.RoleMaster, Instance: insts[1]},
 	}, connPool.Info())
 }
 
@@ -611,7 +611,7 @@ func TestConnSuccessfullyDuplicates(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{"c0", "c1", "c2", "c3"},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -641,7 +641,7 @@ func TestReconnect(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -659,7 +659,7 @@ func TestReconnect(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -689,7 +689,7 @@ func TestDisconnect_withReconnect(t *testing.T) {
 	test_helpers.StopTarantoolWithCleanup(helpInstances[serverId])
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{servers[serverId]},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -708,7 +708,7 @@ func TestDisconnect_withReconnect(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{servers[serverId]},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -739,7 +739,7 @@ func TestDisconnectAll(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -761,7 +761,7 @@ func TestDisconnectAll(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -795,7 +795,7 @@ func TestAdd(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -920,7 +920,7 @@ func TestAdd_exist(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -958,7 +958,7 @@ func TestAdd_unreachable(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1066,7 +1066,7 @@ func TestRemove(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1097,7 +1097,7 @@ func TestRemove_double(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1126,7 +1126,7 @@ func TestRemove_unknown(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1178,7 +1178,7 @@ func TestRemove_concurrent(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1248,7 +1248,7 @@ func TestClose(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1264,7 +1264,7 @@ func TestClose(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -1292,7 +1292,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1312,7 +1312,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	evalSleep := 3 // In seconds.
 	req := tarantool.NewEvalRequest(eval).Args([]interface{}{evalSleep})
-	fut := connPool.Do(req, pool.ANY)
+	fut := connPool.Do(req, pool.ModeAny)
 	go func() {
 		err := connPool.CloseGraceful()
 		assert.NoError(t, err)
@@ -1320,7 +1320,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	// Check that a request rejected if graceful shutdown in progress.
 	time.Sleep((time.Duration(evalSleep) * time.Second) / 2)
-	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ANY).Get()
+	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeAny).Get()
 	require.ErrorContains(t, err, "can't find healthy instance in pool")
 
 	// Check that a previous request was successful.
@@ -1329,7 +1329,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -1367,17 +1367,17 @@ func (h *testHandler) Discovered(name string, conn *tarantool.Connection,
 	// discovered >= 3 - update a connection after a role update
 	switch name {
 	case servers[0]:
-		if discovered < 3 && role != pool.MasterRole {
+		if discovered < 3 && role != pool.RoleMaster {
 			h.addErr(fmt.Errorf("unexpected init role %d for name %s", role, name))
 		}
-		if discovered >= 3 && role != pool.ReplicaRole {
+		if discovered >= 3 && role != pool.RoleReplica {
 			h.addErr(fmt.Errorf("unexpected updated role %d for name %s", role, name))
 		}
 	case servers[1]:
 		if discovered >= 3 {
 			h.addErr(fmt.Errorf("unexpected discovery for name %s", name))
 		}
-		if role != pool.ReplicaRole {
+		if role != pool.RoleReplica {
 			h.addErr(fmt.Errorf("unexpected role %d for name %s", role, name))
 		}
 	default:
@@ -1398,7 +1398,7 @@ func (h *testHandler) Deactivated(name string, conn *tarantool.Connection,
 
 	if deactivated == 1 && name == servers[0] {
 		// A first close is a role update.
-		if role != pool.MasterRole {
+		if role != pool.RoleMaster {
 			h.addErr(fmt.Errorf("unexpected removed role %d for name %s", role, name))
 		}
 		return nil
@@ -1406,7 +1406,7 @@ func (h *testHandler) Deactivated(name string, conn *tarantool.Connection,
 
 	if name == servers[0] || name == servers[1] {
 		// Close.
-		if role != pool.ReplicaRole {
+		if role != pool.RoleReplica {
 			h.addErr(fmt.Errorf("unexpected removed role %d for name %s", role, name))
 		}
 	} else {
@@ -1440,7 +1440,7 @@ func TestHandlerOpenUpdateClose(t *testing.T) {
 		Args([]interface{}{map[string]bool{
 			"read_only": true,
 		}}),
-		pool.RW).GetResponse()
+		pool.ModeRW).GetResponse()
 	require.NoErrorf(t, err, "failed to make ro")
 
 	for i := 0; i < 100; i++ {
@@ -1470,7 +1470,7 @@ func TestHandlerOpenUpdateClose(t *testing.T) {
 	}
 
 	assert.Empty(t, h.errs, "Unexpected errors")
-	connected, err := connPool.ConnectedNow(pool.ANY)
+	connected, err := connPool.ConnectedNow(pool.ModeAny)
 	require.NoErrorf(t, err, "failed to get connected state")
 	require.Falsef(t, connected, "connection pool still be connected")
 
@@ -1518,9 +1518,9 @@ func TestHandlerOpenError(t *testing.T) {
 	require.NotNil(t, connPool, "pool expected")
 	require.Equal(t, map[string]pool.Info{
 		servers[0]: pool.Info{
-			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
+			ConnectedNow: false, Role: pool.RoleUnknown, Instance: insts[0]},
 		servers[1]: pool.Info{
-			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
+			ConnectedNow: false, Role: pool.RoleUnknown, Instance: insts[1]},
 	}, connPool.Info())
 	_ = connPool.Close()
 
@@ -1572,7 +1572,7 @@ func TestHandlerUpdateError(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
 
-	connected, err := connPool.ConnectedNow(pool.ANY)
+	connected, err := connPool.ConnectedNow(pool.ModeAny)
 	require.NoErrorf(t, err, "failed to get ConnectedNow()")
 	require.Truef(t, connected, "should be connected")
 
@@ -1582,20 +1582,20 @@ func TestHandlerUpdateError(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		// Wait for updates done.
-		connected, err = connPool.ConnectedNow(pool.ANY)
+		connected, err = connPool.ConnectedNow(pool.ModeAny)
 		if !connected || err != nil {
 			break
 		}
 		time.Sleep(poolOpts.CheckTimeout)
 	}
-	connected, err = connPool.ConnectedNow(pool.ANY)
+	connected, err = connPool.ConnectedNow(pool.ModeAny)
 
 	require.NoErrorf(t, err, "failed to get ConnectedNow()")
 	require.Falsef(t, connected, "should not be any active connection")
 
 	_ = connPool.Close()
 
-	connected, err = connPool.ConnectedNow(pool.ANY)
+	connected, err = connPool.ConnectedNow(pool.ModeAny)
 
 	require.NoErrorf(t, err, "failed to get ConnectedNow()")
 	require.Falsef(t, connected, "should be deactivated")
@@ -1647,7 +1647,7 @@ func TestHandlerDeactivated_on_remove(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: true,
 		ExpectedStatuses: map[string]bool{
@@ -1665,7 +1665,7 @@ func TestHandlerDeactivated_on_remove(t *testing.T) {
 
 	args = test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            servers,
 		ExpectedPoolStatus: false,
 	}
@@ -1694,7 +1694,7 @@ func TestRequestOnClosed(t *testing.T) {
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
-		Mode:               pool.ANY,
+		Mode:               pool.ModeAny,
 		Servers:            []string{server1, server2},
 		ExpectedPoolStatus: false,
 		ExpectedStatuses: map[string]bool{
@@ -1708,7 +1708,7 @@ func TestRequestOnClosed(t *testing.T) {
 	}, timeout, tick)
 	require.NoError(t, err)
 
-	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ANY).Get()
+	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeAny).Get()
 	require.Errorf(t, err, "err is nil after Do with PingRequest")
 
 	err = test_helpers.RestartTarantool(helpInstances[0])
@@ -1733,61 +1733,61 @@ func TestDoWithCallRequest(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// PreferRO
+	// ModePreferRO
 	data, err := connPool.Do(
 		tarantool.NewCallRequest("box.info").
 			Args([]interface{}{}),
-		pool.PreferRO).Get()
+		pool.ModePreferRO).Get()
 	require.NoErrorf(t, err, "failed to Do with CallRequest")
 	require.NotNilf(t, data, "response is nil after Do with CallRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with CallRequest")
 
 	val := data[0].(map[interface{}]interface{})["ro"]
 	ro, ok := val.(bool)
-	require.Truef(t, ok, "expected `true` with mode `PreferRO`")
-	require.Truef(t, ro, "expected `true` with mode `PreferRO`")
+	require.Truef(t, ok, "expected `true` with mode `ModePreferRO`")
+	require.Truef(t, ro, "expected `true` with mode `ModePreferRO`")
 
-	// PreferRW
+	// ModePreferRW
 	data, err = connPool.Do(
 		tarantool.NewCallRequest("box.info").
 			Args([]interface{}{}),
-		pool.PreferRW).Get()
+		pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Do with CallRequest")
 	require.NotNilf(t, data, "response is nil after Do with CallRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with CallRequest")
 
 	val = data[0].(map[interface{}]interface{})["ro"]
 	ro, ok = val.(bool)
-	require.Truef(t, ok, "expected `false` with mode `PreferRW`")
-	require.Falsef(t, ro, "expected `false` with mode `PreferRW`")
+	require.Truef(t, ok, "expected `false` with mode `ModePreferRW`")
+	require.Falsef(t, ro, "expected `false` with mode `ModePreferRW`")
 
-	// RO
+	// ModeRO
 	data, err = connPool.Do(
 		tarantool.NewCallRequest("box.info").
 			Args([]interface{}{}),
-		pool.RO).Get()
+		pool.ModeRO).Get()
 	require.NoErrorf(t, err, "failed to Do with CallRequest")
 	require.NotNilf(t, data, "response is nil after Do with CallRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with CallRequest")
 
 	val = data[0].(map[interface{}]interface{})["ro"]
 	ro, ok = val.(bool)
-	require.Truef(t, ok, "expected `true` with mode `RO`")
-	require.Truef(t, ro, "expected `true` with mode `RO`")
+	require.Truef(t, ok, "expected `true` with mode `ModeRO`")
+	require.Truef(t, ro, "expected `true` with mode `ModeRO`")
 
-	// RW
+	// ModeRW
 	data, err = connPool.Do(
 		tarantool.NewCallRequest("box.info").
 			Args([]interface{}{}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with CallRequest")
 	require.NotNilf(t, data, "response is nil after Do with CallRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with CallRequest")
 
 	val = data[0].(map[interface{}]interface{})["ro"]
 	ro, ok = val.(bool)
-	require.Truef(t, ok, "expected `false` with mode `RW`")
-	require.Falsef(t, ro, "expected `false` with mode `RW`")
+	require.Truef(t, ok, "expected `false` with mode `ModeRW`")
+	require.Falsef(t, ro, "expected `false` with mode `ModeRW`")
 }
 
 func TestDoWithEvalRequest(t *testing.T) {
@@ -1805,57 +1805,57 @@ func TestDoWithEvalRequest(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// PreferRO
+	// ModePreferRO
 	data, err := connPool.Do(
 		tarantool.NewEvalRequest("return box.info().ro").
 			Args([]interface{}{}),
-		pool.PreferRO).Get()
+		pool.ModePreferRO).Get()
 	require.NoErrorf(t, err, "failed to Do with EvalRequest")
 	require.NotNilf(t, data, "response is nil after Do with EvalRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with EvalRequest")
 
 	val, ok := data[0].(bool)
-	require.Truef(t, ok, "expected `true` with mode `PreferRO`")
-	require.Truef(t, val, "expected `true` with mode `PreferRO`")
+	require.Truef(t, ok, "expected `true` with mode `ModePreferRO`")
+	require.Truef(t, val, "expected `true` with mode `ModePreferRO`")
 
-	// PreferRW
+	// ModePreferRW
 	data, err = connPool.Do(
 		tarantool.NewEvalRequest("return box.info().ro").
 			Args([]interface{}{}),
-		pool.PreferRW).Get()
+		pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Do with EvalRequest")
 	require.NotNilf(t, data, "response is nil after Do with EvalRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with EvalRequest")
 
 	val, ok = data[0].(bool)
-	require.Truef(t, ok, "expected `false` with mode `PreferRW`")
-	require.Falsef(t, val, "expected `false` with mode `PreferRW`")
+	require.Truef(t, ok, "expected `false` with mode `ModePreferRW`")
+	require.Falsef(t, val, "expected `false` with mode `ModePreferRW`")
 
-	// RO
+	// ModeRO
 	data, err = connPool.Do(
 		tarantool.NewEvalRequest("return box.info().ro").
 			Args([]interface{}{}),
-		pool.RO).Get()
+		pool.ModeRO).Get()
 	require.NoErrorf(t, err, "failed to Do with EvalRequest")
 	require.NotNilf(t, data, "response is nil after Do with EvalRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with EvalRequest")
 
 	val, ok = data[0].(bool)
-	require.Truef(t, ok, "expected `true` with mode `RO`")
-	require.Truef(t, val, "expected `true` with mode `RO`")
+	require.Truef(t, ok, "expected `true` with mode `ModeRO`")
+	require.Truef(t, val, "expected `true` with mode `ModeRO`")
 
-	// RW
+	// ModeRW
 	data, err = connPool.Do(
 		tarantool.NewEvalRequest("return box.info().ro").
 			Args([]interface{}{}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with EvalRequest")
 	require.NotNilf(t, data, "response is nil after Do with EvalRequest")
 	require.GreaterOrEqualf(t, len(data), 1, "response.Data is empty after Do with EvalRequest")
 
 	val, ok = data[0].(bool)
-	require.Truef(t, ok, "expected `false` with mode `RW`")
-	require.Falsef(t, val, "expected `false` with mode `RW`")
+	require.Truef(t, ok, "expected `false` with mode `ModeRW`")
+	require.Falsef(t, val, "expected `false` with mode `ModeRW`")
 }
 
 type Member struct {
@@ -1901,7 +1901,7 @@ func TestDoWithExecuteRequest(t *testing.T) {
 	request := "SELECT NAME0, NAME1 FROM SQL_TEST WHERE NAME0 == 1;"
 	mem := []Member{}
 
-	fut := connPool.Do(tarantool.NewExecuteRequest(request).Args([]interface{}{}), pool.ANY)
+	fut := connPool.Do(tarantool.NewExecuteRequest(request).Args([]interface{}{}), pool.ModeAny)
 	data, err := fut.Get()
 	require.NoErrorf(t, err, "failed to Do with ExecuteRequest")
 	require.NotNilf(t, data, "response is nil after Execute")
@@ -1948,56 +1948,56 @@ func TestRoundRobinStrategy(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// ANY
+	// ModeAny
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.ANY,
+		Mode:          pool.ModeAny,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RW
+	// ModeRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.RW,
+		Mode:          pool.ModeRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RO
+	// ModeRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.RO,
+		Mode:          pool.ModeRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRW
+	// ModePreferRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRW,
+		Mode:          pool.ModePreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRO
+	// ModePreferRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRO,
+		Mode:          pool.ModePreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -2028,53 +2028,53 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// RO
+	// ModeRO
 	_, err = connPool.Do(
 		tarantool.NewEvalRequest("return box.cfg.listen").
 			Args([]interface{}{}),
-		pool.RO).Get()
+		pool.ModeRO).Get()
 	require.Errorf(t, err, "expected to fail after Do with EvalRequest, but error is nil")
 	require.Equal(t, "can't find ro instance in pool", err.Error())
 
-	// ANY
+	// ModeAny
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.ANY,
+		Mode:          pool.ModeAny,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RW
+	// ModeRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.RW,
+		Mode:          pool.ModeRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRW
+	// ModePreferRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRW,
+		Mode:          pool.ModePreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRO
+	// ModePreferRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRO,
+		Mode:          pool.ModePreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -2105,53 +2105,53 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// RW
+	// ModeRW
 	_, err = connPool.Do(
 		tarantool.NewEvalRequest("return box.cfg.listen").
 			Args([]interface{}{}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.Errorf(t, err, "expected to fail after Do with EvalRequest, but error is nil")
 	require.Equal(t, "can't find rw instance in pool", err.Error())
 
-	// ANY
+	// ModeAny
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.ANY,
+		Mode:          pool.ModeAny,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RO
+	// ModeRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.RO,
+		Mode:          pool.ModeRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRW
+	// ModePreferRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRW,
+		Mode:          pool.ModePreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRO
+	// ModePreferRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRO,
+		Mode:          pool.ModePreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -2194,56 +2194,56 @@ func TestUpdateInstancesRoles(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// ANY
+	// ModeAny
 	args := test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.ANY,
+		Mode:          pool.ModeAny,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RW
+	// ModeRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.RW,
+		Mode:          pool.ModeRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// RO
+	// ModeRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.RO,
+		Mode:          pool.ModeRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRW
+	// ModePreferRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRW,
+		Mode:          pool.ModePreferRW,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
 	require.NoError(t, err)
 
-	// PreferRO
+	// ModePreferRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRO,
+		Mode:          pool.ModePreferRO,
 	}
 
 	err = test_helpers.ProcessListenOnInstance(args)
@@ -2267,12 +2267,12 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	cancelSetRoles()
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	// ANY
+	// ModeAny
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: allPorts,
 		Pool:          connPool,
-		Mode:          pool.ANY,
+		Mode:          pool.ModeAny,
 	}
 
 	assert.Eventually(t, func() bool {
@@ -2281,12 +2281,12 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	}, timeout, tick)
 	require.NoError(t, err)
 
-	// RW
+	// ModeRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.RW,
+		Mode:          pool.ModeRW,
 	}
 
 	assert.Eventually(t, func() bool {
@@ -2295,12 +2295,12 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	}, timeout, tick)
 	require.NoError(t, err)
 
-	// RO
+	// ModeRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.RO,
+		Mode:          pool.ModeRO,
 	}
 
 	assert.Eventually(t, func() bool {
@@ -2309,12 +2309,12 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	}, timeout, tick)
 	require.NoError(t, err)
 
-	// PreferRW
+	// ModePreferRW
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: masterPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRW,
+		Mode:          pool.ModePreferRW,
 	}
 
 	assert.Eventually(t, func() bool {
@@ -2323,12 +2323,12 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	}, timeout, tick)
 	require.NoError(t, err)
 
-	// PreferRO
+	// ModePreferRO
 	args = test_helpers.ListenOnInstanceArgs{
 		ServersNumber: serversNumber,
 		ExpectedPorts: replicaPorts,
 		Pool:          connPool,
-		Mode:          pool.PreferRO,
+		Mode:          pool.ModePreferRO,
 	}
 
 	assert.Eventually(t, func() bool {
@@ -2353,10 +2353,10 @@ func TestDoWithInsertRequest(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// RW
+	// ModeRW
 	data, err := connPool.Do(tarantool.NewInsertRequest(spaceName).
 		Tuple([]interface{}{"rw_insert_key", "rw_insert_value"}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Insert")
 	require.NotNilf(t, data, "response is nil after Insert")
 	require.Lenf(t, data, 1, "response Body len != 1 after Insert")
@@ -2374,7 +2374,7 @@ func TestDoWithInsertRequest(t *testing.T) {
 	require.Equalf(t, "rw_insert_value", value, "unexpected body of Insert (1)")
 
 	// Connect to servers[2] to check if tuple
-	// was inserted on RW instance
+	// was inserted on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -2399,9 +2399,9 @@ func TestDoWithInsertRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Select (1)")
 	require.Equalf(t, "rw_insert_value", value, "unexpected body of Select (1)")
 
-	// PreferRW
+	// ModePreferRW
 	data, err = connPool.Do(tarantool.NewInsertRequest(spaceName).Tuple(
-		[]interface{}{"preferRW_insert_key", "preferRW_insert_value"}), pool.PreferRW).Get()
+		[]interface{}{"preferRW_insert_key", "preferRW_insert_value"}), pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Insert")
 	require.NotNilf(t, data, "response is nil after Insert")
 	require.Lenf(t, data, 1, "response Body len != 1 after Insert")
@@ -2456,7 +2456,7 @@ func TestDoWithDeleteRequest(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	// Connect to servers[2] to check if tuple
-	// was inserted on RW instance
+	// was inserted on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -2481,7 +2481,7 @@ func TestDoWithDeleteRequest(t *testing.T) {
 		tarantool.NewDeleteRequest(spaceName).
 			Index(indexNo).
 			Key([]interface{}{"delete_key"}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with DeleteRequest")
 	require.NotNilf(t, data, "response is nil after Do with DeleteRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with DeleteRequest")
@@ -2524,14 +2524,14 @@ func TestDoWithUpsertRequest(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	// Connect to servers[2] to check if tuple
-	// was inserted on RW instance
+	// was inserted on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
-	// RW
+	// ModeRW
 	data, err := connPool.Do(tarantool.NewUpsertRequest(spaceName).Tuple(
 		[]interface{}{"upsert_key", "upsert_value"}).Operations(
-		tarantool.NewOperations().Assign(1, "new_value")), pool.RW).Get()
+		tarantool.NewOperations().Assign(1, "new_value")), pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Upsert")
 	require.NotNilf(t, data, "response is nil after Upsert")
 
@@ -2556,10 +2556,10 @@ func TestDoWithUpsertRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Select (1)")
 	require.Equalf(t, "upsert_value", value, "unexpected body of Select (1)")
 
-	// PreferRW
+	// ModePreferRW
 	data, err = connPool.Do(tarantool.NewUpsertRequest(
 		spaceName).Tuple([]interface{}{"upsert_key", "upsert_value"}).Operations(
-		tarantool.NewOperations().Assign(1, "new_value")), pool.PreferRW).Get()
+		tarantool.NewOperations().Assign(1, "new_value")), pool.ModePreferRW).Get()
 
 	require.NoErrorf(t, err, "failed to Upsert")
 	require.NotNilf(t, data, "response is nil after Upsert")
@@ -2597,7 +2597,7 @@ func TestDoWithUpdateRequest(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	// Connect to servers[2] to check if tuple
-	// was inserted on RW instance
+	// was inserted on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -2619,12 +2619,12 @@ func TestDoWithUpdateRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Insert (1)")
 	require.Equalf(t, "update_value", value, "unexpected body of Insert (1)")
 
-	// RW
+	// ModeRW
 	resp, err := connPool.Do(tarantool.NewUpdateRequest(spaceName).
 		Index(indexNo).
 		Key([]interface{}{"update_key"}).
 		Operations(tarantool.NewOperations().Assign(1, "new_value")),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Update")
 	require.NotNilf(t, resp, "response is nil after Update")
 
@@ -2649,12 +2649,12 @@ func TestDoWithUpdateRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Select (1)")
 	require.Equalf(t, "new_value", value, "unexpected body of Select (1)")
 
-	// PreferRW
+	// ModePreferRW
 	resp, err = connPool.Do(tarantool.NewUpdateRequest(spaceName).
 		Index(indexNo).
 		Key([]interface{}{"update_key"}).
 		Operations(tarantool.NewOperations().Assign(1, "another_value")),
-		pool.PreferRW).Get()
+		pool.ModePreferRW).Get()
 
 	require.NoErrorf(t, err, "failed to Update")
 	require.NotNilf(t, resp, "response is nil after Update")
@@ -2692,7 +2692,7 @@ func TestDoWithReplaceRequest(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	// Connect to servers[2] to check if tuple
-	// was inserted on RW instance
+	// was inserted on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -2714,10 +2714,10 @@ func TestDoWithReplaceRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Insert (1)")
 	require.Equalf(t, "replace_value", value, "unexpected body of Insert (1)")
 
-	// RW
+	// ModeRW
 	resp, err := connPool.Do(tarantool.NewReplaceRequest(spaceNo).
 		Tuple([]interface{}{"new_key", "new_value"}),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with ReplaceRequest")
 	require.NotNilf(t, resp, "response is nil after Do with ReplaceRequest")
 
@@ -2742,10 +2742,10 @@ func TestDoWithReplaceRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Select (1)")
 	require.Equalf(t, "new_value", value, "unexpected body of Select (1)")
 
-	// PreferRW
+	// ModePreferRW
 	resp, err = connPool.Do(tarantool.NewReplaceRequest(spaceNo).
 		Tuple([]interface{}{"new_key", "new_value"}),
-		pool.PreferRW).Get()
+		pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Do with ReplaceRequest")
 	require.NotNilf(t, resp, "response is nil after Do with ReplaceRequest")
 
@@ -2802,14 +2802,14 @@ func TestDoWithSelectRequest(t *testing.T) {
 	err = test_helpers.InsertOnInstances(ctx, makeDialers(allServers), connOpts, spaceNo, anyTpl)
 	require.NoError(t, err)
 
-	// ANY
+	// ModeAny
 	data, err := connPool.Do(tarantool.NewSelectRequest(spaceNo).
 		Index(indexNo).
 		Offset(0).
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key(anyKey),
-		pool.ANY).Get()
+		pool.ModeAny).Get()
 	require.NoErrorf(t, err, "failed to Do with SelectRequest")
 	require.NotNilf(t, data, "response is nil after Do with SelectRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with SelectRequest")
@@ -2826,14 +2826,14 @@ func TestDoWithSelectRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Do with SelectRequest (1)")
 	require.Equalf(t, "any_select_value", value, "unexpected body of Do with SelectRequest (1)")
 
-	// PreferRO
+	// ModePreferRO
 	data, err = connPool.Do(tarantool.NewSelectRequest(spaceNo).
 		Index(indexNo).
 		Offset(0).
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key(roKey),
-		pool.PreferRO).Get()
+		pool.ModePreferRO).Get()
 	require.NoErrorf(t, err, "failed to Do with SelectRequest")
 	require.NotNilf(t, data, "response is nil after Do with SelectRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with SelectRequest")
@@ -2846,14 +2846,14 @@ func TestDoWithSelectRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Do with SelectRequest (0)")
 	require.Equalf(t, "ro_select_key", key, "unexpected body of Do with SelectRequest (0)")
 
-	// PreferRW
+	// ModePreferRW
 	data, err = connPool.Do(tarantool.NewSelectRequest(spaceNo).
 		Index(indexNo).
 		Offset(0).
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key(rwKey),
-		pool.PreferRW).Get()
+		pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Do with SelectRequest")
 	require.NotNilf(t, data, "response is nil after Do with SelectRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with SelectRequest")
@@ -2870,14 +2870,14 @@ func TestDoWithSelectRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Do with SelectRequest (1)")
 	require.Equalf(t, "rw_select_value", value, "unexpected body of Do with SelectRequest (1)")
 
-	// RO
+	// ModeRO
 	data, err = connPool.Do(tarantool.NewSelectRequest(spaceNo).
 		Index(indexNo).
 		Offset(0).
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key(roKey),
-		pool.RO).Get()
+		pool.ModeRO).Get()
 	require.NoErrorf(t, err, "failed to Do with SelectRequest")
 	require.NotNilf(t, data, "response is nil after Do with SelectRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with SelectRequest")
@@ -2894,14 +2894,14 @@ func TestDoWithSelectRequest(t *testing.T) {
 	require.Truef(t, ok, "unexpected body of Do with SelectRequest (1)")
 	require.Equalf(t, "ro_select_value", value, "unexpected body of Do with SelectRequest (1)")
 
-	// RW
+	// ModeRW
 	data, err = connPool.Do(tarantool.NewSelectRequest(spaceNo).
 		Index(indexNo).
 		Offset(0).
 		Limit(1).
 		Iterator(tarantool.IterEq).
 		Key(rwKey),
-		pool.RW).Get()
+		pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with SelectRequest")
 	require.NotNilf(t, data, "response is nil after Do with SelectRequest")
 	require.Lenf(t, data, 1, "response Body len != 1 after Do with SelectRequest")
@@ -2934,27 +2934,27 @@ func TestDoWithPingRequest(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	// ANY
-	data, err := connPool.Do(tarantool.NewPingRequest(), pool.ANY).Get()
+	// ModeAny
+	data, err := connPool.Do(tarantool.NewPingRequest(), pool.ModeAny).Get()
 	require.NoErrorf(t, err, "failed to Do with Ping Request")
 	require.Nilf(t, data, "response data is not nil after Do with Ping Request")
 
-	// RW
-	data, err = connPool.Do(tarantool.NewPingRequest(), pool.RW).Get()
+	// ModeRW
+	data, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Do with Ping Request")
 	require.Nilf(t, data, "response data is not nil after Do with Ping Request")
 
-	// RO
-	_, err = connPool.Do(tarantool.NewPingRequest(), pool.RO).Get()
+	// ModeRO
+	_, err = connPool.Do(tarantool.NewPingRequest(), pool.ModeRO).Get()
 	require.NoErrorf(t, err, "failed to Do with Ping Request")
 
-	// PreferRW
-	data, err = connPool.Do(tarantool.NewPingRequest(), pool.PreferRW).Get()
+	// ModePreferRW
+	data, err = connPool.Do(tarantool.NewPingRequest(), pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Do with Ping Request")
 	require.Nilf(t, data, "response data is not nil after Do with Ping Request")
 
-	// PreferRO
-	data, err = connPool.Do(tarantool.NewPingRequest(), pool.PreferRO).Get()
+	// ModePreferRO
+	data, err = connPool.Do(tarantool.NewPingRequest(), pool.ModePreferRO).Get()
 	require.NoErrorf(t, err, "failed to Do with Ping Request")
 	require.Nilf(t, data, "response data is not nil after Do with Ping Request")
 }
@@ -2975,24 +2975,24 @@ func TestDo(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	req := tarantool.NewPingRequest()
-	// ANY
-	_, err = connPool.Do(req, pool.ANY).Get()
+	// ModeAny
+	_, err = connPool.Do(req, pool.ModeAny).Get()
 	require.NoErrorf(t, err, "failed to Ping")
 
-	// RW
-	_, err = connPool.Do(req, pool.RW).Get()
+	// ModeRW
+	_, err = connPool.Do(req, pool.ModeRW).Get()
 	require.NoErrorf(t, err, "failed to Ping")
 
-	// RO
-	_, err = connPool.Do(req, pool.RO).Get()
+	// ModeRO
+	_, err = connPool.Do(req, pool.ModeRO).Get()
 	require.NoErrorf(t, err, "failed to Ping")
 
-	// PreferRW
-	_, err = connPool.Do(req, pool.PreferRW).Get()
+	// ModePreferRW
+	_, err = connPool.Do(req, pool.ModePreferRW).Get()
 	require.NoErrorf(t, err, "failed to Ping")
 
-	// PreferRO
-	_, err = connPool.Do(req, pool.PreferRO).Get()
+	// ModePreferRO
+	_, err = connPool.Do(req, pool.ModePreferRO).Get()
 	require.NoErrorf(t, err, "failed to Ping")
 }
 
@@ -3020,7 +3020,7 @@ func TestDo_concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			_, err := connPool.Do(req, pool.ANY).Get()
+			_, err := connPool.Do(req, pool.ModeAny).Get()
 			assert.NoError(t, err)
 		}()
 	}
@@ -3116,13 +3116,13 @@ func TestNewPrepared(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	stmt, err := connPool.NewPrepared(
-		"SELECT NAME0, NAME1 FROM SQL_TEST WHERE NAME0=:id AND NAME1=:name;", pool.RO)
+		"SELECT NAME0, NAME1 FROM SQL_TEST WHERE NAME0=:id AND NAME1=:name;", pool.ModeRO)
 	require.NoErrorf(t, err, "fail to prepare statement: %v", err)
 
 	executeReq := tarantool.NewExecutePreparedRequest(stmt)
 	unprepareReq := tarantool.NewUnprepareRequest(stmt)
 
-	resp, err := connPool.Do(executeReq.Args([]interface{}{1, "test"}), pool.ANY).GetResponse()
+	resp, err := connPool.Do(executeReq.Args([]interface{}{1, "test"}), pool.ModeAny).GetResponse()
 	require.NoError(t, err, "failed to execute prepared")
 	require.NotNil(t, resp, "nil response")
 	data, err := resp.Decode()
@@ -3138,14 +3138,14 @@ func TestNewPrepared(t *testing.T) {
 	assert.Equal(t, "NAME1", metaData[1].FieldName)
 
 	// the second argument for unprepare request is unused - it already belongs to some connection
-	_, err = connPool.Do(unprepareReq, pool.ANY).Get()
+	_, err = connPool.Do(unprepareReq, pool.ModeAny).Get()
 	require.NoError(t, err, "failed to unprepare prepared statement")
 
-	_, err = connPool.Do(unprepareReq, pool.ANY).Get()
+	_, err = connPool.Do(unprepareReq, pool.ModeAny).Get()
 	require.Error(t, err, "the statement must be already unprepared")
 	require.Contains(t, err.Error(), "Prepared statement with id")
 
-	_, err = connPool.Do(executeReq, pool.ANY).Get()
+	_, err = connPool.Do(executeReq, pool.ModeAny).Get()
 	require.Error(t, err, "the statement must be already unprepared")
 	require.Contains(t, err.Error(), "Prepared statement with id")
 }
@@ -3170,7 +3170,7 @@ func TestDoWithStrangerConn(t *testing.T) {
 
 	req := test_helpers.NewMockRequest()
 
-	_, err = connPool.Do(req, pool.ANY).Get()
+	_, err = connPool.Do(req, pool.ModeAny).Get()
 	require.Error(t, err, "nil error caught")
 	require.EqualError(t, err, expectedErr.Error(), "Unexpected error caught")
 }
@@ -3194,7 +3194,7 @@ func TestStream_Commit(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
 
-	stream, err := connPool.NewStream(pool.PreferRW)
+	stream, err := connPool.NewStream(pool.ModePreferRW)
 	require.NoErrorf(t, err, "failed to create stream")
 	require.NotNilf(t, connPool, "stream is nil after NewStream")
 
@@ -3210,7 +3210,7 @@ func TestStream_Commit(t *testing.T) {
 	require.NoErrorf(t, err, "failed to Insert")
 
 	// Connect to servers[2] to check if tuple
-	// was inserted outside of stream on RW instance
+	// was inserted outside of stream on ModeRW instance
 	// before transaction commit
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
@@ -3286,7 +3286,7 @@ func TestStream_Rollback(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
 
-	stream, err := connPool.NewStream(pool.PreferRW)
+	stream, err := connPool.NewStream(pool.ModePreferRW)
 	require.NoErrorf(t, err, "failed to create stream")
 	require.NotNilf(t, connPool, "stream is nil after NewStream")
 
@@ -3302,7 +3302,7 @@ func TestStream_Rollback(t *testing.T) {
 	require.NoErrorf(t, err, "failed to Insert")
 
 	// Connect to servers[2] to check if tuple
-	// was not inserted outside of stream on RW instance
+	// was not inserted outside of stream on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -3377,12 +3377,12 @@ func TestStream_TxnIsolationLevel(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
 
-	stream, err := connPool.NewStream(pool.PreferRW)
+	stream, err := connPool.NewStream(pool.ModePreferRW)
 	require.NoErrorf(t, err, "failed to create stream")
 	require.NotNilf(t, connPool, "stream is nil after NewStream")
 
 	// Connect to servers[2] to check if tuple
-	// was not inserted outside of stream on RW instance
+	// was not inserted outside of stream on ModeRW instance
 	conn := test_helpers.ConnectWithValidation(t, makeDialer(servers[2]), connOpts)
 	defer func() { _ = conn.Close() }()
 
@@ -3461,7 +3461,7 @@ func TestPool_NewWatcher_no_watchers(t *testing.T) {
 	ch := make(chan struct{})
 	_, _ = connPool.NewWatcher(key, func(event tarantool.WatchEvent) {
 		close(ch)
-	}, pool.ANY)
+	}, pool.ModeAny)
 
 	select {
 	case <-time.After(time.Second):
@@ -3490,19 +3490,19 @@ func TestPool_NewWatcher_modes(t *testing.T) {
 	defer func() { _ = connPool.Close() }()
 
 	modes := []pool.Mode{
-		pool.ANY,
-		pool.RW,
-		pool.RO,
-		pool.PreferRW,
-		pool.PreferRO,
+		pool.ModeAny,
+		pool.ModeRW,
+		pool.ModeRO,
+		pool.ModePreferRW,
+		pool.ModePreferRO,
 	}
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("%d", mode), func(t *testing.T) {
 			expectedServers := []string{}
 			for i, server := range servers {
-				if roles[i] && mode == pool.RW {
+				if roles[i] && mode == pool.ModeRW {
 					continue
-				} else if !roles[i] && mode == pool.RO {
+				} else if !roles[i] && mode == pool.ModeRO {
 					continue
 				}
 				expectedServers = append(expectedServers, server)
@@ -3550,7 +3550,7 @@ func TestPool_NewWatcher_update(t *testing.T) {
 	test_helpers.SkipIfWatchersUnsupported(t)
 
 	const key = "TestPool_NewWatcher_update"
-	const mode = pool.RW
+	const mode = pool.ModeRW
 	const initCnt = 2
 	roles := []bool{true, false, false, true, true}
 
@@ -3636,7 +3636,7 @@ func TestWatcher_Unregister(t *testing.T) {
 	test_helpers.SkipIfWatchersUnsupported(t)
 
 	const key = "TestWatcher_Unregister"
-	const mode = pool.RW
+	const mode = pool.ModeRW
 	const expectedCnt = 2
 	roles := []bool{true, false, false, true, true}
 
@@ -3712,7 +3712,7 @@ func TestPool_NewWatcher_concurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(testConcurrency)
 
-	mode := pool.ANY
+	mode := pool.ModeAny
 	callback := func(event tarantool.WatchEvent) {}
 	for i := 0; i < testConcurrency; i++ {
 		go func() {
@@ -3746,7 +3746,7 @@ func TestWatcher_Unregister_concurrent(t *testing.T) {
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
 
-	mode := pool.ANY
+	mode := pool.ModeAny
 	watcher, err := connPool.NewWatcher(key, func(event tarantool.WatchEvent) {
 	}, mode)
 	require.NoErrorf(t, err, "failed to create a watcher")

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -102,55 +102,55 @@ const timeout = defaultCountRetry * tick
 
 var helpInstances []*test_helpers.TarantoolInstance
 
-func TestConnect_error_duplicate(t *testing.T) {
+func TestNew_error_duplicate(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{"foo", "foo"}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{"foo", "foo"}, connOpts))
 	cancel()
 
 	assert.Nil(t, connPool)
 	require.EqualError(t, err, "duplicate instance name: \"foo\"")
 }
 
-func TestConnect_error_reconnect(t *testing.T) {
+func TestNew_error_reconnect(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
 	opts := connOpts
 	opts.Reconnect = time.Second
 
-	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+	connPool, err := pool.New(ctx, makeInstances([]string{"any"}, opts))
 
 	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrOptsReconnect)
 }
 
-func TestConnect_error_max_reconnects(t *testing.T) {
+func TestNew_error_max_reconnects(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
 	opts := connOpts
 	opts.MaxReconnects = 3
 
-	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+	connPool, err := pool.New(ctx, makeInstances([]string{"any"}, opts))
 
 	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
 }
 
-func TestConnect_error_notify(t *testing.T) {
+func TestNew_error_notify(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
 	opts := connOpts
 	opts.Notify = make(chan tarantool.ConnEvent)
 
-	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+	connPool, err := pool.New(ctx, makeInstances([]string{"any"}, opts))
 
 	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrOptsNotify)
 }
 
-func TestConnect_error_multiple_opts(t *testing.T) {
+func TestNew_error_multiple_opts(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
@@ -159,7 +159,7 @@ func TestConnect_error_multiple_opts(t *testing.T) {
 	opts.MaxReconnects = 3
 	opts.Notify = make(chan tarantool.ConnEvent)
 
-	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+	connPool, err := pool.New(ctx, makeInstances([]string{"any"}, opts))
 
 	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrOptsReconnect)
@@ -167,7 +167,7 @@ func TestConnect_error_multiple_opts(t *testing.T) {
 	require.ErrorIs(t, err, pool.ErrOptsNotify)
 }
 
-func TestConnect_error_multiple_instances(t *testing.T) {
+func TestNew_error_multiple_instances(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
@@ -180,16 +180,16 @@ func TestConnect_error_multiple_instances(t *testing.T) {
 		makeInstance("bad2", badOpts2),
 	}
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 
 	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrOptsReconnect)
 	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
 }
 
-func TestConnectWithOpts_error_no_timeout(t *testing.T) {
+func TestNewWithOpts_error_no_timeout(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, connOpts),
+	connPool, err := pool.NewWithOpts(ctx, makeInstances([]string{"any"}, connOpts),
 		pool.Opts{})
 	cancel()
 	assert.Nil(t, connPool)
@@ -203,7 +203,7 @@ func TestConnectWithOpts_error_reconnect(t *testing.T) {
 	opts := connOpts
 	opts.Reconnect = time.Second
 
-	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+	connPool, err := pool.NewWithOpts(ctx, makeInstances([]string{"any"}, opts),
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -217,7 +217,7 @@ func TestConnectWithOpts_error_max_reconnects(t *testing.T) {
 	opts := connOpts
 	opts.MaxReconnects = 3
 
-	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+	connPool, err := pool.NewWithOpts(ctx, makeInstances([]string{"any"}, opts),
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -231,7 +231,7 @@ func TestConnectWithOpts_error_notify(t *testing.T) {
 	opts := connOpts
 	opts.Notify = make(chan tarantool.ConnEvent)
 
-	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+	connPool, err := pool.NewWithOpts(ctx, makeInstances([]string{"any"}, opts),
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -249,7 +249,7 @@ func TestConnectWithOpts_error_reconnect_partial(t *testing.T) {
 		makeInstance("bad", badOpts),
 	}
 
-	connPool, err := pool.ConnectWithOpts(ctx, instances,
+	connPool, err := pool.NewWithOpts(ctx, instances,
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -267,7 +267,7 @@ func TestConnectWithOpts_error_max_reconnects_partial(t *testing.T) {
 		makeInstance("bad", badOpts),
 	}
 
-	connPool, err := pool.ConnectWithOpts(ctx, instances,
+	connPool, err := pool.NewWithOpts(ctx, instances,
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -285,7 +285,7 @@ func TestConnectWithOpts_error_notify_partial(t *testing.T) {
 		makeInstance("bad", badOpts),
 	}
 
-	connPool, err := pool.ConnectWithOpts(ctx, instances,
+	connPool, err := pool.NewWithOpts(ctx, instances,
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -301,7 +301,7 @@ func TestConnectWithOpts_error_multiple_opts(t *testing.T) {
 	opts.MaxReconnects = 3
 	opts.Notify = make(chan tarantool.ConnEvent)
 
-	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+	connPool, err := pool.NewWithOpts(ctx, makeInstances([]string{"any"}, opts),
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -323,7 +323,7 @@ func TestConnectWithOpts_error_multiple_instances(t *testing.T) {
 		makeInstance("bad2", badOpts2),
 	}
 
-	connPool, err := pool.ConnectWithOpts(ctx, instances,
+	connPool, err := pool.NewWithOpts(ctx, instances,
 		pool.Opts{CheckTimeout: time.Second})
 
 	assert.Nil(t, connPool)
@@ -336,7 +336,7 @@ func TestConnSuccessfully(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{healthyServ, "err"}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{healthyServ, "err"}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -364,7 +364,7 @@ func TestConn_no_execute_supported(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx,
+	connPool, err := pool.New(ctx,
 		[]pool.Instance{makeNoExecuteInstance(healthyServ, connOpts)})
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -399,7 +399,7 @@ func TestConn_no_execute_unsupported(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx,
+	connPool, err := pool.New(ctx,
 		[]pool.Instance{makeNoExecuteInstance(healthyServ, connOpts)})
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -428,7 +428,7 @@ func TestConn_no_execute_unsupported(t *testing.T) {
 	require.Equal(t, "can't find healthy instance in pool", err.Error())
 }
 
-func TestConnect_empty(t *testing.T) {
+func TestNew_empty(t *testing.T) {
 	cases := []struct {
 		Name      string
 		Instances []pool.Instance
@@ -441,7 +441,7 @@ func TestConnect_empty(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			ctx, cancel := test_helpers.GetPoolConnectContext()
 			defer cancel()
-			connPool, err := pool.Connect(ctx, tc.Instances)
+			connPool, err := pool.New(ctx, tc.Instances)
 			if connPool != nil {
 				defer func() { _ = connPool.Close() }()
 			}
@@ -453,12 +453,12 @@ func TestConnect_empty(t *testing.T) {
 	}
 }
 
-func TestConnect_unavailable(t *testing.T) {
+func TestNew_unavailable(t *testing.T) {
 	servers := []string{"err1", "err2"}
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	insts := makeInstances([]string{"err1", "err2"}, connOpts)
 
-	connPool, err := pool.Connect(ctx, insts)
+	connPool, err := pool.New(ctx, insts)
 	cancel()
 
 	if connPool != nil {
@@ -475,7 +475,7 @@ func TestConnect_unavailable(t *testing.T) {
 	}, connPool.Info())
 }
 
-func TestConnect_single_server_hang(t *testing.T) {
+func TestNew_single_server_hang(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
@@ -485,7 +485,7 @@ func TestConnect_single_server_hang(t *testing.T) {
 
 	insts := makeInstances([]string{l.Addr().String()}, connOpts)
 
-	connPool, err := pool.Connect(ctx, insts)
+	connPool, err := pool.New(ctx, insts)
 	if connPool != nil {
 		defer func() { _ = connPool.Close() }()
 	}
@@ -494,7 +494,7 @@ func TestConnect_single_server_hang(t *testing.T) {
 	require.Nil(t, connPool)
 }
 
-func TestConnect_server_hang(t *testing.T) {
+func TestNew_server_hang(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer func() { _ = l.Close() }()
@@ -505,7 +505,7 @@ func TestConnect_server_hang(t *testing.T) {
 	servers := []string{l.Addr().String(), servers[0]}
 	insts := makeInstances(servers, connOpts)
 
-	connPool, err := pool.Connect(ctx, insts)
+	connPool, err := pool.New(ctx, insts)
 	if connPool != nil {
 		defer func() { _ = connPool.Close() }()
 	}
@@ -531,7 +531,7 @@ func TestConnErrorAfterCtxCancel(t *testing.T) {
 	var err error
 
 	cancel()
-	connPool, err = pool.Connect(ctx, makeInstances(servers, longTimeoutOpts))
+	connPool, err = pool.New(ctx, makeInstances(servers, longTimeoutOpts))
 
 	require.Nil(t, connPool, "Pool was created after cancel")
 	require.Error(t, err, "Pool was created after cancel")
@@ -576,7 +576,7 @@ func TestConnectContextCancelAfterConnect(t *testing.T) {
 		})
 	}
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	if connPool != nil {
 		defer func() { _ = connPool.Close() }()
 	}
@@ -603,7 +603,7 @@ func TestConnSuccessfullyDuplicates(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -631,7 +631,7 @@ func TestReconnect(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -679,7 +679,7 @@ func TestDisconnect_withReconnect(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -728,7 +728,7 @@ func TestDisconnectAll(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server1, server2}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server1, server2}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -779,7 +779,7 @@ func TestDisconnectAll(t *testing.T) {
 func TestAdd(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "conn is nil after Connect")
 
@@ -817,7 +817,7 @@ func TestAdd(t *testing.T) {
 func TestAdd_canceled_ctx(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -833,7 +833,7 @@ func TestAdd_canceled_ctx(t *testing.T) {
 func TestAdd_reconnect_error(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "conn is nil after Connect")
 
@@ -850,7 +850,7 @@ func TestAdd_reconnect_error(t *testing.T) {
 func TestAdd_max_reconnects_error(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "conn is nil after Connect")
 
@@ -867,7 +867,7 @@ func TestAdd_max_reconnects_error(t *testing.T) {
 func TestAdd_notify_error(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "conn is nil after Connect")
 
@@ -884,7 +884,7 @@ func TestAdd_notify_error(t *testing.T) {
 func TestAdd_error_multiple_opts(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoError(t, err, "failed to connect")
 	require.NotNil(t, connPool, "conn is nil after Connect")
 
@@ -905,7 +905,7 @@ func TestAdd_error_multiple_opts(t *testing.T) {
 func TestAdd_exist(t *testing.T) {
 	server := servers[0]
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server}, connOpts))
 	cancel()
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -939,7 +939,7 @@ func TestAdd_unreachable(t *testing.T) {
 	server := servers[0]
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server}, connOpts))
 	cancel()
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -977,7 +977,7 @@ func TestAdd_unreachable(t *testing.T) {
 func TestAdd_afterClose(t *testing.T) {
 	server := servers[0]
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server}, connOpts))
 	cancel()
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -996,7 +996,7 @@ func TestAdd_Close_concurrent(t *testing.T) {
 	serv1 := servers[1]
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{serv0}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{serv0}, connOpts))
 	cancel()
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -1025,7 +1025,7 @@ func TestAdd_CloseGraceful_concurrent(t *testing.T) {
 	serv1 := servers[1]
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{serv0}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{serv0}, connOpts))
 	cancel()
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
@@ -1053,7 +1053,7 @@ func TestAdd_CloseGraceful_concurrent(t *testing.T) {
 func TestRemove(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1084,7 +1084,7 @@ func TestRemove(t *testing.T) {
 func TestRemove_double(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances(servers[:2], connOpts))
+	connPool, err := pool.New(ctx, makeInstances(servers[:2], connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1115,7 +1115,7 @@ func TestRemove_double(t *testing.T) {
 func TestRemove_unknown(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances(servers[:2], connOpts))
+	connPool, err := pool.New(ctx, makeInstances(servers[:2], connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1145,7 +1145,7 @@ func TestRemove_unknown(t *testing.T) {
 func TestRemove_concurrent(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances(servers[:2], connOpts))
+	connPool, err := pool.New(ctx, makeInstances(servers[:2], connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1196,7 +1196,7 @@ func TestRemove_concurrent(t *testing.T) {
 func TestRemove_Close_concurrent(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances(servers[:2], connOpts))
+	connPool, err := pool.New(ctx, makeInstances(servers[:2], connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1217,7 +1217,7 @@ func TestRemove_Close_concurrent(t *testing.T) {
 func TestRemove_CloseGraceful_concurrent(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances(servers[:2], connOpts))
+	connPool, err := pool.New(ctx, makeInstances(servers[:2], connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1242,7 +1242,7 @@ func TestClose(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server1, server2}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server1, server2}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1286,7 +1286,7 @@ func TestCloseGraceful(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server1, server2}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server1, server2}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1432,7 +1432,7 @@ func TestHandlerOpenUpdateClose(t *testing.T) {
 		CheckTimeout: 100 * time.Millisecond,
 		Handler:      h,
 	}
-	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
+	connPool, err := pool.NewWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1510,7 +1510,7 @@ func TestHandlerOpenError(t *testing.T) {
 	defer cancel()
 
 	insts := makeInstances(poolServers, connOpts)
-	connPool, err := pool.ConnectWithOpts(ctx, insts, poolOpts)
+	connPool, err := pool.NewWithOpts(ctx, insts, poolOpts)
 	if err == nil {
 		defer func() { _ = connPool.Close() }()
 	}
@@ -1567,7 +1567,7 @@ func TestHandlerUpdateError(t *testing.T) {
 		CheckTimeout: 100 * time.Microsecond,
 		Handler:      h,
 	}
-	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
+	connPool, err := pool.NewWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -1640,7 +1640,7 @@ func TestHandlerDeactivated_on_remove(t *testing.T) {
 		CheckTimeout: 100 * time.Millisecond,
 		Handler:      h,
 	}
-	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
+	connPool, err := pool.NewWithOpts(ctx, poolInstances, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -1683,7 +1683,7 @@ func TestRequestOnClosed(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server1, server2}, connOpts))
+	connPool, err := pool.New(ctx, makeInstances([]string{server1, server2}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1727,7 +1727,7 @@ func TestDoWithCallRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1799,7 +1799,7 @@ func TestDoWithEvalRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1892,7 +1892,7 @@ func TestDoWithExecuteRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -1942,7 +1942,7 @@ func TestRoundRobinStrategy(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2022,7 +2022,7 @@ func TestRoundRobinStrategy_NoReplica(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2099,7 +2099,7 @@ func TestRoundRobinStrategy_NoMaster(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2188,7 +2188,7 @@ func TestUpdateInstancesRoles(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2347,7 +2347,7 @@ func TestDoWithInsertRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2449,7 +2449,7 @@ func TestDoWithDeleteRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2517,7 +2517,7 @@ func TestDoWithUpsertRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2590,7 +2590,7 @@ func TestDoWithUpdateRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2685,7 +2685,7 @@ func TestDoWithReplaceRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2775,7 +2775,7 @@ func TestDoWithSelectRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2928,7 +2928,7 @@ func TestDoWithPingRequest(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -2968,7 +2968,7 @@ func TestDo(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3005,7 +3005,7 @@ func TestDo_concurrent(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3032,7 +3032,7 @@ func TestDoOn(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3055,7 +3055,7 @@ func TestDoOn_not_found(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	connPool, err := pool.New(ctx, []pool.Instance{})
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3069,7 +3069,7 @@ func TestDoOn_not_found(t *testing.T) {
 func TestDoOn_concurrent(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3109,7 +3109,7 @@ func TestNewPrepared(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3162,7 +3162,7 @@ func TestDoWithStrangerConn(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -3189,7 +3189,7 @@ func TestStream_Commit(t *testing.T) {
 	err = test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3281,7 +3281,7 @@ func TestStream_Rollback(t *testing.T) {
 	err = test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3372,7 +3372,7 @@ func TestStream_TxnIsolationLevel(t *testing.T) {
 	err = test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3453,7 +3453,7 @@ func TestPool_NewWatcher_no_watchers(t *testing.T) {
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nill after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3484,7 +3484,7 @@ func TestPool_NewWatcher_modes(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3563,7 +3563,7 @@ func TestPool_NewWatcher_update(t *testing.T) {
 	poolOpts := pool.Opts{
 		CheckTimeout: 500 * time.Millisecond,
 	}
-	pool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
+	pool, err := pool.NewWithOpts(ctx, instances, poolOpts)
 
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, pool, "conn is nil after Connect")
@@ -3646,7 +3646,7 @@ func TestWatcher_Unregister(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	pool, err := pool.Connect(ctx, instances)
+	pool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, pool, "conn is nil after Connect")
 	defer func() { _ = pool.Close() }()
@@ -3704,7 +3704,7 @@ func TestPool_NewWatcher_concurrent(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3741,7 +3741,7 @@ func TestWatcher_Unregister_concurrent(t *testing.T) {
 	err := test_helpers.SetClusterRO(ctx, dialers, connOpts, roles)
 	require.NoErrorf(t, err, "fail to set roles for cluster")
 
-	connPool, err := pool.Connect(ctx, instances)
+	connPool, err := pool.New(ctx, instances)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 	defer func() { _ = connPool.Close() }()
@@ -3822,7 +3822,7 @@ func TestPool_Info_equal_instance_info(t *testing.T) {
 
 	for _, tc := range tCases {
 		ctx, cancel := test_helpers.GetPoolConnectContext()
-		connPool, err := pool.Connect(ctx, tc)
+		connPool, err := pool.New(ctx, tc)
 		cancel()
 		require.NoErrorf(t, err, "failed to connect")
 		require.NotNilf(t, connPool, "conn is nil after Connect")

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1580,18 +1580,11 @@ func TestHandlerUpdateError(t *testing.T) {
 	err = test_helpers.SetClusterRO(ctx, makeDialers(poolServers), connOpts, roles)
 	require.NoErrorf(t, err, "failed to make ro")
 
-	for i := 0; i < 100; i++ {
-		// Wait for updates done.
+	require.Eventuallyf(t, func() bool {
 		connected, err = connPool.ConnectedNow(pool.ModeAny)
-		if !connected || err != nil {
-			break
-		}
-		time.Sleep(poolOpts.CheckTimeout)
-	}
-	connected, err = connPool.ConnectedNow(pool.ModeAny)
-
+		return err == nil && !connected
+	}, timeout, poolOpts.CheckTimeout, "should not be any active connection")
 	require.NoErrorf(t, err, "failed to get ConnectedNow()")
-	require.Falsef(t, connected, "should not be any active connection")
 
 	_ = connPool.Close()
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -3028,7 +3028,7 @@ func TestDo_concurrent(t *testing.T) {
 	wg.Wait()
 }
 
-func TestDoInstance(t *testing.T) {
+func TestDoOn(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 
@@ -3040,13 +3040,13 @@ func TestDoInstance(t *testing.T) {
 
 	req := tarantool.NewEvalRequest("return box.cfg.listen")
 	for _, server := range servers {
-		data, err := connPool.DoInstance(req, server).Get()
+		data, err := connPool.DoOn(req, server).Get()
 		require.NoError(t, err)
 		assert.Equal(t, []interface{}{server}, data)
 	}
 }
 
-func TestDoInstance_not_found(t *testing.T) {
+func TestDoOn_not_found(t *testing.T) {
 	roles := []bool{true, true, false, true, false}
 
 	ctx, cancel := test_helpers.GetPoolConnectContext()
@@ -3061,12 +3061,12 @@ func TestDoInstance_not_found(t *testing.T) {
 
 	defer func() { _ = connPool.Close() }()
 
-	data, err := connPool.DoInstance(tarantool.NewPingRequest(), "not_exist").Get()
+	data, err := connPool.DoOn(tarantool.NewPingRequest(), "not_exist").Get()
 	assert.Nil(t, data)
 	require.ErrorIs(t, err, pool.ErrNoHealthyInstance)
 }
 
-func TestDoInstance_concurrent(t *testing.T) {
+func TestDoOn_concurrent(t *testing.T) {
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
 	connPool, err := pool.Connect(ctx, instances)
@@ -3086,11 +3086,11 @@ func TestDoInstance_concurrent(t *testing.T) {
 			defer wg.Done()
 
 			for _, server := range servers {
-				data, err := connPool.DoInstance(eval, server).Get()
+				data, err := connPool.DoOn(eval, server).Get()
 				assert.NoError(t, err)
 				assert.Equal(t, []interface{}{server}, data)
 			}
-			_, err := connPool.DoInstance(ping, "not_exist").Get()
+			_, err := connPool.DoOn(ping, "not_exist").Get()
 			assert.ErrorIs(t, err, pool.ErrNoHealthyInstance)
 		}()
 	}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -448,7 +448,7 @@ func TestConnect_empty(t *testing.T) {
 
 			require.NoError(t, err, "failed to create a pool")
 			require.NotNilf(t, connPool, "pool is nil after Connect")
-			require.Emptyf(t, connPool.GetInfo(), "empty pool expected")
+			require.Emptyf(t, connPool.Info(), "empty pool expected")
 		})
 	}
 }
@@ -472,7 +472,7 @@ func TestConnect_unavailable(t *testing.T) {
 			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
 		servers[1]: pool.Info{
 			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
-	}, connPool.GetInfo())
+	}, connPool.Info())
 }
 
 func TestConnect_single_server_hang(t *testing.T) {
@@ -517,7 +517,7 @@ func TestConnect_server_hang(t *testing.T) {
 			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
 		servers[1]: pool.Info{
 			ConnectedNow: true, Role: pool.MasterRole, Instance: insts[1]},
-	}, connPool.GetInfo())
+	}, connPool.Info())
 }
 
 func TestConnErrorAfterCtxCancel(t *testing.T) {
@@ -1521,7 +1521,7 @@ func TestHandlerOpenError(t *testing.T) {
 			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[0]},
 		servers[1]: pool.Info{
 			ConnectedNow: false, Role: pool.UnknownRole, Instance: insts[1]},
-	}, connPool.GetInfo())
+	}, connPool.Info())
 	_ = connPool.Close()
 
 	// It could happen additional reconnect attempts in the background, but
@@ -3809,7 +3809,7 @@ func runTestMain(m *testing.M) int {
 	return m.Run()
 }
 
-func TestPool_GetInfo_equal_instance_info(t *testing.T) {
+func TestPool_Info_equal_instance_info(t *testing.T) {
 	var tCases [][]pool.Instance
 
 	tCases = append(tCases, makeInstances([]string{servers[0], servers[1]}, connOpts))
@@ -3827,7 +3827,7 @@ func TestPool_GetInfo_equal_instance_info(t *testing.T) {
 		require.NoErrorf(t, err, "failed to connect")
 		require.NotNilf(t, connPool, "conn is nil after Connect")
 
-		info := connPool.GetInfo()
+		info := connPool.Info()
 
 		var infoInstances []pool.Instance
 

--- a/pool/pooler.go
+++ b/pool/pooler.go
@@ -20,7 +20,7 @@ type Pooler interface {
 
 	ConnectedNow(mode Mode) (bool, error)
 	Close() error
-	// CloseGraceful closes connections in the ConnectionPool gracefully. It waits
+	// CloseGraceful closes connections in the Pool gracefully. It waits
 	// for all requests to complete.
 	CloseGraceful() error
 	ConfiguredTimeout(mode Mode) (time.Duration, error)

--- a/pool/role_string.go
+++ b/pool/role_string.go
@@ -8,9 +8,9 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[UnknownRole-0]
-	_ = x[MasterRole-1]
-	_ = x[ReplicaRole-2]
+	_ = x[RoleUnknown-0]
+	_ = x[RoleMaster-1]
+	_ = x[RoleReplica-2]
 }
 
 const _Role_name = "unknownmasterreplica"

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/tarantool/go-tarantool/v3/test_helpers"
 )
 
-// QueueConnectionHandler handles new connections in a ConnectionPool.
-type QueueConnectionHandler struct {
+// QueueHandler handles new connections in a Pool.
+type QueueHandler struct {
 	name string
 	cfg  queue.Cfg
 
@@ -28,12 +28,12 @@ type QueueConnectionHandler struct {
 	masterCnt  int32
 }
 
-// QueueConnectionHandler implements the ConnectionHandler interface.
-var _ pool.ConnectionHandler = &QueueConnectionHandler{}
+// QueueHandler implements the Handler interface.
+var _ pool.Handler = &QueueHandler{}
 
-// NewQueueConnectionHandler creates a QueueConnectionHandler object.
-func NewQueueConnectionHandler(name string, cfg queue.Cfg) *QueueConnectionHandler {
-	return &QueueConnectionHandler{
+// NewQueueHandler creates a QueueHandler object.
+func NewQueueHandler(name string, cfg queue.Cfg) *QueueHandler {
+	return &QueueHandler{
 		name:    name,
 		cfg:     cfg,
 		updated: make(chan struct{}, 10),
@@ -45,7 +45,7 @@ func NewQueueConnectionHandler(name string, cfg queue.Cfg) *QueueConnectionHandl
 //
 // NOTE: the Queue supports only a master-replica cluster configuration. It
 // does not support a master-master configuration.
-func (h *QueueConnectionHandler) Discovered(name string, conn *tarantool.Connection,
+func (h *QueueHandler) Discovered(name string, conn *tarantool.Connection,
 	role pool.Role) error {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
@@ -114,7 +114,7 @@ func (h *QueueConnectionHandler) Discovered(name string, conn *tarantool.Connect
 }
 
 // Deactivated doesn't do anything useful for the example.
-func (h *QueueConnectionHandler) Deactivated(name string, conn *tarantool.Connection,
+func (h *QueueHandler) Deactivated(name string, conn *tarantool.Connection,
 	role pool.Role) error {
 	if role == pool.MasterRole {
 		atomic.AddInt32(&h.masterCnt, -1)
@@ -122,25 +122,25 @@ func (h *QueueConnectionHandler) Deactivated(name string, conn *tarantool.Connec
 	return nil
 }
 
-// Closes closes a QueueConnectionHandler object.
-func (h *QueueConnectionHandler) Close() {
+// Closes closes a QueueHandler object.
+func (h *QueueHandler) Close() {
 	close(h.updated)
 }
 
 // Example demonstrates how to use the queue package with the pool
-// package. First of all, you need to create a ConnectionHandler implementation
-// for the a ConnectionPool object to process new connections from
+// package. First of all, you need to create a Handler implementation
+// for the a Pool object to process new connections from
 // RW-instances.
 //
 // You need to register a shared session UUID at a first master connection.
 // It needs to be used to re-identify as the shared session on new
-// RW-instances. See QueueConnectionHandler.Discovered() implementation.
+// RW-instances. See QueueHandler.Discovered() implementation.
 //
 // After that, you need to create a ConnectorAdapter object with RW mode for
-// the ConnectionPool to send requests into RW-instances. This adapter can
+// the Pool to send requests into RW-instances. This adapter can
 // be used to create a ready-to-work queue object.
 func Example_connectionPool() {
-	// Create a ConnectionHandler object.
+	// Create a Handler object.
 	cfg := queue.Cfg{
 		Temporary:   false,
 		IfNotExists: true,
@@ -149,10 +149,10 @@ func Example_connectionPool() {
 			Ttl: 10 * time.Second,
 		},
 	}
-	h := NewQueueConnectionHandler("test_queue", cfg)
+	h := NewQueueHandler("test_queue", cfg)
 	defer h.Close()
 
-	// Create a ConnectionPool object.
+	// Create a Pool object.
 	poolServers := []string{"127.0.0.1:3014", "127.0.0.1:3015"}
 	poolDialers := []tarantool.Dialer{}
 	poolInstances := []pool.Instance{}
@@ -178,8 +178,8 @@ func Example_connectionPool() {
 	defer cancel()
 
 	poolOpts := pool.Opts{
-		CheckTimeout:      5 * time.Second,
-		ConnectionHandler: h,
+		CheckTimeout: 5 * time.Second,
+		Handler:      h,
 	}
 	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
 	if err != nil {
@@ -197,7 +197,7 @@ func Example_connectionPool() {
 		return
 	}
 
-	// Create a Queue object from the ConnectionPool object via
+	// Create a Queue object from the Pool object via
 	// a ConnectorAdapter.
 	rw := pool.NewConnectorAdapter(connPool, pool.RW)
 	q := queue.New(rw, "test_queue")

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -181,7 +181,7 @@ func Example_connectionPool() {
 		CheckTimeout: 5 * time.Second,
 		Handler:      h,
 	}
-	connPool, err := pool.ConnectWithOpts(ctx, poolInstances, poolOpts)
+	connPool, err := pool.NewWithOpts(ctx, poolInstances, poolOpts)
 	if err != nil {
 		fmt.Printf("Unable to connect to the pool: %s", err)
 		return

--- a/queue/example_connection_pool_test.go
+++ b/queue/example_connection_pool_test.go
@@ -54,7 +54,7 @@ func (h *QueueHandler) Discovered(name string, conn *tarantool.Connection,
 		return h.err
 	}
 
-	master := role == pool.MasterRole
+	master := role == pool.RoleMaster
 
 	q := queue.New(conn, h.name)
 
@@ -116,7 +116,7 @@ func (h *QueueHandler) Discovered(name string, conn *tarantool.Connection,
 // Deactivated doesn't do anything useful for the example.
 func (h *QueueHandler) Deactivated(name string, conn *tarantool.Connection,
 	role pool.Role) error {
-	if role == pool.MasterRole {
+	if role == pool.RoleMaster {
 		atomic.AddInt32(&h.masterCnt, -1)
 	}
 	return nil
@@ -130,14 +130,14 @@ func (h *QueueHandler) Close() {
 // Example demonstrates how to use the queue package with the pool
 // package. First of all, you need to create a Handler implementation
 // for the a Pool object to process new connections from
-// RW-instances.
+// ModeRW-instances.
 //
 // You need to register a shared session UUID at a first master connection.
 // It needs to be used to re-identify as the shared session on new
-// RW-instances. See QueueHandler.Discovered() implementation.
+// ModeRW-instances. See QueueHandler.Discovered() implementation.
 //
-// After that, you need to create a ConnectorAdapter object with RW mode for
-// the Pool to send requests into RW-instances. This adapter can
+// After that, you need to create a ConnectorAdapter object with ModeRW mode for
+// the Pool to send requests into ModeRW-instances. This adapter can
 // be used to create a ready-to-work queue object.
 func Example_connectionPool() {
 	// Create a Handler object.
@@ -199,7 +199,7 @@ func Example_connectionPool() {
 
 	// Create a Queue object from the Pool object via
 	// a ConnectorAdapter.
-	rw := pool.NewConnectorAdapter(connPool, pool.RW)
+	rw := pool.NewConnectorAdapter(connPool, pool.ModeRW)
 	q := queue.New(rw, "test_queue")
 	fmt.Println("A Queue object is ready to work.")
 
@@ -236,7 +236,7 @@ func Example_connectionPool() {
 
 	for i := 0; i < 2 && atomic.LoadInt32(&h.masterCnt) != 1; i++ {
 		// The pool does not immediately detect role switching. It may happen
-		// that requests will be sent to RO instances. In that case q.Take()
+		// that requests will be sent to ModeRO instances. In that case q.Take()
 		// method will return a nil value.
 		//
 		// We need to make the example test output deterministic so we need to

--- a/test_helpers/pool_helper.go
+++ b/test_helpers/pool_helper.go
@@ -13,14 +13,14 @@ import (
 )
 
 type ListenOnInstanceArgs struct {
-	ConnPool      *pool.ConnectionPool
+	Pool          *pool.Pool
 	Mode          pool.Mode
 	ServersNumber int
 	ExpectedPorts map[string]bool
 }
 
 type CheckStatusesArgs struct {
-	ConnPool           *pool.ConnectionPool
+	Pool               *pool.Pool
 	Servers            []string
 	Mode               pool.Mode
 	ExpectedPoolStatus bool
@@ -62,14 +62,14 @@ func comparePortMaps(expected map[string]bool, actual map[string]bool) error {
 }
 
 func CheckPoolStatuses(args CheckStatusesArgs) error {
-	connected, _ := args.ConnPool.ConnectedNow(args.Mode)
+	connected, _ := args.Pool.ConnectedNow(args.Mode)
 	if connected != args.ExpectedPoolStatus {
 		return fmt.Errorf(
 			"incorrect connection pool status: expected status %t actual status %t",
 			args.ExpectedPoolStatus, connected)
 	}
 
-	poolInfo := args.ConnPool.GetInfo()
+	poolInfo := args.Pool.GetInfo()
 	for _, server := range args.Servers {
 		status := poolInfo[server].ConnectedNow
 		if args.ExpectedStatuses[server] != status {
@@ -97,7 +97,7 @@ func ProcessListenOnInstance(args ListenOnInstanceArgs) error {
 	for i := 0; i < args.ServersNumber; i++ {
 		req := tarantool.NewEvalRequest("return box.cfg.listen")
 		var data []string
-		err := args.ConnPool.Do(req, args.Mode).GetTyped(&data)
+		err := args.Pool.Do(req, args.Mode).GetTyped(&data)
 		if err != nil {
 			return fmt.Errorf("failed to get response: %w", err)
 		}

--- a/test_helpers/pool_helper.go
+++ b/test_helpers/pool_helper.go
@@ -69,7 +69,7 @@ func CheckPoolStatuses(args CheckStatusesArgs) error {
 			args.ExpectedPoolStatus, connected)
 	}
 
-	poolInfo := args.Pool.GetInfo()
+	poolInfo := args.Pool.Info()
 	for _, server := range args.Servers {
 		status := poolInfo[server].ConnectedNow
 		if args.ExpectedStatuses[server] != status {

--- a/test_helpers/pool_helper.go
+++ b/test_helpers/pool_helper.go
@@ -85,11 +85,11 @@ func CheckPoolStatuses(args CheckStatusesArgs) error {
 // ProcessListenOnInstance helper calls "return box.cfg.listen"
 // as many times as there are servers in the connection pool
 // with specified mode.
-// For RO mode expected received ports equals to replica ports.
-// For RW mode expected received ports equals to master ports.
-// For PreferRO mode expected received ports equals to replica
+// For ModeRO mode expected received ports equals to replica ports.
+// For ModeRW mode expected received ports equals to master ports.
+// For ModePreferRO mode expected received ports equals to replica
 // ports or to all ports.
-// For PreferRW mode expected received ports equals to master ports
+// For ModePreferRW mode expected received ports equals to master ports
 // or to all ports.
 func ProcessListenOnInstance(args ListenOnInstanceArgs) error {
 	actualPorts := map[string]bool{}


### PR DESCRIPTION
This PR renames public types, methods, functions, and enum constants in the `pool` package to follow Go naming conventions and eliminate redundancy.

**Types:**
- `ConnectionPool` → `Pool`
- `ConnectionHandler` → `Handler`
- `ConnectionInfo` → `Info`
- `ConnectionInfo.ConnRole` → `Info.Role`

**Methods:**
- `GetInfo()` → `Info()`
- `DoInstance()` → `DoOn()`

**Functions:**
- `Connect()` → `New()`
- `ConnectWithOpts()` → `NewWithOpts()`

**Enum constants:**
- `ANY` → `ModeAny`
- `RW` → `ModeRW`
- `RO` → `ModeRO`
- `PreferRW` → `ModePreferRW`
- `PreferRO` → `ModePreferRO`
- `UnknownRole` → `RoleUnknown`
- `MasterRole` → `RoleMaster`
- `ReplicaRole` → `RoleReplica`

The old names were either tautological (`ConnectionPool` in package `pool`) or violated Go conventions (`GetInfo` getter with prefix, `Connect` as a factory function). Enum names were unified to a prefix style consistent with the standard library (`http.StatusOK`, `os.O_RDONLY`).

All changes are breaking; no deprecation aliases are provided since this is the v3 branch with an unstable API.