### PR TITLE
pool: ban Reconnect, MaxReconnects and Notify opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * `test_helpers.CheckPoolStatuses` and `test_helpers.ProcessListenOnInstance`
   now accept typed arguments (`CheckStatusesArgs` and `ListenOnInstanceArgs`
   respectively) instead of `interface{}`.
+* `ConnectionPool.ConnectWithOpts()`, `ConnectionPool.Connect()` and
+  `ConnectionPool.Add()` now return an error if `tarantool.Opts.Reconnect`,
+  `tarantool.Opts.MaxReconnects` or `tarantool.Opts.Notify` options are set
+  for an instance connection. These options conflict with the pool's own
+  reconnection logic and produce misleading events. Use
+  `pool.ConnectionHandler` to track connection availability instead of
+  `tarantool.Opts.Notify`. All validation errors are combined using
+  `errors.Join` and can be checked with `errors.Is`.
 
 ### Removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,40 @@ TODO
 * Future.done replaced with Future.cond (sync.Cond) + Future.finished bool.
 * `Future` is an interface now.
 * `ConnectionPool.Close()` returns a single error value, combining multiple errors using errors.Join()
+* `ConnectionPool.ConnectWithOpts()`, `ConnectionPool.Connect()` and
+  `ConnectionPool.Add()` now return an error if `tarantool.Opts.Reconnect`,
+  `tarantool.Opts.MaxReconnects` or `tarantool.Opts.Notify` options are set
+  for an instance connection. These options create conflicts with the pool's
+  own reconnection logic: the pool reconnects via `pool.Opts.CheckTimeout`,
+  so an internal `Reconnect` creates a race with the pool; `MaxReconnects`
+  permanently closes a Connection while the pool would create a new one;
+  `Notify` events from an individual connection are misleading in a pool
+  context (e.g., `Disconnected` does not mean the endpoint is unavailable).
+  Use `pool.ConnectionHandler` to track endpoint availability.
+  All validation errors are combined using `errors.Join` and can be
+  checked with `errors.Is`.
+
+  Before:
+  ```Go
+  opts := tarantool.Opts{
+      Reconnect:     time.Second,
+      MaxReconnects: 3,
+      Notify:        make(chan tarantool.ConnEvent),
+  }
+  connPool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
+  ```
+
+  After:
+  ```Go
+  opts := tarantool.Opts{
+      // Reconnect, MaxReconnects, Notify must not be set.
+  }
+  poolOpts := pool.Opts{
+      CheckTimeout:      time.Second,
+      ConnectionHandler: myHandler, // Implement pool.ConnectionHandler.
+  }
+  connPool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
+  ```
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/pool/connection_pool.go
+++ b/pool/connection_pool.go
@@ -36,6 +36,27 @@ var (
 	ErrUnknownRequest    = errors.New("the passed connected request doesn't belong to " +
 		"the current connection pool")
 	ErrContextCanceled = errors.New("operation was canceled")
+	// ErrOptsReconnect is returned if tarantool.Opts.Reconnect is set for an
+	// instance connection. It must not be used with ConnectionPool: the pool
+	// itself manages reconnection via pool.Opts.CheckTimeout, so an internal
+	// reconnect creates a conflict with the pool's own reconnection logic.
+	ErrOptsReconnect = errors.New(
+		"tarantool.Opts.Reconnect must not be used with ConnectionPool")
+	// ErrOptsMaxReconnects is returned if tarantool.Opts.MaxReconnects is set
+	// for an instance connection. It must not be used with ConnectionPool: the
+	// pool itself manages connection lifetime, so an internal reconnect limit
+	// permanently closes a Connection while the pool will create a new one
+	// anyway.
+	ErrOptsMaxReconnects = errors.New(
+		"tarantool.Opts.MaxReconnects must not be used with ConnectionPool")
+	// ErrOptsNotify is returned if tarantool.Opts.Notify is set for an instance
+	// connection. It must not be used with ConnectionPool: events from an
+	// individual connection are misleading in a pool context (e.g., Disconnected
+	// does not mean the endpoint is unavailable, since the pool may have already
+	// reconnected); use pool.ConnectionHandler to track endpoint availability
+	// instead.
+	ErrOptsNotify = errors.New(
+		"tarantool.Opts.Notify must not be used with ConnectionPool")
 )
 
 // ConnectionHandler provides callbacks for components interested in handling
