### PR TITLE
api: replace custom Logger with *slog.Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `ModeRW`, `RO` → `ModeRO`, `PreferRW` → `ModePreferRW`, `PreferRO` →
   `ModePreferRO`, `UnknownRole` → `RoleUnknown`, `MasterRole` → `RoleMaster`,
   `ReplicaRole` → `RoleReplica`.
+* Replaced custom `Logger` interface with `*slog.Logger` from the standard
+  library (#504). The `Logger` interface, `ConnLogKind` type, and its constants
+  (`LogReconnectFailed`, `LogLastReconnectFailed`, `LogUnexpectedResultId`,
+  `LogWatchEventReadFailed`, `LogBoxSessionPushUnsupported`) are removed.
+  Use `Opts.Logger *slog.Logger` instead. Pool `Opts.Logger *slog.Logger`
+  replaces direct `log.Printf` calls that were not customizable.
+  By default, logs are discarded (silent). See MIGRATION.md for details.
 
 ### Removed
 
@@ -93,6 +100,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   `NewCallRequest` instead.
 * `test_helpers.Retry` function. Use `assert.Eventually` from testify instead.
   `test_helpers.WaitUntilReconnected` reimplemented without `Retry`.
+* `Logger` interface and `defaultLogger` type — replaced by
+  `*slog.Logger` (#504).
+* `ConnLogKind` type and its constants — log messages are now identified
+  by string constants in `log.go` (#504).
 
 ### Fixed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -103,6 +103,69 @@ TODO
   All functions in `test_helpers` that previously accepted `*testing.T` now
   accept the `T` interface instead, making them usable in broader contexts like
   example functions and custom test runners.
+* Replaced custom `Logger` interface with `*slog.Logger` from the standard
+  library. The `Logger` interface, `ConnLogKind` type, and its constants
+  are removed. Use `Opts.Logger *slog.Logger` instead. Pool `Opts.Logger
+  *slog.Logger` replaces direct `log.Printf` calls. By default, logs are
+  discarded (silent).
+
+  Before:
+  ```go
+  type MyLogger struct{}
+
+  func (l MyLogger) Report(event tarantool.ConnLogKind, conn *tarantool.Connection, v ...any) {
+      switch event {
+      case tarantool.LogReconnectFailed:
+          reconnects := v[0].(uint)
+          err := v[1].(error)
+          log.Printf("reconnect %d failed: %s", reconnects, err)
+      // ... other cases
+      }
+  }
+
+  opts := tarantool.Opts{
+      Logger: MyLogger{},
+  }
+  ```
+
+  After:
+  ```go
+  import "log/slog"
+
+  opts := tarantool.Opts{
+      Logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+          Level: slog.LevelWarn,
+      })),
+  }
+  ```
+
+  For pool:
+  ```go
+  poolOpts := pool.Opts{
+      CheckTimeout: time.Second,
+      Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+  }
+  connPool, err := pool.NewWithOpts(ctx, instances, poolOpts)
+  ```
+
+  Removed types and constants:
+
+  | Removed | Replacement |
+  |---|---|
+  | `Logger` interface | `*slog.Logger` in `Opts.Logger` |
+  | `ConnLogKind` type | String constants (e.g., `LogMsgReconnectFailed`) |
+  | `LogReconnectFailed` | `LogMsgReconnectFailed` |
+  | `LogLastReconnectFailed` | `LogMsgLastReconnectFailed` |
+  | `LogUnexpectedResultId` | `LogMsgUnexpectedRequestId` |
+  | `LogWatchEventReadFailed` | `LogMsgWatchEventReadFailed` |
+  | `LogBoxSessionPushUnsupported` | `LogMsgPushUnsupported` |
+  | `defaultLogger` type | Discarded by default (previously logged to stderr via `log.Printf`) |
+
+  Note about log groups: connection log messages appear under the
+  `tarantool` group, while pool-level log messages appear under the
+  `tarantool.pool` group. When a pool logger is set and a connection
+  does not have its own logger, the pool passes its logger to each
+  connection, which then applies its own `WithGroup("tarantool")`.
 
 ## Migration from v1.x.x to v2.x.x
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ faster than other packages according to public benchmarks.
   * [API reference](#api-reference)
   * [Walking\-through example](#walking-through-example)
   * [Example with encrypting traffic](#example-with-encrypting-traffic)
+  * [Logging](#logging)
 * [Migration guide](#migration-guide)
 * [Contributing](#contributing)
 * [Related libraries](#related-libraries)
@@ -236,6 +237,52 @@ func main() {
 
 Note that [traffic encryption](https://www.tarantool.io/en/doc/latest/enterprise/security/#encrypting-traffic)
 is only available in Tarantool Enterprise Edition 2.10 or newer.
+
+### Logging
+
+The library uses Go's standard `log/slog` package for structured logging. By
+default, all log output is discarded. To enable logging, pass a `*slog.Logger`
+to `Opts.Logger`:
+
+```go
+import (
+    "log/slog"
+    "os"
+
+    "github.com/tarantool/go-tarantool/v3"
+)
+
+opts := tarantool.Opts{
+    Logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+        Level: slog.LevelWarn,
+    })),
+}
+```
+
+The library automatically wraps the logger with `WithGroup("tarantool")` to
+namespace its attributes. For pool connections, the group is
+`tarantool.pool`. This prevents key collisions with your application's own
+log attributes.
+
+When a pool logger is set and a connection does not have its own logger, the
+pool passes the original (unwrapped) logger to each connection, which then
+applies its own `WithGroup("tarantool")`. As a result, pool-level messages
+appear under the `tarantool.pool` group, while connection-level messages
+appear under the `tarantool` group.
+
+For a production-ready structured logging library, see
+[go-tlog](https://github.com/tarantool/go-tlog) — it supports multiple
+output formats (text, JSON), multiple destinations, log levels, and
+automatic stacktraces for errors. Since `tlog.Logger()` returns a
+`*slog.Logger`, it integrates directly:
+
+```go
+import "github.com/tarantool/go-tlog"
+
+opts := tarantool.Opts{
+    Logger: tlog.Logger(),
+}
+```
 
 ### Custom Requests
 

--- a/connection.go
+++ b/connection.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"math"
 	"net"
 	"runtime"
@@ -33,7 +33,6 @@ const (
 const shutdownEventKey = "box.shutdown"
 
 type ConnEventKind int
-type ConnLogKind int
 
 var (
 	errUnknownRequest = errors.New("the passed connected request doesn't belong " +
@@ -52,19 +51,6 @@ const (
 	// Closed signals that either reconnect attempts exhausted, or explicit
 	// Close is called.
 	Closed
-
-	// LogReconnectFailed is logged when reconnect attempt failed.
-	LogReconnectFailed ConnLogKind = iota + 1
-	// LogLastReconnectFailed is logged when last reconnect attempt failed,
-	// connection will be closed after that.
-	LogLastReconnectFailed
-	// LogUnexpectedResultId is logged when response with unknown id was received.
-	// Most probably it is due to request timeout.
-	LogUnexpectedResultId
-	// LogWatchEventReadFailed is logged when failed to read a watch event.
-	LogWatchEventReadFailed
-	// LogBoxSessionPushUnsupported is logged when response type turned IPROTO_CHUNK.
-	LogBoxSessionPushUnsupported
 )
 
 // ConnEvent is sent throw Notify channel specified in Opts.
@@ -81,53 +67,6 @@ type connWatchEvent struct {
 }
 
 var epoch = time.Now()
-
-// Logger is logger type expected to be passed in options.
-type Logger interface {
-	Report(event ConnLogKind, conn *Connection, v ...any)
-}
-
-type defaultLogger struct{}
-
-func (d defaultLogger) Report(event ConnLogKind, conn *Connection, v ...any) {
-	switch event {
-	case LogReconnectFailed:
-		reconnects := v[0].(uint)
-		err := v[1].(error)
-		addr := conn.Addr()
-		if addr == nil {
-			log.Printf("tarantool: connect (%d/%d) failed: %s",
-				reconnects, conn.opts.MaxReconnects, err)
-		} else {
-			log.Printf("tarantool: reconnect (%d/%d) to %s failed: %s",
-				reconnects, conn.opts.MaxReconnects, addr, err)
-		}
-	case LogLastReconnectFailed:
-		err := v[0].(error)
-		addr := conn.Addr()
-		if addr == nil {
-			log.Printf("tarantool: last connect failed: %s, giving it up",
-				err)
-		} else {
-			log.Printf("tarantool: last reconnect to %s failed: %s, giving it up",
-				addr, err)
-		}
-	case LogUnexpectedResultId:
-		header := v[0].(Header)
-		log.Printf("tarantool: connection %s got unexpected request ID (%d) in response "+
-			"(probably cancelled request)",
-			conn.Addr(), header.RequestId)
-	case LogWatchEventReadFailed:
-		err := v[0].(error)
-		log.Printf("tarantool: unable to parse watch event: %s", err)
-	case LogBoxSessionPushUnsupported:
-		header := v[0].(Header)
-		log.Printf("tarantool: unsupported box.session.push() for request %d", header.RequestId)
-	default:
-		args := append([]any{"tarantool: unexpected event ", event, conn}, v...)
-		log.Print(args...)
-	}
-}
 
 // Connection is a handle with a single connection to a Tarantool instance.
 //
@@ -214,6 +153,8 @@ type Connection struct {
 
 	// alloc is an allocator for response buffers.
 	alloc Allocator
+	// logger is a structured logger for the connection.
+	logger *slog.Logger
 }
 
 var _ = Connector(&Connection{}) // Check compatibility with connector interface.
@@ -329,8 +270,10 @@ type Opts struct {
 	// Handle is user specified value, that could be retrivied with
 	// Handle() method.
 	Handle any
-	// Logger is user specified logger used for error messages.
-	Logger Logger
+	// Logger is a structured logger for the connection. If nil, logs are
+	// discarded. If non-nil, the logger is automatically wrapped with
+	// WithGroup("tarantool") to namespace library attributes.
+	Logger *slog.Logger
 	// Allocator is used to allocate and deallocate response buffers.
 	// If nil, default Go allocation is used.
 	Allocator Allocator
@@ -376,8 +319,10 @@ func Connect(ctx context.Context, dialer Dialer, opts Opts) (conn *Connection, e
 		}
 	}
 
-	if conn.opts.Logger == nil {
-		conn.opts.Logger = defaultLogger{}
+	if opts.Logger == nil {
+		conn.logger = slog.New(slog.DiscardHandler)
+	} else {
+		conn.logger = opts.Logger.WithGroup("tarantool")
 	}
 
 	if conn.opts.Allocator != nil {
@@ -451,6 +396,13 @@ func (conn *Connection) CloseGraceful() error {
 // Addr returns a configured address of Tarantool socket.
 func (conn *Connection) Addr() net.Addr {
 	return conn.addr
+}
+
+func (conn *Connection) addrString() string {
+	if a := conn.Addr(); a != nil {
+		return a.String()
+	}
+	return ""
 }
 
 // Handle returns a user-specified handle from Opts.
@@ -687,7 +639,12 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 			return nil
 		}
 
-		conn.opts.Logger.Report(LogReconnectFailed, conn, reconnects, err)
+		conn.logger.Warn(LogMsgReconnectFailed,
+			slog.Uint64(LogKeyAttempt, uint64(reconnects)),
+			slog.Uint64(LogKeyMaxAttempts, uint64(conn.opts.MaxReconnects)),
+			slog.Any(LogKeyError, err),
+			slog.String(LogKeyAddress, conn.addrString()),
+		)
 		conn.notify(ReconnectFailed)
 		reconnects++
 		conn.mutex.Unlock()
@@ -702,7 +659,10 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 		conn.mutex.Lock()
 	}
 
-	conn.opts.Logger.Report(LogLastReconnectFailed, conn, err)
+	conn.logger.Warn(LogMsgLastReconnectFailed,
+		slog.Any(LogKeyError, err),
+		slog.String(LogKeyAddress, conn.addrString()),
+	)
 	// mark connection as closed to avoid reopening by another goroutine
 	return ClientError{ErrConnectionClosed, "last reconnect failed"}
 }
@@ -878,7 +838,10 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 			fut := conn.fetchFuture(r.header.RequestId)
 			if fut == nil {
 				r.buf.Release()
-				conn.opts.Logger.Report(LogUnexpectedResultId, conn, r.header)
+				conn.logger.Warn(LogMsgUnexpectedRequestId,
+					slog.Uint64(LogKeyRequestId, uint64(r.header.RequestId)),
+					slog.String(LogKeyAddress, conn.addrString()),
+				)
 				continue
 			}
 
@@ -927,12 +890,16 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 					ErrProtocolError,
 					fmt.Sprintf("failed to decode IPROTO_EVENT: %s", err),
 				}
-				conn.opts.Logger.Report(LogWatchEventReadFailed, conn, err)
+				conn.logger.Warn(LogMsgWatchEventReadFailed,
+					slog.Any(LogKeyError, err),
+				)
 			}
 			buf.Release()
 		case iproto.IPROTO_CHUNK:
 			buf.Release()
-			conn.opts.Logger.Report(LogBoxSessionPushUnsupported, conn, header)
+			conn.logger.Warn(LogMsgPushUnsupported,
+				slog.Uint64(LogKeyRequestId, uint64(header.RequestId)),
+			)
 		default:
 			resps <- resp{header: header, buf: buf}
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,9 @@ package tarantool_test
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
+	"os"
 	"regexp"
 	"time"
 
@@ -1182,6 +1184,41 @@ func ExampleConnect_reconnects() {
 	}
 	defer func() { _ = conn.Close() }()
 	if conn != nil {
+		fmt.Println("Connection is ready")
+	}
+	// Output:
+	// Connection is ready
+}
+
+// ExampleOpts_Logger demonstrates how to configure a structured logger
+// for the connection. By default, all log output is discarded.
+func ExampleOpts_Logger() {
+	dialer := tarantool.NetDialer{
+		Address:  server,
+		User:     "test",
+		Password: "test",
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+
+	opts := tarantool.Opts{
+		Timeout: 5 * time.Second,
+		Logger:  logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	conn, err := tarantool.Connect(ctx, dialer, opts)
+	if err != nil {
+		fmt.Println("No connection available")
+		return
+	}
+
+	if conn != nil {
+		defer func() { _ = conn.Close() }()
 		fmt.Println("Connection is ready")
 	}
 	// Output:

--- a/log.go
+++ b/log.go
@@ -1,0 +1,33 @@
+package tarantool
+
+const (
+	// LogMsgReconnectFailed is a log message emitted when a reconnection
+	// attempt fails.
+	LogMsgReconnectFailed = "reconnect failed"
+	// LogMsgLastReconnectFailed is a log message emitted when the last
+	// allowed reconnection attempt fails and the connection gives up.
+	LogMsgLastReconnectFailed = "last reconnect failed, giving up"
+	// LogMsgUnexpectedRequestId is a log message emitted when a response
+	// with an unrecognized request ID is received.
+	LogMsgUnexpectedRequestId = "unexpected request ID in response"
+	// LogMsgWatchEventReadFailed is a log message emitted when decoding
+	// of a watch event from the server fails.
+	LogMsgWatchEventReadFailed = "failed to decode watch event"
+	// LogMsgPushUnsupported is a log message emitted when the server sends
+	// a push message but box.session.push() is not supported.
+	LogMsgPushUnsupported = "unsupported box.session.push()"
+)
+
+const (
+	// LogKeyAttempt is a log key for the current reconnection attempt number.
+	LogKeyAttempt = "attempt"
+	// LogKeyMaxAttempts is a log key for the maximum number of reconnection
+	// attempts.
+	LogKeyMaxAttempts = "max_attempts"
+	// LogKeyError is a log key for an error value.
+	LogKeyError = "error"
+	// LogKeyRequestId is a log key for an IPROTO request ID.
+	LogKeyRequestId = "request_id"
+	// LogKeyAddress is a log key for a connection address.
+	LogKeyAddress = "address"
+)

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,194 @@
+package tarantool_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/tarantool/go-tarantool/v3"
+	"github.com/tarantool/go-tarantool/v3/test_helpers"
+)
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestLogMessageConstants(t *testing.T) {
+	msgs := []string{
+		LogMsgReconnectFailed,
+		LogMsgLastReconnectFailed,
+		LogMsgUnexpectedRequestId,
+		LogMsgWatchEventReadFailed,
+		LogMsgPushUnsupported,
+	}
+	for _, msg := range msgs {
+		assert.NotEmpty(t, msg, "log message constant must not be empty")
+	}
+}
+
+func TestLogKeyConstants(t *testing.T) {
+	keys := []string{
+		LogKeyAttempt,
+		LogKeyMaxAttempts,
+		LogKeyError,
+		LogKeyRequestId,
+		LogKeyAddress,
+	}
+	for _, key := range keys {
+		assert.NotEmpty(t, key, "log key constant must not be empty")
+	}
+}
+
+func TestConnectionCustomLogger(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	testOpts := opts
+	testOpts.Logger = logger
+
+	conn := test_helpers.ConnectWithValidation(t, dialer, testOpts)
+	defer func() { _ = conn.Close() }()
+
+	_, err := conn.Do(NewCallRequest("push_func").Args([]any{1})).Get()
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, LogMsgPushUnsupported)
+	require.Contains(t, output, LogKeyRequestId)
+}
+
+func TestConnectionLoggerWithGroup(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	grouped := logger.WithGroup("myapp")
+
+	testOpts := opts
+	testOpts.Logger = grouped
+
+	conn := test_helpers.ConnectWithValidation(t, dialer, testOpts)
+	defer func() { _ = conn.Close() }()
+
+	_, err := conn.Do(NewCallRequest("push_func").Args([]any{1})).Get()
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, "myapp.tarantool")
+	require.Contains(t, output, LogMsgPushUnsupported)
+}
+
+func TestConnectionNilLoggerDiscards(t *testing.T) {
+	testOpts := opts
+	testOpts.Logger = nil
+
+	conn := test_helpers.ConnectWithValidation(t, dialer, testOpts)
+	defer func() { _ = conn.Close() }()
+
+	_, err := conn.Do(NewCallRequest("push_func").Args([]any{1})).Get()
+	require.NoError(t, err)
+}
+
+func TestConnectionUnexpectedRequestId(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf,
+		&slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	dialer := mockIoDialer{
+		init: func(conn *mockIoConn) {
+			conn.read = make(chan struct{})
+			conn.written = make(chan struct{})
+			conn.writeWgDelay = 1
+			conn.readWgDelay = 2
+			conn.readbuf.Write([]byte{
+				0xce, 0x00, 0x00, 0x00, 0x0a,
+				0x82,
+				0x00, 0x00,
+				0x01, 0xce, 0x00, 0x00, 0xde, 0xad,
+				0x80,
+			})
+			conn.wgDoneOnClose = false
+		},
+	}
+
+	ctx, cancel := test_helpers.GetConnectContext()
+	defer cancel()
+
+	conn, err := Connect(ctx, &dialer, Opts{
+		Timeout:    1000 * time.Second,
+		SkipSchema: true,
+		Logger:     logger,
+	})
+	require.NoError(t, err)
+
+	conn.Do(NewPingRequest())
+
+	<-dialer.conn.written
+	dialer.conn.written = nil
+
+	<-dialer.conn.read
+	<-dialer.conn.read
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), LogMsgUnexpectedRequestId)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	output := buf.String()
+	require.Contains(t, output, LogKeyRequestId)
+
+	dialer.conn.writeWg.Done()
+	_ = conn.Close()
+}
+
+func TestConnectionErrorAttributeFormat(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	reconnectOpts := Opts{
+		Timeout:       500 * time.Millisecond,
+		Reconnect:     100 * time.Millisecond,
+		MaxReconnects: 1,
+		Logger:        logger,
+		SkipSchema:    true,
+	}
+
+	_, err := Connect(context.Background(), NetDialer{
+		Address: "127.0.0.1:0",
+	}, reconnectOpts)
+	require.Error(t, err)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), LogMsgReconnectFailed)
+	}, 3*time.Second, 50*time.Millisecond)
+
+	output := buf.String()
+	assert.Contains(t, output, LogKeyError)
+	assert.Contains(t, output, LogKeyAttempt)
+	assert.Contains(t, output, LogKeyMaxAttempts)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), LogMsgLastReconnectFailed)
+	}, 3*time.Second, 50*time.Millisecond)
+
+	output = buf.String()
+	assert.Contains(t, output, LogKeyError)
+	assert.Contains(t, output, LogKeyAddress)
+}

--- a/pool/log.go
+++ b/pool/log.go
@@ -1,0 +1,35 @@
+package pool
+
+const (
+	// LogMsgConnectFailed is a log message emitted when a connection
+	// attempt to a pool instance fails.
+	LogMsgConnectFailed = "connect failed"
+	// LogMsgInitWatchersFailed is a log message emitted when initialization
+	// of watchers for a pool instance connection fails.
+	LogMsgInitWatchersFailed = "failed to initialize watchers"
+	// LogMsgStoringConnectionCanceled is a log message emitted when storing
+	// a discovered connection is canceled by the Handler.Discovered callback.
+	LogMsgStoringConnectionCanceled = "storing connection canceled"
+	// LogMsgDeactivatingFailed is a log message emitted when the
+	// Handler.Deactivated callback returns an error during connection
+	// deactivation.
+	LogMsgDeactivatingFailed = "handler deactivation failed"
+	// LogMsgStoringConnectionFailed is a log message emitted when storing
+	// a connection fails due to a role detection error.
+	LogMsgStoringConnectionFailed = "storing connection failed"
+	// LogMsgReconnectFailed is a log message emitted when a reconnection
+	// attempt for a pool instance fails.
+	LogMsgReconnectFailed = "reconnect failed"
+	// LogMsgReopenFailed is a log message emitted when reopening a
+	// connection for a pool instance fails.
+	LogMsgReopenFailed = "reopen connection failed"
+)
+
+const (
+	// LogKeyInstance is a log key for a pool instance name.
+	LogKeyInstance = "instance"
+	// LogKeyError is a log key for an error value.
+	// It intentionally mirrors tarantool.LogKeyError to avoid an
+	// inter-package dependency.
+	LogKeyError = "error"
+)

--- a/pool/log_test.go
+++ b/pool/log_test.go
@@ -1,0 +1,370 @@
+package pool_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-tarantool/v3"
+	"github.com/tarantool/go-tarantool/v3/pool"
+	"github.com/tarantool/go-tarantool/v3/test_helpers"
+)
+
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+type cancelDiscoveryHandler struct{}
+
+func (h *cancelDiscoveryHandler) Discovered(_ string, _ *tarantool.Connection, _ pool.Role) error {
+	return errors.New("discovery canceled")
+}
+
+func (h *cancelDiscoveryHandler) Deactivated(_ string, _ *tarantool.Connection, _ pool.Role) error {
+	return nil
+}
+
+type failDeactivationHandler struct{}
+
+func (h *failDeactivationHandler) Discovered(_ string, _ *tarantool.Connection, _ pool.Role) error {
+	return nil
+}
+
+func (h *failDeactivationHandler) Deactivated(
+	_ string, _ *tarantool.Connection, _ pool.Role,
+) error {
+	return errors.New("deactivation failed")
+}
+
+type mockIoAddr struct{}
+
+func (a mockIoAddr) Network() string { return "tcp" }
+func (a mockIoAddr) String() string  { return "mock:0" }
+
+type mockIoConn struct {
+	readbuf bytes.Buffer
+	readWg  sync.WaitGroup
+	readCnt int
+	writeWg sync.WaitGroup
+	closeWg sync.WaitGroup
+}
+
+func newMockIoConn(response []byte) *mockIoConn {
+	c := &mockIoConn{}
+	c.readbuf.Write(response)
+	c.readWg.Add(1)
+	c.writeWg.Add(1)
+	c.closeWg.Add(1)
+	return c
+}
+
+func (m *mockIoConn) Read(b []byte) (int, error) {
+	n, err := m.readbuf.Read(b)
+	if err != nil {
+		m.readWg.Wait()
+		n, err = m.readbuf.Read(b)
+	}
+	m.readCnt++
+	return n, err
+}
+
+func (m *mockIoConn) Write(_ []byte) (int, error) {
+	m.writeWg.Wait()
+	return 0, nil
+}
+
+func (m *mockIoConn) Flush() error { return nil }
+
+func (m *mockIoConn) Close() error {
+	m.readWg.Done()
+	m.writeWg.Done()
+	m.closeWg.Done()
+	return nil
+}
+
+func (m *mockIoConn) Greeting() tarantool.Greeting {
+	return tarantool.Greeting{}
+}
+
+func (m *mockIoConn) ProtocolInfo() tarantool.ProtocolInfo {
+	return tarantool.ProtocolInfo{}
+}
+
+func (m *mockIoConn) Addr() net.Addr { return mockIoAddr{} }
+
+type mockIoDialer struct {
+	conn *mockIoConn
+}
+
+func (d *mockIoDialer) Dial(_ context.Context, _ tarantool.DialOpts) (tarantool.Conn, error) {
+	return d.conn, nil
+}
+
+// unexpectedRequestIdResponse is an IPROTO response with sync=0xDEAD,
+// which will never match any registered future.
+var unexpectedRequestIdResponse = []byte{
+	0xce, 0x00, 0x00, 0x00, 0x0a, // Length = 10.
+	0x82,       // Header map (2 entries).
+	0x00, 0x00, // IPROTO_REQUEST_TYPE = 0 (OK).
+	0x01, 0xce, 0x00, 0x00, 0xde, 0xad, // IPROTO_SYNC = 0xDEAD.
+	0x80, // Body: empty map.
+}
+
+func TestPoolLogMessageConstants(t *testing.T) {
+	msgs := []string{
+		pool.LogMsgConnectFailed,
+		pool.LogMsgInitWatchersFailed,
+		pool.LogMsgStoringConnectionCanceled,
+		pool.LogMsgDeactivatingFailed,
+		pool.LogMsgStoringConnectionFailed,
+		pool.LogMsgReconnectFailed,
+		pool.LogMsgReopenFailed,
+	}
+	for _, msg := range msgs {
+		assert.NotEmpty(t, msg, "log message constant must not be empty")
+	}
+}
+
+func TestPoolLogKeyConstants(t *testing.T) {
+	keys := []string{
+		pool.LogKeyInstance,
+		pool.LogKeyError,
+	}
+	for _, key := range keys {
+		assert.NotEmpty(t, key, "log key constant must not be empty")
+	}
+}
+
+func TestPoolCustomLogger(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       logger,
+	}
+
+	badInstance := pool.Instance{
+		Name: "unreachable",
+		Dialer: tarantool.NetDialer{
+			Address: "127.0.0.1:0",
+		},
+		Opts: tarantool.Opts{
+			Timeout:    500 * time.Millisecond,
+			SkipSchema: true,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, []pool.Instance{badInstance}, poolOpts)
+	require.NoError(t, err)
+	defer func() { _ = connPool.Close() }()
+
+	output := buf.String()
+	require.Contains(t, output, pool.LogMsgConnectFailed)
+	require.Contains(t, output, pool.LogKeyInstance)
+	require.Contains(t, output, pool.LogKeyError)
+}
+
+func TestPoolLoggerWithGroup(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	grouped := logger.WithGroup("myapp")
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       grouped,
+	}
+
+	badInstance := pool.Instance{
+		Name: "unreachable",
+		Dialer: tarantool.NetDialer{
+			Address: "127.0.0.1:0",
+		},
+		Opts: tarantool.Opts{
+			Timeout:    500 * time.Millisecond,
+			SkipSchema: true,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, []pool.Instance{badInstance}, poolOpts)
+	require.NoError(t, err)
+	defer func() { _ = connPool.Close() }()
+
+	output := buf.String()
+	require.Contains(t, output, "myapp.tarantool.pool")
+}
+
+func TestPoolNilLoggerDiscards(t *testing.T) {
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       nil,
+	}
+
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, instances, poolOpts)
+	require.NoError(t, err)
+	defer func() { _ = connPool.Close() }()
+}
+
+func TestPoolLoggerStoringConnectionCanceled(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       logger,
+		Handler:      &cancelDiscoveryHandler{},
+	}
+
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, instances, poolOpts)
+	require.NoError(t, err)
+	defer func() { _ = connPool.Close() }()
+
+	output := buf.String()
+	require.Contains(t, output, pool.LogMsgStoringConnectionCanceled)
+	require.Contains(t, output, pool.LogKeyInstance)
+	require.Contains(t, output, pool.LogKeyError)
+}
+
+func TestPoolLoggerDeactivatingFailed(t *testing.T) {
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       logger,
+		Handler:      &failDeactivationHandler{},
+	}
+
+	ctx, cancel := test_helpers.GetPoolConnectContext()
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, instances, poolOpts)
+	require.NoError(t, err)
+
+	require.NoError(t, connPool.Close())
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(buf.String(), pool.LogMsgDeactivatingFailed)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	output := buf.String()
+	require.Contains(t, output, pool.LogKeyInstance)
+	require.Contains(t, output, pool.LogKeyError)
+}
+
+func TestPoolLoggerInheritedByConnections(t *testing.T) {
+	var poolBuf safeBuffer
+	poolLogger := slog.New(slog.NewTextHandler(&poolBuf,
+		&slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	mockConn := newMockIoConn(unexpectedRequestIdResponse)
+	dialer := &mockIoDialer{conn: mockConn}
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       poolLogger,
+	}
+
+	mockInstance := pool.Instance{
+		Name:   "mock_inherited",
+		Dialer: dialer,
+		Opts: tarantool.Opts{
+			Timeout:    500 * time.Millisecond,
+			SkipSchema: true,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, []pool.Instance{mockInstance}, poolOpts)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(poolBuf.String(), tarantool.LogMsgUnexpectedRequestId)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	output := poolBuf.String()
+	require.Contains(t, output, tarantool.LogMsgUnexpectedRequestId)
+	require.Contains(t, output, "tarantool.")
+
+	require.NoError(t, connPool.Close())
+}
+
+func TestPoolLoggerNotInheritedWhenInstanceHasOwn(t *testing.T) {
+	var poolBuf, instanceBuf safeBuffer
+	poolLogger := slog.New(slog.NewTextHandler(&poolBuf,
+		&slog.HandlerOptions{Level: slog.LevelWarn}))
+	instanceLogger := slog.New(slog.NewTextHandler(&instanceBuf,
+		&slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	mockConn := newMockIoConn(unexpectedRequestIdResponse)
+	dialer := &mockIoDialer{conn: mockConn}
+
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       poolLogger,
+	}
+
+	mockInstance := pool.Instance{
+		Name:   "mock_own_logger",
+		Dialer: dialer,
+		Opts: tarantool.Opts{
+			Timeout:    500 * time.Millisecond,
+			SkipSchema: true,
+			Logger:     instanceLogger,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	connPool, err := pool.NewWithOpts(ctx, []pool.Instance{mockInstance}, poolOpts)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(instanceBuf.String(), tarantool.LogMsgUnexpectedRequestId)
+	}, 2*time.Second, 50*time.Millisecond)
+
+	instanceOutput := instanceBuf.String()
+	poolOutput := poolBuf.String()
+	require.Contains(t, instanceOutput, tarantool.LogMsgUnexpectedRequestId)
+	require.Contains(t, instanceOutput, "tarantool")
+	require.NotContains(t, poolOutput, tarantool.LogMsgUnexpectedRequestId)
+
+	require.NoError(t, connPool.Close())
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -107,6 +107,13 @@ type Opts struct {
 	CheckTimeout time.Duration
 	// Handler provides an ability to handle connection updates.
 	Handler Handler
+	// Logger is a structured logger for the pool. If nil, logs are
+	// discarded. If non-nil, the logger is automatically wrapped with
+	// WithGroup("tarantool.pool") to namespace library attributes.
+	//
+	// If a logger is not set in connection opts, the pool logger will
+	// be set for each connection automatically.
+	Logger *slog.Logger
 }
 
 /*
@@ -133,7 +140,12 @@ type Pool struct {
 	ends      map[string]*endpoint
 	endsMutex sync.RWMutex
 
-	opts Opts
+	opts   Opts
+	logger *slog.Logger
+	// rawLogger is the original logger without a WithGroup wrapper.
+	// It is passed to child connections so they can apply their own
+	// WithGroup("tarantool") namespace.
+	rawLogger *slog.Logger
 
 	state            state
 	done             chan struct{}
@@ -227,6 +239,13 @@ func NewWithOpts(ctx context.Context, instances []Instance,
 		rwPool:  rwPool,
 		roPool:  roPool,
 		anyPool: anyPool,
+	}
+
+	if opts.Logger == nil {
+		p.logger = slog.New(slog.DiscardHandler)
+	} else {
+		p.logger = opts.Logger.WithGroup("tarantool.pool")
+		p.rawLogger = opts.Logger
 	}
 
 	fillCtx, fillCancel := context.WithCancel(ctx)
@@ -371,7 +390,10 @@ func (p *Pool) Add(ctx context.Context, instance Instance) error {
 			close(e.closed)
 			return err
 		} else {
-			log.Printf("tarantool: connect to %s failed: %s\n", instance.Name, err)
+			p.logger.Warn(LogMsgConnectFailed,
+				slog.String(LogKeyInstance, instance.Name),
+				slog.Any(LogKeyError, err),
+			)
 		}
 	}
 
@@ -716,7 +738,10 @@ func (p *Pool) addConnection(name string,
 			for _, watcher := range watched {
 				watcher.unwatch(conn)
 			}
-			log.Printf("tarantool: failed initialize watchers for %s: %s", name, err)
+			p.logger.Warn(LogMsgInitWatchersFailed,
+				slog.String(LogKeyInstance, name),
+				slog.Any(LogKeyError, err),
+			)
 			return err
 		}
 	}
@@ -740,7 +765,10 @@ func (p *Pool) handlerDiscovered(name string, conn *tarantool.Connection,
 	}
 
 	if err != nil {
-		log.Printf("tarantool: storing connection to %s canceled: %s\n", name, err)
+		p.logger.Warn(LogMsgStoringConnectionCanceled,
+			slog.String(LogKeyInstance, name),
+			slog.Any(LogKeyError, err),
+		)
 		return false
 	}
 	return true
@@ -754,8 +782,10 @@ func (p *Pool) handlerDeactivated(name string, conn *tarantool.Connection,
 	}
 
 	if err != nil {
-		log.Printf("tarantool: deactivating connection to %s by user failed: %s\n",
-			name, err)
+		p.logger.Warn(LogMsgDeactivatingFailed,
+			slog.String(LogKeyInstance, name),
+			slog.Any(LogKeyError, err),
+		)
 	}
 }
 
@@ -774,7 +804,10 @@ func (p *Pool) fillPools(ctx context.Context, instances []Instance) <-chan error
 
 		go func() {
 			if err := p.tryConnect(ctx, end); err != nil {
-				log.Printf("tarantool: connect to %s failed: %s\n", name, err)
+				p.logger.Warn(LogMsgConnectFailed,
+					slog.String(LogKeyInstance, name),
+					slog.Any(LogKeyError, err),
+				)
 				done <- fmt.Errorf("failed to connect to %s :%w", name, err)
 
 				return
@@ -851,6 +884,9 @@ func (p *Pool) tryConnect(ctx context.Context, e *endpoint) error {
 
 	connOpts := e.opts
 	connOpts.Notify = e.notify
+	if connOpts.Logger == nil && p.rawLogger != nil {
+		connOpts.Logger = p.rawLogger
+	}
 	conn, err := tarantool.Connect(ctx, e.dialer, connOpts)
 
 	p.poolsMutex.Lock()
@@ -870,8 +906,10 @@ func (p *Pool) tryConnect(ctx context.Context, e *endpoint) error {
 
 		if err != nil {
 			_ = conn.Close()
-			log.Printf("tarantool: storing connection to %s failed: %s\n",
-				e.name, err)
+			p.logger.Warn(LogMsgStoringConnectionFailed,
+				slog.String(LogKeyInstance, e.name),
+				slog.Any(LogKeyError, err),
+			)
 			return err
 		}
 
@@ -919,7 +957,10 @@ func (p *Pool) reconnect(ctx context.Context, e *endpoint) {
 	e.role = RoleUnknown
 
 	if err := p.tryConnect(ctx, e); err != nil {
-		log.Printf("tarantool: reconnect to %s failed: %s\n", e.name, err)
+		p.logger.Warn(LogMsgReconnectFailed,
+			slog.String(LogKeyInstance, e.name),
+			slog.Any(LogKeyError, err),
+		)
 	}
 }
 
@@ -1010,8 +1051,10 @@ func (p *Pool) controller(ctx context.Context, e *endpoint) {
 					switch {
 					case e.conn == nil:
 						if err := p.tryConnect(ctx, e); err != nil {
-							log.Printf("tarantool: reopen connection to %s failed: %s\n",
-								e.name, err)
+							p.logger.Warn(LogMsgReopenFailed,
+								slog.String(LogKeyInstance, e.name),
+								slog.Any(LogKeyError, err),
+							)
 						}
 					case !e.conn.ClosedNow():
 						p.updateConnection(e)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1,10 +1,10 @@
 package pool_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -391,24 +391,29 @@ func TestConn_no_execute_supported(t *testing.T) {
 func TestConn_no_execute_unsupported(t *testing.T) {
 	test_helpers.SkipIfWatchOnceSupported(t)
 
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	healthyServ := servers[0]
 
+	poolOpts := pool.Opts{
+		CheckTimeout: 1 * time.Second,
+		Logger:       logger,
+	}
+
 	ctx, cancel := test_helpers.GetPoolConnectContext()
 	defer cancel()
-	connPool, err := pool.New(ctx,
-		[]pool.Instance{makeNoExecuteInstance(healthyServ, connOpts)})
+	connPool, err := pool.NewWithOpts(ctx,
+		[]pool.Instance{makeNoExecuteInstance(healthyServ, connOpts)}, poolOpts)
 	require.NoErrorf(t, err, "failed to connect")
 	require.NotNilf(t, connPool, "conn is nil after Connect")
 
 	defer func() { _ = connPool.Close() }()
 
-	require.Contains(t, buf.String(),
-		fmt.Sprintf("connect to %s failed: Execute access to function "+
-			"'box.info' is denied for user '%s'", servers[0], userNoExec))
+	output := buf.String()
+	require.Contains(t, output, pool.LogMsgConnectFailed)
+	require.Contains(t, output, pool.LogKeyInstance)
+	require.Contains(t, output, healthyServ)
 
 	args := test_helpers.CheckStatusesArgs{
 		Pool:               connPool,
@@ -1483,18 +1488,18 @@ func TestHandlerOpenUpdateClose(t *testing.T) {
 }
 
 type testAddErrorHandler struct {
-	discovered, deactivated int
+	discovered, deactivated uint32
 }
 
 func (h *testAddErrorHandler) Discovered(name string, conn *tarantool.Connection,
 	role pool.Role) error {
-	h.discovered++
+	atomic.AddUint32(&h.discovered, 1)
 	return fmt.Errorf("any error")
 }
 
 func (h *testAddErrorHandler) Deactivated(name string, conn *tarantool.Connection,
 	role pool.Role) error {
-	h.deactivated++
+	atomic.AddUint32(&h.deactivated, 1)
 	return nil
 }
 
@@ -1526,8 +1531,10 @@ func TestHandlerOpenError(t *testing.T) {
 
 	// It could happen additional reconnect attempts in the background, but
 	// at least 2 connects on start.
-	require.GreaterOrEqualf(t, h.discovered, 2, "unexpected discovered count")
-	require.Equalf(t, 0, h.deactivated, "unexpected deactivated count")
+	require.GreaterOrEqualf(t, atomic.LoadUint32(&h.discovered), uint32(2),
+		"unexpected discovered count")
+	require.Equalf(t, uint32(0), atomic.LoadUint32(&h.deactivated),
+		"unexpected deactivated count")
 }
 
 type testUpdateErrorHandler struct {

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -1,12 +1,12 @@
 package tarantool_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"math"
 	"os"
 	"os/exec"
@@ -2371,21 +2371,20 @@ func TestStream_DoWithClosedConn(t *testing.T) {
 }
 
 func TestConnectionBoxSessionPushUnsupported(t *testing.T) {
-	old := log.Writer()
-	defer log.SetOutput(old)
+	var buf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	var buf bytes.Buffer
-	log.SetOutput(&buf)
+	testOpts := opts
+	testOpts.Logger = logger
 
-	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
+	conn := test_helpers.ConnectWithValidation(t, dialer, testOpts)
 	defer func() { _ = conn.Close() }()
 
 	_, err := conn.Do(NewCallRequest("push_func").Args([]any{1})).Get()
 	require.NoError(t, err)
 
 	actualLog := buf.String()
-	expectedLog := "unsupported box.session.push()"
-	require.Contains(t, actualLog, expectedLog)
+	require.Contains(t, actualLog, LogMsgPushUnsupported)
 }
 
 func TestConnectionProtocolInfoSupported(t *testing.T) {


### PR DESCRIPTION
The library defined a custom Logger interface that users had to implement for connection logging. This created unnecessary friction because Go 1.21 introduced the standard log/slog package, which is now the idiomatic way to do structured logging in the ecosystem.

Using a custom interface prevented users from plugging in existing slog handlers, level filters, and third-party loggers without writing adapter code. It also forced the library to maintain its own logging abstraction instead of relying on the standard library.

Replace the Logger interface and ConnLogKind constants with *slog.Logger. Connection logs are now emitted via slog.Warn with structured attributes. The pool no longer uses log.Printf for errors; it uses the same slog-based approach with a "tarantool.pool" group namespace.

By default, both connection and pool log output is discarded. Users who previously relied on the implicit stderr logging must now explicitly provide a *slog.Logger in Opts.Logger.

See MIGRATION.md for the full migration guide, including before and after examples.

Closes #504
Closes #562