@@ -69,7 +90,11 @@ type Instance struct {
 	Name string
 	// Dialer will be used to create a connection to the instance.
 	Dialer tarantool.Dialer
-	// Opts configures a connection to the instance.
+	// Opts configures a connection to the instance. tarantool.Opts.Reconnect,
+	// tarantool.Opts.MaxReconnects and tarantool.Opts.Notify must not be set:
+	// the pool manages reconnection and connection lifetime itself, and
+	// individual connection events are misleading in a pool context. Use
+	// pool.ConnectionHandler to track endpoint availability.
 	Opts tarantool.Opts
 }
 
@@ -135,6 +160,20 @@ type endpoint struct {
 	closeErr error
 }
 
+func validateInstanceOpts(opts tarantool.Opts) []error {
+	var errs []error
+	if opts.Reconnect != 0 {
+		errs = append(errs, ErrOptsReconnect)
+	}
+	if opts.MaxReconnects != 0 {
+		errs = append(errs, ErrOptsMaxReconnects)
+	}
+	if opts.Notify != nil {
+		errs = append(errs, ErrOptsNotify)
+	}
+	return errs
+}
+
 func newEndpoint(name string, dialer tarantool.Dialer, opts tarantool.Opts) *endpoint {
 	return &endpoint{
 		name:     name,
@@ -164,6 +203,14 @@ func ConnectWithOpts(ctx context.Context, instances []Instance,
 
 	if opts.CheckTimeout <= 0 {
 		return nil, ErrWrongCheckTimeout
+	}
+
+	var validationErrs []error
+	for _, instance := range instances {
+		validationErrs = append(validationErrs, validateInstanceOpts(instance.Opts)...)
+	}
+	if err := errors.Join(validationErrs...); err != nil {
+		return nil, err
 	}
 
 	size := len(instances)
@@ -223,10 +270,6 @@ func ConnectWithOpts(ctx context.Context, instances []Instance,
 
 // Connect creates pool for instances with specified instances. Instances must
 // have unique names.
-//
-// It is useless to set up tarantool.Opts.Reconnect value for a connection.
-// The connection pool has its own reconnection logic. See
-// Opts.CheckTimeout description.
 func Connect(ctx context.Context, instances []Instance) (*ConnectionPool, error) {
 	opts := Opts{
 		CheckTimeout: 1 * time.Second,
@@ -275,6 +318,10 @@ func (p *ConnectionPool) ConfiguredTimeout(mode Mode) (time.Duration, error) {
 // if the context has been cancelled or on concurrent Close()/CloseGraceful()
 // call.
 func (p *ConnectionPool) Add(ctx context.Context, instance Instance) error {
+	if err := errors.Join(validateInstanceOpts(instance.Opts)...); err != nil {
+		return err
+	}
+
 	e := newEndpoint(instance.Name, instance.Dialer, instance.Opts)
 
 	p.endsMutex.Lock()
@@ -717,8 +764,7 @@ func (p *ConnectionPool) fillPools(ctx context.Context, instances []Instance) <-
 	// It is called before controller() goroutines, so we don't expect
 	// concurrency issues here.
 	for _, instance := range instances {
-		end := newEndpoint(instance.Name, instance.Dialer, instance.Opts)
-		p.ends[instance.Name] = end
+		p.ends[instance.Name] = newEndpoint(instance.Name, instance.Dialer, instance.Opts)
 	}
 
 	for _, instance := range instances {

--- a/pool/connection_pool_test.go
+++ b/pool/connection_pool_test.go
@@ -107,8 +107,84 @@ func TestConnect_error_duplicate(t *testing.T) {
 	connPool, err := pool.Connect(ctx, makeInstances([]string{"foo", "foo"}, connOpts))
 	cancel()
 
-	require.Nilf(t, connPool, "conn is not nil with incorrect param")
+	assert.Nil(t, connPool)
 	require.EqualError(t, err, "duplicate instance name: \"foo\"")
+}
+
+func TestConnect_error_reconnect(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+
+	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+}
+
+func TestConnect_error_max_reconnects(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.MaxReconnects = 3
+
+	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+}
+
+func TestConnect_error_notify(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestConnect_error_multiple_opts(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+	opts.MaxReconnects = 3
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	connPool, err := pool.Connect(ctx, makeInstances([]string{"any"}, opts))
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestConnect_error_multiple_instances(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	badOpts1 := connOpts
+	badOpts1.Reconnect = time.Second
+	badOpts2 := connOpts
+	badOpts2.MaxReconnects = 3
+	instances := []pool.Instance{
+		makeInstance("bad1", badOpts1),
+		makeInstance("bad2", badOpts2),
+	}
+
+	connPool, err := pool.Connect(ctx, instances)
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
 }
 
 func TestConnectWithOpts_error_no_timeout(t *testing.T) {
@@ -116,8 +192,143 @@ func TestConnectWithOpts_error_no_timeout(t *testing.T) {
 	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, connOpts),
 		pool.Opts{})
 	cancel()
-	require.Nilf(t, connPool, "conn is not nil with incorrect param")
+	assert.Nil(t, connPool)
 	require.ErrorIs(t, err, pool.ErrWrongCheckTimeout)
+}
+
+func TestConnectWithOpts_error_reconnect(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+
+	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+}
+
+func TestConnectWithOpts_error_max_reconnects(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.MaxReconnects = 3
+
+	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+}
+
+func TestConnectWithOpts_error_notify(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestConnectWithOpts_error_reconnect_partial(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	badOpts := connOpts
+	badOpts.Reconnect = time.Second
+	instances := []pool.Instance{
+		makeInstance(servers[0], connOpts),
+		makeInstance("bad", badOpts),
+	}
+
+	connPool, err := pool.ConnectWithOpts(ctx, instances,
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+}
+
+func TestConnectWithOpts_error_max_reconnects_partial(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	badOpts := connOpts
+	badOpts.MaxReconnects = 3
+	instances := []pool.Instance{
+		makeInstance(servers[0], connOpts),
+		makeInstance("bad", badOpts),
+	}
+
+	connPool, err := pool.ConnectWithOpts(ctx, instances,
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+}
+
+func TestConnectWithOpts_error_notify_partial(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	badOpts := connOpts
+	badOpts.Notify = make(chan tarantool.ConnEvent)
+	instances := []pool.Instance{
+		makeInstance(servers[0], connOpts),
+		makeInstance("bad", badOpts),
+	}
+
+	connPool, err := pool.ConnectWithOpts(ctx, instances,
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestConnectWithOpts_error_multiple_opts(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+	opts.MaxReconnects = 3
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	connPool, err := pool.ConnectWithOpts(ctx, makeInstances([]string{"any"}, opts),
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestConnectWithOpts_error_multiple_instances(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	badOpts1 := connOpts
+	badOpts1.Reconnect = time.Second
+	badOpts2 := connOpts
+	badOpts2.MaxReconnects = 3
+	instances := []pool.Instance{
+		makeInstance("bad1", badOpts1),
+		makeInstance("bad2", badOpts2),
+	}
+
+	connPool, err := pool.ConnectWithOpts(ctx, instances,
+		pool.Opts{CheckTimeout: time.Second})
+
+	assert.Nil(t, connPool)
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
 }
 
 func TestConnSuccessfully(t *testing.T) {
@@ -310,10 +521,8 @@ func TestConnect_server_hang(t *testing.T) {
 }
 
 func TestConnErrorAfterCtxCancel(t *testing.T) {
-	var connLongReconnectOpts = tarantool.Opts{
-		Timeout:       5 * time.Second,
-		Reconnect:     time.Second,
-		MaxReconnects: 100,
+	var longTimeoutOpts = tarantool.Opts{
+		Timeout: 5 * time.Second,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -322,7 +531,7 @@ func TestConnErrorAfterCtxCancel(t *testing.T) {
 	var err error
 
 	cancel()
-	connPool, err = pool.Connect(ctx, makeInstances(servers, connLongReconnectOpts))
+	connPool, err = pool.Connect(ctx, makeInstances(servers, longTimeoutOpts))
 
 	require.Nil(t, connPool, "ConnectionPool was created after cancel")
 	require.Error(t, err, "ConnectionPool was created after cancel")
@@ -468,12 +677,9 @@ func TestDisconnect_withReconnect(t *testing.T) {
 	serverId := 0
 	server := servers[serverId]
 
-	opts := connOpts
-	opts.Reconnect = 10 * time.Second
-
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, opts))
+	connPool, err := pool.Connect(ctx, makeInstances([]string{server}, connOpts))
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
@@ -622,6 +828,78 @@ func TestAdd_canceled_ctx(t *testing.T) {
 
 	err = connPool.Add(ctx, makeInstance(servers[0], connOpts))
 	require.Error(t, err)
+}
+
+func TestAdd_reconnect_error(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	require.NoError(t, err, "failed to connect")
+	require.NotNil(t, connPool, "conn is nil after Connect")
+
+	defer func() { _ = connPool.Close() }()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+
+	err = connPool.Add(ctx, makeInstance(servers[0], opts))
+
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+}
+
+func TestAdd_max_reconnects_error(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	require.NoError(t, err, "failed to connect")
+	require.NotNil(t, connPool, "conn is nil after Connect")
+
+	defer func() { _ = connPool.Close() }()
+
+	opts := connOpts
+	opts.MaxReconnects = 3
+
+	err = connPool.Add(ctx, makeInstance(servers[0], opts))
+
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+}
+
+func TestAdd_notify_error(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	require.NoError(t, err, "failed to connect")
+	require.NotNil(t, connPool, "conn is nil after Connect")
+
+	defer func() { _ = connPool.Close() }()
+
+	opts := connOpts
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	err = connPool.Add(ctx, makeInstance(servers[0], opts))
+
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
+}
+
+func TestAdd_error_multiple_opts(t *testing.T) {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+	connPool, err := pool.Connect(ctx, []pool.Instance{})
+	require.NoError(t, err, "failed to connect")
+	require.NotNil(t, connPool, "conn is nil after Connect")
+
+	defer func() { _ = connPool.Close() }()
+
+	opts := connOpts
+	opts.Reconnect = time.Second
+	opts.MaxReconnects = 3
+	opts.Notify = make(chan tarantool.ConnEvent)
+
+	err = connPool.Add(ctx, makeInstance(servers[0], opts))
+
+	require.ErrorIs(t, err, pool.ErrOptsReconnect)
+	require.ErrorIs(t, err, pool.ErrOptsMaxReconnects)
+	require.ErrorIs(t, err, pool.ErrOptsNotify)
 }
 
 func TestAdd_exist(t *testing.T) {

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -1,6 +1,7 @@
 package pool_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -479,4 +480,48 @@ func ExampleConnectionPool_CloseGraceful_force() {
 	// ConnectionPool.CloseGraceful() done!
 	// Result:
 	// [] connection closed by client (0x4001)
+}
+
+func ExampleConnect_invalidOpts() {
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	// tarantool.Opts.Reconnect, MaxReconnects and Notify must not be used
+	// with ConnectionPool. The pool manages reconnection itself and
+	// individual connection events are misleading in a pool context.
+	opts := tarantool.Opts{
+		Timeout:       5 * time.Second,
+		Reconnect:     time.Second,
+		MaxReconnects: 3,
+	}
+	instances := []pool.Instance{
+		{
+			Name: "instance",
+			Dialer: tarantool.NetDialer{
+				Address: "127.0.0.1:3301",
+			},
+			Opts: opts,
+		},
+	}
+
+	connPool, err := pool.ConnectWithOpts(ctx, instances, pool.Opts{
+		CheckTimeout: time.Second,
+	})
+	if err != nil {
+		if errors.Is(err, pool.ErrOptsReconnect) {
+			fmt.Println("Reconnect is not allowed")
+		}
+		if errors.Is(err, pool.ErrOptsMaxReconnects) {
+			fmt.Println("MaxReconnects is not allowed")
+		}
+		if errors.Is(err, pool.ErrOptsNotify) {
+			fmt.Println("Notify is not allowed")
+		}
+	}
+	if connPool != nil {
+		_ = connPool.Close()
+	}
+	// Output:
+	// Reconnect is not allowed
+	// MaxReconnects is not allowed
 }


### PR DESCRIPTION
## Problem

`ConnectionPool` has its own reconnection logic based on `pool.Opts.CheckTimeout`, but it was possible to set `tarantool.Opts.Reconnect`, `MaxReconnects` and `Notify` for instance connections, which created conflicts:

- **Reconnect**: internal `Connection` reconnection races with the pool's own reconnection, causing resource leaks (two live connections to the same address)
- **MaxReconnects**: permanently closes a `Connection`, but the pool creates a new one anyway — the option is meaningless
- **Notify**: events from an individual `Connection` are misleading in a pool context (`Disconnected` doesn't mean the endpoint is unavailable; the pool may have already reconnected). Use `pool.ConnectionHandler` to track endpoint availability instead.

## Solution

`ConnectWithOpts()`, `Connect()` and `Add()` now return an error if these options are set. All validation errors are combined using `errors.Join` and can be checked with `errors.Is`.

## Migration

Before:
```go
opts := tarantool.Opts{
    Reconnect:     time.Second,
    MaxReconnects: 3,
    Notify:        make(chan tarantool.ConnEvent),
}
connPool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
```

After:
```go
opts := tarantool.Opts{
    // Reconnect, MaxReconnects, Notify must not be set.
}
poolOpts := pool.Opts{
    CheckTimeout:      time.Second,
    ConnectionHandler: myHandler, // Implement pool.ConnectionHandler.
}
connPool, err := pool.ConnectWithOpts(ctx, instances, poolOpts)
```