### PR TITLE
request: switch all request types to value receivers and value returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Changed
 
+* All top-level `New*Request()` constructors now return values instead of
+  pointers. All methods on request types use value receivers and return
+  values, enabling immutable builder-style chaining.
+* Renamed value constructors `Make*` to `New*` for naming consistency across
+  the connector. Affects `crud.Make*Request` (now `crud.New*Request`),
+  `datetime.MakeDatetime` (now `datetime.NewDatetime`), `decimal.MakeDecimal`
+  and `decimal.MakeDecimalFromString` (now `decimal.NewDecimal` and
+  `decimal.NewDecimalFromString`), `decimal.MustMakeDecimal` (now
+  `decimal.MustNewDecimal`), `arrow.MakeArrow` (now `arrow.NewArrow`), and
+  `crud.MakeResult` (now `crud.NewResult`).
+* Removed intermediate `spaceRequest`, `spaceIndexRequest` types — `space`
+  and `index` fields are now inlined directly into each request struct.
+  The same flattening was applied to `crud.spaceRequest`.
 * Required Go version is `1.24` now (#456).
 * `test_helpers.MockDoer` is now an interface instead of a struct. The
   `Requests` field became a method `Requests()`. The `NewMockDoer()`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -182,6 +182,51 @@ TODO
   stream, _ := conn.NewStream()
   log.Printf("opened stream on %v", conn)
   ```
+* All request types (`PingRequest`, `SelectRequest`, `CallRequest`, etc.) now
+  use value receivers and constructors return values instead of pointers.
+  Builder methods return modified copies instead of mutating in place.
+
+  **Breaking**: calling a builder method without using its return value silently
+  discards the change:
+  ```Go
+  // Before (pointer receivers, mutation in place):
+  req := NewSelectRequest("space")
+  req.Index("idx")           // mutated req directly
+  conn.Do(req)
+
+  // After (value receivers, must use return value):
+  req := NewSelectRequest("space")
+  req = req.Index("idx")     // must reassign
+  conn.Do(req)
+
+  // Or chain directly:
+  conn.Do(NewSelectRequest("space").Index("idx"))
+  ```
+
+  The same value-receiver pattern was applied to `arrow.InsertRequest` and
+  `settings.SetRequest`/`settings.GetRequest`.
+
+  In the `box` subpackage, request types (`InfoRequest`, `UserExistsRequest`,
+  `UserCreateRequest`, `SessionSuRequest`, etc.) no longer embed
+  `tarantool.CallRequest`. They store it as a private field and implement
+  their own `Context()` method returning the wrapper type. Usage stays clean:
+  ```Go
+  req := box.NewUserExistsRequest(username).Context(ctx)
+  ```
+* Renamed value constructors from `Make*` to `New*` for naming consistency
+  across the connector. Previously, the main package used `New*Request` while
+  the `crud` package and value-type constructors used `Make*`. They now all
+  use the `New*` prefix.
+
+  | Before | After |
+  |---|---|
+  | `datetime.MakeDatetime` | `datetime.NewDatetime` |
+  | `decimal.MakeDecimal` | `decimal.NewDecimal` |
+  | `decimal.MakeDecimalFromString` | `decimal.NewDecimalFromString` |
+  | `decimal.MustMakeDecimal` | `decimal.MustNewDecimal` |
+  | `arrow.MakeArrow` | `arrow.NewArrow` |
+  | `crud.MakeResult` | `crud.NewResult` |
+  | `crud.Make*Request` (all of them) | `crud.New*Request` |
 
 ## Migration from v1.x.x to v2.x.x
 
@@ -440,12 +485,13 @@ is supported.
 
 Now you need to use objects of the Datetime type instead of pointers to it. A
 new constructor `MakeDatetime` returns an object. `NewDatetime` has been
-removed.
+removed. (`MakeDatetime` was later renamed back to `NewDatetime` in v3.)
 
 ### decimal package
 
 Now you need to use objects of the Decimal type instead of pointers to it. A
 new constructor `MakeDecimal` returns an object. `NewDecimal` has been removed.
+(`MakeDecimal` was later renamed back to `NewDecimal` in v3.)
 
 ### multi package
 

--- a/arrow/arrow.go
+++ b/arrow/arrow.go
@@ -17,9 +17,9 @@ type Arrow struct {
 	data []byte
 }
 
-// MakeArrow returns a new arrow.Arrow object that contains
+// NewArrow returns a new arrow.Arrow object that contains
 // wrapped a raw arrow data buffer.
-func MakeArrow(arrow []byte) (Arrow, error) {
+func NewArrow(arrow []byte) (Arrow, error) {
 	return Arrow{arrow}, nil
 }
 

--- a/arrow/arrow_gen_test.go
+++ b/arrow/arrow_gen_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSomeOptionalArrow(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
 	opt := SomeOptionalArrow(val)
 
@@ -33,7 +33,7 @@ func TestNoneOptionalArrow(t *testing.T) {
 }
 
 func TestOptionalArrow_MustGet(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
 	optSome := SomeOptionalArrow(val)
 	optNone := NoneOptionalArrow()
@@ -43,7 +43,7 @@ func TestOptionalArrow_MustGet(t *testing.T) {
 }
 
 func TestOptionalArrow_Unwrap(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
 	optSome := SomeOptionalArrow(val)
 	optNone := NoneOptionalArrow()
@@ -53,9 +53,9 @@ func TestOptionalArrow_Unwrap(t *testing.T) {
 }
 
 func TestOptionalArrow_UnwrapOr(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
-	def, err := MakeArrow([]byte{4, 5, 6})
+	def, err := NewArrow([]byte{4, 5, 6})
 	require.NoError(t, err)
 	optSome := SomeOptionalArrow(val)
 	optNone := NoneOptionalArrow()
@@ -65,9 +65,9 @@ func TestOptionalArrow_UnwrapOr(t *testing.T) {
 }
 
 func TestOptionalArrow_UnwrapOrElse(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
-	def, err := MakeArrow([]byte{4, 5, 6})
+	def, err := NewArrow([]byte{4, 5, 6})
 	require.NoError(t, err)
 	optSome := SomeOptionalArrow(val)
 	optNone := NoneOptionalArrow()
@@ -77,7 +77,7 @@ func TestOptionalArrow_UnwrapOrElse(t *testing.T) {
 }
 
 func TestOptionalArrow_EncodeDecodeMsgpack_Some(t *testing.T) {
-	val, err := MakeArrow([]byte{1, 2, 3})
+	val, err := NewArrow([]byte{1, 2, 3})
 	require.NoError(t, err)
 	some := SomeOptionalArrow(val)
 

--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -72,7 +72,7 @@ func TestEncodeArrow(t *testing.T) {
 			buf := bytes.NewBuffer([]byte{})
 			enc := msgpack.NewEncoder(buf)
 
-			arr, err := arrow.MakeArrow(tt.arr)
+			arr, err := arrow.NewArrow(tt.arr)
 			require.NoError(t, err)
 
 			err = enc.Encode(arr)

--- a/arrow/example_test.go
+++ b/arrow/example_test.go
@@ -42,7 +42,7 @@ func Example() {
 		log.Fatalf("Failed to connect: %s", err)
 	}
 
-	arr, err := arrow.MakeArrow(arrowBinData)
+	arr, err := arrow.NewArrow(arrowBinData)
 	if err != nil {
 		log.Fatalf("Failed prepare Arrow data: %s", err)
 	}

--- a/arrow/request.go
+++ b/arrow/request.go
@@ -19,25 +19,25 @@ type InsertRequest struct {
 }
 
 // NewInsertRequest returns a new InsertRequest.
-func NewInsertRequest(space any, arrow Arrow) *InsertRequest {
-	return &InsertRequest{
+func NewInsertRequest(space any, arrow Arrow) InsertRequest {
+	return InsertRequest{
 		space: space,
 		arrow: arrow,
 	}
 }
 
 // Type returns a IPROTO_INSERT_ARROW type for the request.
-func (r *InsertRequest) Type() iproto.Type {
+func (r InsertRequest) Type() iproto.Type {
 	return iproto.IPROTO_INSERT_ARROW
 }
 
 // Async returns false to the request return a response.
-func (r *InsertRequest) Async() bool {
+func (r InsertRequest) Async() bool {
 	return false
 }
 
 // Ctx returns a context of the request.
-func (r *InsertRequest) Ctx() context.Context {
+func (r InsertRequest) Ctx() context.Context {
 	return r.ctx
 }
 
@@ -47,20 +47,20 @@ func (r *InsertRequest) Ctx() context.Context {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (r *InsertRequest) Context(ctx context.Context) *InsertRequest {
+func (r InsertRequest) Context(ctx context.Context) InsertRequest {
 	r.ctx = ctx
 	return r
 }
 
 // Arrow sets the arrow for insertion the insert arrow request.
 // Note: default value is nil.
-func (r *InsertRequest) Arrow(arrow Arrow) *InsertRequest {
+func (r InsertRequest) Arrow(arrow Arrow) InsertRequest {
 	r.arrow = arrow
 	return r
 }
 
 // Body fills an msgpack.Encoder with the insert arrow request body.
-func (r *InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (r InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (r *InsertRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder)
 }
 
 // Response creates a response for the InsertRequest.
-func (r *InsertRequest) Response(
+func (r InsertRequest) Response(
 	header tarantool.Header,
 	body io.Reader,
 ) (tarantool.Response, error) {

--- a/arrow/request_test.go
+++ b/arrow/request_test.go
@@ -129,7 +129,7 @@ func TestInsertRequestSetters(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	enc := msgpack.NewEncoder(buf)
 
-	arr, err := arrow.MakeArrow([]byte{'a', 'b', 'c'})
+	arr, err := arrow.NewArrow([]byte{'a', 'b', 'c'})
 	require.NoError(t, err)
 
 	resolver := stubSchemeResolver{validSpace}

--- a/arrow/tarantool_test.go
+++ b/arrow/tarantool_test.go
@@ -71,7 +71,7 @@ func TestInsert_invalid(t *testing.T) {
 			data, err := hex.DecodeString(a.arrow)
 			require.NoError(t, err)
 
-			arr, err := arrow.MakeArrow(data)
+			arr, err := arrow.NewArrow(data)
 			require.NoError(t, err)
 
 			req := arrow.NewInsertRequest(space, arr)

--- a/box/info.go
+++ b/box/info.go
@@ -1,6 +1,7 @@
 package box
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmihailenco/msgpack/v5"
@@ -8,7 +9,7 @@ import (
 	"github.com/tarantool/go-tarantool/v3"
 )
 
-var _ tarantool.Request = (*InfoRequest)(nil)
+var _ tarantool.Request = InfoRequest{}
 
 // Info represents detailed information about the Tarantool instance.
 // It includes version, node ID, read-only status, process ID, cluster information, and more.
@@ -112,14 +113,20 @@ func (ir *InfoResponse) DecodeMsgpack(d *msgpack.Decoder) error {
 // InfoRequest represents a request to retrieve information about the Tarantool instance.
 // It implements the tarantool.Request interface.
 type InfoRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewInfoRequest returns a new empty info request.
 func NewInfoRequest() InfoRequest {
-	callReq := tarantool.NewCallRequest("box.info")
-
 	return InfoRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{
+			call: tarantool.NewCallRequest("box.info"),
+		},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req InfoRequest) Context(ctx context.Context) InfoRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }

--- a/box/request.go
+++ b/box/request.go
@@ -1,0 +1,44 @@
+package box
+
+import (
+	"context"
+	"io"
+
+	"github.com/tarantool/go-iproto"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/tarantool/go-tarantool/v3"
+)
+
+// baseCallRequest wraps a tarantool.CallRequest and implements
+// the tarantool.Request interface by delegation.
+type baseCallRequest struct {
+	call tarantool.CallRequest
+}
+
+// Type returns IPROTO type for the request.
+func (req baseCallRequest) Type() iproto.Type {
+	return req.call.Type()
+}
+
+// Body fills an encoder with the request body.
+func (req baseCallRequest) Body(res tarantool.SchemaResolver,
+	enc *msgpack.Encoder) error {
+	return req.call.Body(res, enc)
+}
+
+// Ctx returns a context of the request.
+func (req baseCallRequest) Ctx() context.Context {
+	return req.call.Ctx()
+}
+
+// Async returns whether the request expects a response.
+func (req baseCallRequest) Async() bool {
+	return req.call.Async()
+}
+
+// Response creates a response for the request.
+func (req baseCallRequest) Response(header tarantool.Header,
+	body io.Reader) (tarantool.Response, error) {
+	return req.call.Response(header, body)
+}

--- a/box/schema_user.go
+++ b/box/schema_user.go
@@ -24,7 +24,7 @@ func newSchemaUser(conn tarantool.Doer) *SchemaUser {
 
 // UserExistsRequest represents a request to check if a user exists in Tarantool.
 type UserExistsRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // UserExistsResponse represents the response to a user existence check.
@@ -55,8 +55,14 @@ func NewUserExistsRequest(username string) UserExistsRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.exists").Args([]any{username})
 
 	return UserExistsRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserExistsRequest) Context(ctx context.Context) UserExistsRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Exists checks if the specified user exists in Tarantool.
@@ -81,7 +87,7 @@ type UserCreateOptions struct {
 
 // UserCreateRequest represents a request to create a new user in Tarantool.
 type UserCreateRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserCreateRequest creates a new request to create a user with specified options.
@@ -90,8 +96,14 @@ func NewUserCreateRequest(username string, options UserCreateOptions) UserCreate
 		Args([]any{username, options})
 
 	return UserCreateRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserCreateRequest) Context(ctx context.Context) UserCreateRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserCreateResponse represents the response to a user creation request.
@@ -127,7 +139,7 @@ type UserDropOptions struct {
 
 // UserDropRequest represents a request to drop a user from Tarantool.
 type UserDropRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserDropRequest creates a new request to drop a user with specified options.
@@ -136,8 +148,14 @@ func NewUserDropRequest(username string, options UserDropOptions) UserDropReques
 		Args([]any{username, options})
 
 	return UserDropRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserDropRequest) Context(ctx context.Context) UserDropRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserDropResponse represents the response to a user drop request.
@@ -162,7 +180,7 @@ func (u *SchemaUser) Drop(ctx context.Context, username string, options UserDrop
 
 // UserPasswordRequest represents a request to retrieve a user's password from Tarantool.
 type UserPasswordRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserPasswordRequest creates a new request to fetch the user's password.
@@ -172,8 +190,14 @@ func NewUserPasswordRequest(username string) UserPasswordRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.password").Args([]any{username})
 
 	return UserPasswordRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserPasswordRequest) Context(ctx context.Context) UserPasswordRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserPasswordResponse represents the response to the user password request.
@@ -225,7 +249,7 @@ func (u *SchemaUser) Password(ctx context.Context, password string) (string, err
 
 // UserPasswdRequest represents a request to change a user's password in Tarantool.
 type UserPasswdRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserPasswdRequest creates a new request to change  a user's password in Tarantool.
@@ -234,14 +258,20 @@ func NewUserPasswdRequest(args ...string) (UserPasswdRequest, error) {
 
 	switch len(args) {
 	case 1:
-		callReq.Args([]any{args[0]})
+		callReq = callReq.Args([]any{args[0]})
 	case 2:
-		callReq.Args([]any{args[0], args[1]})
+		callReq = callReq.Args([]any{args[0], args[1]})
 	default:
 		return UserPasswdRequest{}, fmt.Errorf("len of fields must be 1 or 2, got %d", len(args))
 	}
 
-	return UserPasswdRequest{callReq}, nil
+	return UserPasswdRequest{baseCallRequest: baseCallRequest{call: callReq}}, nil
+}
+
+// Context sets a passed context to the request.
+func (req UserPasswdRequest) Context(ctx context.Context) UserPasswdRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserPasswdResponse represents the response to a user passwd request.
@@ -257,7 +287,7 @@ func (u *SchemaUser) Passwd(ctx context.Context, args ...string) error {
 		return err
 	}
 
-	req.Context(ctx)
+	req = req.Context(ctx)
 
 	resp := &UserPasswdResponse{}
 
@@ -274,7 +304,7 @@ func (u *SchemaUser) Passwd(ctx context.Context, args ...string) error {
 
 // UserInfoRequest represents a request to get a user's info in Tarantool.
 type UserInfoRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserInfoRequest creates a new request to get user privileges.
@@ -282,8 +312,14 @@ func NewUserInfoRequest(username string) UserInfoRequest {
 	callReq := tarantool.NewCallRequest("box.schema.user.info").Args([]any{username})
 
 	return UserInfoRequest{
-		callReq,
+		baseCallRequest: baseCallRequest{call: callReq},
 	}
+}
+
+// Context sets a passed context to the request.
+func (req UserInfoRequest) Context(ctx context.Context) UserInfoRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // PrivilegeType is a struct based on privilege object types list
@@ -470,7 +506,7 @@ type UserGrantOptions struct {
 
 // UserGrantRequest wraps a Tarantool call request for granting user permissions.
 type UserGrantRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewUserGrantRequest creates a new UserGrantRequest based on provided parameters.
@@ -481,7 +517,13 @@ func NewUserGrantRequest(username string, privilege Privilege,
 	// Create a new call request for the box.schema.user.grant method with the given args.
 	callReq := tarantool.NewCallRequest("box.schema.user.grant").Args(args)
 
-	return UserGrantRequest{callReq} // Return the UserGrantRequest.
+	return UserGrantRequest{baseCallRequest: baseCallRequest{call: callReq}}
+}
+
+// Context sets a passed context to the request.
+func (req UserGrantRequest) Context(ctx context.Context) UserGrantRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // UserGrantResponse represents the response from a user grant request.
@@ -510,7 +552,7 @@ type UserRevokeOptions struct {
 
 // UserRevokeRequest wraps a Tarantool call request for revoking user permissions.
 type UserRevokeRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // UserRevokeResponse represents the response from a user revoke request.
@@ -524,7 +566,13 @@ func NewUserRevokeRequest(username string, privilege Privilege,
 	// Create a new call request for the box.schema.user.revoke method with the given args.
 	callReq := tarantool.NewCallRequest("box.schema.user.revoke").Args(args)
 
-	return UserRevokeRequest{callReq}
+	return UserRevokeRequest{baseCallRequest: baseCallRequest{call: callReq}}
+}
+
+// Context sets a passed context to the request.
+func (req UserRevokeRequest) Context(ctx context.Context) UserRevokeRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Revoke executes the user revoke operation in Tarantool, returning an error if it fails.

--- a/box/session.go
+++ b/box/session.go
@@ -23,7 +23,7 @@ func (b *Box) Session() *Session {
 
 // SessionSuRequest struct wraps a Tarantool call request specifically for session switching.
 type SessionSuRequest struct {
-	*tarantool.CallRequest // Underlying Tarantool call request.
+	baseCallRequest
 }
 
 // NewSessionSuRequest creates a new SessionSuRequest for switching session to a specified username.
@@ -31,12 +31,17 @@ type SessionSuRequest struct {
 func NewSessionSuRequest(username string) (SessionSuRequest, error) {
 	args := []any{username} // Create args slice with the username.
 
-	// Create a new call request for the box.session.su method with the given args.
-	callReq := tarantool.NewCallRequest("box.session.su").Args(args)
-
 	return SessionSuRequest{
-		callReq, // Return the new SessionSuRequest containing the call request.
+		baseCallRequest: baseCallRequest{
+			call: tarantool.NewCallRequest("box.session.su").Args(args),
+		},
 	}, nil
+}
+
+// Context sets a passed context to the request.
+func (req SessionSuRequest) Context(ctx context.Context) SessionSuRequest {
+	req.call = req.call.Context(ctx)
+	return req
 }
 
 // Su method is used to switch the session to the specified username.
@@ -48,7 +53,7 @@ func (s *Session) Su(ctx context.Context, username string) error {
 		return err // Return any errors encountered while creating the request.
 	}
 
-	req.Context(ctx) // Attach the context to the request for cancellation and timeout.
+	req = req.Context(ctx) // Attach the context to the request.
 
 	// Execute the request and return the future response, or an error.
 	fut := s.conn.Do(req)

--- a/crud/common.go
+++ b/crud/common.go
@@ -63,11 +63,13 @@ import (
 )
 
 type baseRequest struct {
-	impl *tarantool.CallRequest
+	impl tarantool.CallRequest
 }
 
-func newCall(method string) *tarantool.CallRequest {
-	return tarantool.NewCallRequest(method)
+func newBaseRequest(method string) baseRequest {
+	return baseRequest{
+		impl: tarantool.NewCallRequest(method),
+	}
 }
 
 // Type returns IPROTO type for CRUD request.
@@ -86,13 +88,9 @@ func (req baseRequest) Async() bool {
 }
 
 // Response creates a response for the baseRequest.
-func (req baseRequest) Response(header tarantool.Header,
-	body io.Reader) (tarantool.Response, error) {
+func (req baseRequest) Response(
+	header tarantool.Header,
+	body io.Reader,
+) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
-}
-
-type spaceRequest struct {
-	baseRequest
-
-	space string
 }

--- a/crud/count.go
+++ b/crud/count.go
@@ -68,8 +68,9 @@ func (opts CountOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // CountRequest helps you to create request object to call `crud.count`
 // for execution by a Connection.
 type CountRequest struct {
-	spaceRequest
+	baseRequest
 
+	space      string
 	conditions []Condition
 	opts       CountOpts
 }
@@ -81,14 +82,13 @@ type countArgs struct {
 	Opts       CountOpts
 }
 
-// MakeCountRequest returns a new empty CountRequest.
-func MakeCountRequest(space string) CountRequest {
-	req := CountRequest{}
-	req.impl = newCall("crud.count")
-	req.space = space
-	req.conditions = nil
-	req.opts = CountOpts{}
-	return req
+// NewCountRequest returns a new empty CountRequest.
+func NewCountRequest(space string) CountRequest {
+	return CountRequest{
+		baseRequest: newBaseRequest("crud.count"),
+		space:       space,
+		opts:        CountOpts{},
+	}
 }
 
 // Conditions sets the conditions for the CountRequest request.

--- a/crud/delete.go
+++ b/crud/delete.go
@@ -14,10 +14,11 @@ type DeleteOpts = SimpleOperationOpts
 // DeleteRequest helps you to create request object to call `crud.delete`
 // for execution by a Connection.
 type DeleteRequest struct {
-	spaceRequest
+	baseRequest
 
-	key  Tuple
-	opts DeleteOpts
+	space string
+	key   Tuple
+	opts  DeleteOpts
 }
 
 type deleteArgs struct {
@@ -27,13 +28,13 @@ type deleteArgs struct {
 	Opts     DeleteOpts
 }
 
-// MakeDeleteRequest returns a new empty DeleteRequest.
-func MakeDeleteRequest(space string) DeleteRequest {
-	req := DeleteRequest{}
-	req.impl = newCall("crud.delete")
-	req.space = space
-	req.opts = DeleteOpts{}
-	return req
+// NewDeleteRequest returns a new empty DeleteRequest.
+func NewDeleteRequest(space string) DeleteRequest {
+	return DeleteRequest{
+		baseRequest: newBaseRequest("crud.delete"),
+		space:       space,
+		opts:        DeleteOpts{},
+	}
 }
 
 // Key sets the key for the DeleteRequest request.

--- a/crud/example_test.go
+++ b/crud/example_test.go
@@ -42,7 +42,7 @@ func exampleConnect() *tarantool.Connection {
 // interface{} type.
 func ExampleResult_rowsInterface() {
 	conn := exampleConnect()
-	req := crud.MakeReplaceRequest(exampleSpace).
+	req := crud.NewReplaceRequest(exampleSpace).
 		Tuple([]any{uint(2010), nil, "bla"})
 
 	ret := crud.Result{}
@@ -63,7 +63,7 @@ func ExampleResult_rowsInterface() {
 // custom type.
 func ExampleResult_rowsCustomType() {
 	conn := exampleConnect()
-	req := crud.MakeReplaceRequest(exampleSpace).
+	req := crud.NewReplaceRequest(exampleSpace).
 		Tuple([]any{uint(2010), nil, "bla"})
 
 	type Tuple struct {
@@ -72,7 +72,7 @@ func ExampleResult_rowsCustomType() {
 		BucketId uint64
 		Name     string
 	}
-	ret := crud.MakeResult(reflect.TypeFor[Tuple]())
+	ret := crud.NewResult(reflect.TypeFor[Tuple]())
 
 	if err := conn.Do(req).GetTyped(&ret); err != nil {
 		fmt.Printf("Failed to execute request: %s", err)
@@ -99,7 +99,7 @@ func ExampleTuples_customType() {
 		BucketId *uint64
 		Name     string
 	}
-	req := crud.MakeReplaceManyRequest(exampleSpace).Tuples([]Tuple{
+	req := crud.NewReplaceManyRequest(exampleSpace).Tuples([]Tuple{
 		Tuple{
 			Id:       2010,
 			BucketId: nil,
@@ -107,7 +107,7 @@ func ExampleTuples_customType() {
 		},
 	})
 
-	ret := crud.MakeResult(reflect.TypeFor[Tuple]())
+	ret := crud.NewResult(reflect.TypeFor[Tuple]())
 	if err := conn.Do(req).GetTyped(&ret); err != nil {
 		fmt.Printf("Failed to execute request: %s", err)
 		return
@@ -140,7 +140,7 @@ func ExampleObjects_customType() {
 		BucketId *uint64 `msgpack:"bucket_id,omitempty"`
 		Name     string  `msgpack:"name,omitempty"`
 	}
-	req := crud.MakeReplaceObjectManyRequest(exampleSpace).Objects([]Tuple{
+	req := crud.NewReplaceObjectManyRequest(exampleSpace).Objects([]Tuple{
 		Tuple{
 			Id:       2010,
 			BucketId: nil,
@@ -148,7 +148,7 @@ func ExampleObjects_customType() {
 		},
 	})
 
-	ret := crud.MakeResult(reflect.TypeFor[Tuple]())
+	ret := crud.NewResult(reflect.TypeFor[Tuple]())
 	if err := conn.Do(req).GetTyped(&ret); err != nil {
 		fmt.Printf("Failed to execute request: %s", err)
 		return
@@ -174,7 +174,7 @@ func ExampleObjects_customType() {
 // about erroneous objects from crud.Error using `OperationData` field.
 func ExampleResult_operationData() {
 	conn := exampleConnect()
-	req := crud.MakeInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
+	req := crud.NewInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
 		crud.MapObject{
 			"id":        2,
 			"bucket_id": 3,
@@ -215,7 +215,7 @@ func ExampleResult_operationData() {
 // The type of `OperationData` is determined as the crud.Result row type.
 func ExampleResult_operationDataCustomType() {
 	conn := exampleConnect()
-	req := crud.MakeInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
+	req := crud.NewInsertObjectManyRequest(exampleSpace).Objects([]crud.Object{
 		crud.MapObject{
 			"id":        1,
 			"bucket_id": 3,
@@ -238,7 +238,7 @@ func ExampleResult_operationDataCustomType() {
 		Name     string `msgpack:"name,omitempty"`
 	}
 
-	ret := crud.MakeResult(reflect.TypeFor[Tuple]())
+	ret := crud.NewResult(reflect.TypeFor[Tuple]())
 	if err := conn.Do(req).GetTyped(&ret); err != nil {
 		crudErrs := err.(crud.ErrorMany)
 		fmt.Println("Erroneous data:")
@@ -260,7 +260,7 @@ func ExampleResult_operationDataCustomType() {
 // response from *ManyRequest.
 func ExampleResult_many() {
 	conn := exampleConnect()
-	req := crud.MakeReplaceManyRequest(exampleSpace).
+	req := crud.NewReplaceManyRequest(exampleSpace).
 		Tuples([]crud.Tuple{
 			[]any{uint(2010), nil, "bla"},
 			[]any{uint(2011), nil, "bla"},
@@ -284,7 +284,7 @@ func ExampleResult_many() {
 // whether it was successful or not.
 func ExampleResult_noreturn() {
 	conn := exampleConnect()
-	req := crud.MakeReplaceManyRequest(exampleSpace).
+	req := crud.NewReplaceManyRequest(exampleSpace).
 		Tuples([]crud.Tuple{
 			[]any{uint(2010), nil, "bla"},
 			[]any{uint(2011), nil, "bla"},
@@ -310,7 +310,7 @@ func ExampleResult_noreturn() {
 // to handle a crud error.
 func ExampleResult_error() {
 	conn := exampleConnect()
-	req := crud.MakeReplaceRequest("not_exist").
+	req := crud.NewReplaceRequest("not_exist").
 		Tuple([]any{uint(2010), nil, "bla"})
 
 	ret := crud.Result{}
@@ -329,13 +329,13 @@ func ExampleResult_error() {
 // to handle a crud error for a *ManyRequest.
 func ExampleResult_errorMany() {
 	conn := exampleConnect()
-	initReq := crud.MakeReplaceRequest("not_exist").
+	initReq := crud.NewReplaceRequest("not_exist").
 		Tuple([]any{uint(2010), nil, "bla"})
 	if _, err := conn.Do(initReq).Get(); err != nil {
 		fmt.Printf("Failed to initialize the example: %s\n", err)
 	}
 
-	req := crud.MakeInsertManyRequest(exampleSpace).
+	req := crud.NewInsertManyRequest(exampleSpace).
 		Tuples([]crud.Tuple{
 			[]any{uint(2010), nil, "bla"},
 			[]any{uint(2010), nil, "bla"},
@@ -363,7 +363,7 @@ func ExampleSelectRequest_pagination() {
 	)
 	var tuple any
 	for i := range allTuples {
-		req := crud.MakeReplaceRequest(exampleSpace).
+		req := crud.NewReplaceRequest(exampleSpace).
 			Tuple([]any{uint(3000 + i), nil, "bla"})
 		ret := crud.Result{}
 		if err := conn.Do(req).GetTyped(&ret); err != nil {
@@ -375,7 +375,7 @@ func ExampleSelectRequest_pagination() {
 		}
 	}
 
-	req := crud.MakeSelectRequest(exampleSpace).
+	req := crud.NewSelectRequest(exampleSpace).
 		Opts(crud.SelectOpts{
 			First: option.SomeInt64(2),
 			After: option.SomeAny(tuple),
@@ -395,7 +395,7 @@ func ExampleSelectRequest_pagination() {
 func ExampleSchema() {
 	conn := exampleConnect()
 
-	req := crud.MakeSchemaRequest()
+	req := crud.NewSchemaRequest()
 	var result crud.SchemaResult
 
 	if err := conn.Do(req).GetTyped(&result); err != nil {

--- a/crud/get.go
+++ b/crud/get.go
@@ -61,10 +61,11 @@ func (opts GetOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // GetRequest helps you to create request object to call `crud.get`
 // for execution by a Connection.
 type GetRequest struct {
-	spaceRequest
+	baseRequest
 
-	key  Tuple
-	opts GetOpts
+	space string
+	key   Tuple
+	opts  GetOpts
 }
 
 type getArgs struct {
@@ -74,13 +75,13 @@ type getArgs struct {
 	Opts     GetOpts
 }
 
-// MakeGetRequest returns a new empty GetRequest.
-func MakeGetRequest(space string) GetRequest {
-	req := GetRequest{}
-	req.impl = newCall("crud.get")
-	req.space = space
-	req.opts = GetOpts{}
-	return req
+// NewGetRequest returns a new empty GetRequest.
+func NewGetRequest(space string) GetRequest {
+	return GetRequest{
+		baseRequest: newBaseRequest("crud.get"),
+		space:       space,
+		opts:        GetOpts{},
+	}
 }
 
 // Key sets the key for the GetRequest request.

--- a/crud/insert.go
+++ b/crud/insert.go
@@ -14,8 +14,9 @@ type InsertOpts = SimpleOperationOpts
 // InsertRequest helps you to create request object to call `crud.insert`
 // for execution by a Connection.
 type InsertRequest struct {
-	spaceRequest
+	baseRequest
 
+	space string
 	tuple Tuple
 	opts  InsertOpts
 }
@@ -27,13 +28,13 @@ type insertArgs struct {
 	Opts     InsertOpts
 }
 
-// MakeInsertRequest returns a new empty InsertRequest.
-func MakeInsertRequest(space string) InsertRequest {
-	req := InsertRequest{}
-	req.impl = newCall("crud.insert")
-	req.space = space
-	req.opts = InsertOpts{}
-	return req
+// NewInsertRequest returns a new empty InsertRequest.
+func NewInsertRequest(space string) InsertRequest {
+	return InsertRequest{
+		baseRequest: newBaseRequest("crud.insert"),
+		space:       space,
+		opts:        InsertOpts{},
+	}
 }
 
 // Tuple sets the tuple for the InsertRequest request.
@@ -73,8 +74,9 @@ type InsertObjectOpts = SimpleOperationObjectOpts
 // InsertObjectRequest helps you to create request object to call
 // `crud.insert_object` for execution by a Connection.
 type InsertObjectRequest struct {
-	spaceRequest
+	baseRequest
 
+	space  string
 	object Object
 	opts   InsertObjectOpts
 }
@@ -86,13 +88,13 @@ type insertObjectArgs struct {
 	Opts     InsertObjectOpts
 }
 
-// MakeInsertObjectRequest returns a new empty InsertObjectRequest.
-func MakeInsertObjectRequest(space string) InsertObjectRequest {
-	req := InsertObjectRequest{}
-	req.impl = newCall("crud.insert_object")
-	req.space = space
-	req.opts = InsertObjectOpts{}
-	return req
+// NewInsertObjectRequest returns a new empty InsertObjectRequest.
+func NewInsertObjectRequest(space string) InsertObjectRequest {
+	return InsertObjectRequest{
+		baseRequest: newBaseRequest("crud.insert_object"),
+		space:       space,
+		opts:        InsertObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the InsertObjectRequest request.

--- a/crud/insert_many.go
+++ b/crud/insert_many.go
@@ -14,8 +14,9 @@ type InsertManyOpts = OperationManyOpts
 // InsertManyRequest helps you to create request object to call
 // `crud.insert_many` for execution by a Connection.
 type InsertManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space  string
 	tuples Tuples
 	opts   InsertManyOpts
 }
@@ -27,13 +28,13 @@ type insertManyArgs struct {
 	Opts     InsertManyOpts
 }
 
-// MakeInsertManyRequest returns a new empty InsertManyRequest.
-func MakeInsertManyRequest(space string) InsertManyRequest {
-	req := InsertManyRequest{}
-	req.impl = newCall("crud.insert_many")
-	req.space = space
-	req.opts = InsertManyOpts{}
-	return req
+// NewInsertManyRequest returns a new empty InsertManyRequest.
+func NewInsertManyRequest(space string) InsertManyRequest {
+	return InsertManyRequest{
+		baseRequest: newBaseRequest("crud.insert_many"),
+		space:       space,
+		opts:        InsertManyOpts{},
+	}
 }
 
 // Tuples sets the tuples for the InsertManyRequest request.
@@ -73,8 +74,9 @@ type InsertObjectManyOpts = OperationObjectManyOpts
 // InsertObjectManyRequest helps you to create request object to call
 // `crud.insert_object_many` for execution by a Connection.
 type InsertObjectManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space   string
 	objects Objects
 	opts    InsertObjectManyOpts
 }
@@ -86,13 +88,13 @@ type insertObjectManyArgs struct {
 	Opts     InsertObjectManyOpts
 }
 
-// MakeInsertObjectManyRequest returns a new empty InsertObjectManyRequest.
-func MakeInsertObjectManyRequest(space string) InsertObjectManyRequest {
-	req := InsertObjectManyRequest{}
-	req.impl = newCall("crud.insert_object_many")
-	req.space = space
-	req.opts = InsertObjectManyOpts{}
-	return req
+// NewInsertObjectManyRequest returns a new empty InsertObjectManyRequest.
+func NewInsertObjectManyRequest(space string) InsertObjectManyRequest {
+	return InsertObjectManyRequest{
+		baseRequest: newBaseRequest("crud.insert_object_many"),
+		space:       space,
+		opts:        InsertObjectManyOpts{},
+	}
 }
 
 // Objects sets the objects for the InsertObjectManyRequest request.

--- a/crud/len.go
+++ b/crud/len.go
@@ -17,9 +17,10 @@ type LenOpts = BaseOpts
 // LenRequest helps you to create request object to call `crud.len`
 // for execution by a Connection.
 type LenRequest struct {
-	spaceRequest
+	baseRequest
 
-	opts LenOpts
+	space string
+	opts  LenOpts
 }
 
 type lenArgs struct {
@@ -28,13 +29,13 @@ type lenArgs struct {
 	Opts     LenOpts
 }
 
-// MakeLenRequest returns a new empty LenRequest.
-func MakeLenRequest(space string) LenRequest {
-	req := LenRequest{}
-	req.impl = newCall("crud.len")
-	req.space = space
-	req.opts = LenOpts{}
-	return req
+// NewLenRequest returns a new empty LenRequest.
+func NewLenRequest(space string) LenRequest {
+	return LenRequest{
+		baseRequest: newBaseRequest("crud.len"),
+		space:       space,
+		opts:        LenOpts{},
+	}
 }
 
 // Opts sets the options for the LenRequest request.

--- a/crud/max.go
+++ b/crud/max.go
@@ -14,8 +14,9 @@ type MaxOpts = BorderOpts
 // MaxRequest helps you to create request object to call `crud.max`
 // for execution by a Connection.
 type MaxRequest struct {
-	spaceRequest
+	baseRequest
 
+	space string
 	index any
 	opts  MaxOpts
 }
@@ -27,13 +28,13 @@ type maxArgs struct {
 	Opts     MaxOpts
 }
 
-// MakeMaxRequest returns a new empty MaxRequest.
-func MakeMaxRequest(space string) MaxRequest {
-	req := MaxRequest{}
-	req.impl = newCall("crud.max")
-	req.space = space
-	req.opts = MaxOpts{}
-	return req
+// NewMaxRequest returns a new empty MaxRequest.
+func NewMaxRequest(space string) MaxRequest {
+	return MaxRequest{
+		baseRequest: newBaseRequest("crud.max"),
+		space:       space,
+		opts:        MaxOpts{},
+	}
 }
 
 // Index sets the index name/id for the MaxRequest request.

--- a/crud/min.go
+++ b/crud/min.go
@@ -14,8 +14,9 @@ type MinOpts = BorderOpts
 // MinRequest helps you to create request object to call `crud.min`
 // for execution by a Connection.
 type MinRequest struct {
-	spaceRequest
+	baseRequest
 
+	space string
 	index any
 	opts  MinOpts
 }
@@ -27,13 +28,13 @@ type minArgs struct {
 	Opts     MinOpts
 }
 
-// MakeMinRequest returns a new empty MinRequest.
-func MakeMinRequest(space string) MinRequest {
-	req := MinRequest{}
-	req.impl = newCall("crud.min")
-	req.space = space
-	req.opts = MinOpts{}
-	return req
+// NewMinRequest returns a new empty MinRequest.
+func NewMinRequest(space string) MinRequest {
+	return MinRequest{
+		baseRequest: newBaseRequest("crud.min"),
+		space:       space,
+		opts:        MinOpts{},
+	}
 }
 
 // Index sets the index name/id for the MinRequest request.

--- a/crud/replace.go
+++ b/crud/replace.go
@@ -14,8 +14,9 @@ type ReplaceOpts = SimpleOperationOpts
 // ReplaceRequest helps you to create request object to call `crud.replace`
 // for execution by a Connection.
 type ReplaceRequest struct {
-	spaceRequest
+	baseRequest
 
+	space string
 	tuple Tuple
 	opts  ReplaceOpts
 }
@@ -27,13 +28,13 @@ type replaceArgs struct {
 	Opts     ReplaceOpts
 }
 
-// MakeReplaceRequest returns a new empty ReplaceRequest.
-func MakeReplaceRequest(space string) ReplaceRequest {
-	req := ReplaceRequest{}
-	req.impl = newCall("crud.replace")
-	req.space = space
-	req.opts = ReplaceOpts{}
-	return req
+// NewReplaceRequest returns a new empty ReplaceRequest.
+func NewReplaceRequest(space string) ReplaceRequest {
+	return ReplaceRequest{
+		baseRequest: newBaseRequest("crud.replace"),
+		space:       space,
+		opts:        ReplaceOpts{},
+	}
 }
 
 // Tuple sets the tuple for the ReplaceRequest request.
@@ -73,8 +74,9 @@ type ReplaceObjectOpts = SimpleOperationObjectOpts
 // ReplaceObjectRequest helps you to create request object to call
 // `crud.replace_object` for execution by a Connection.
 type ReplaceObjectRequest struct {
-	spaceRequest
+	baseRequest
 
+	space  string
 	object Object
 	opts   ReplaceObjectOpts
 }
@@ -86,13 +88,13 @@ type replaceObjectArgs struct {
 	Opts     ReplaceObjectOpts
 }
 
-// MakeReplaceObjectRequest returns a new empty ReplaceObjectRequest.
-func MakeReplaceObjectRequest(space string) ReplaceObjectRequest {
-	req := ReplaceObjectRequest{}
-	req.impl = newCall("crud.replace_object")
-	req.space = space
-	req.opts = ReplaceObjectOpts{}
-	return req
+// NewReplaceObjectRequest returns a new empty ReplaceObjectRequest.
+func NewReplaceObjectRequest(space string) ReplaceObjectRequest {
+	return ReplaceObjectRequest{
+		baseRequest: newBaseRequest("crud.replace_object"),
+		space:       space,
+		opts:        ReplaceObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the ReplaceObjectRequest request.

--- a/crud/replace_many.go
+++ b/crud/replace_many.go
@@ -14,8 +14,9 @@ type ReplaceManyOpts = OperationManyOpts
 // ReplaceManyRequest helps you to create request object to call
 // `crud.replace_many` for execution by a Connection.
 type ReplaceManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space  string
 	tuples Tuples
 	opts   ReplaceManyOpts
 }
@@ -27,13 +28,13 @@ type replaceManyArgs struct {
 	Opts     ReplaceManyOpts
 }
 
-// MakeReplaceManyRequest returns a new empty ReplaceManyRequest.
-func MakeReplaceManyRequest(space string) ReplaceManyRequest {
-	req := ReplaceManyRequest{}
-	req.impl = newCall("crud.replace_many")
-	req.space = space
-	req.opts = ReplaceManyOpts{}
-	return req
+// NewReplaceManyRequest returns a new empty ReplaceManyRequest.
+func NewReplaceManyRequest(space string) ReplaceManyRequest {
+	return ReplaceManyRequest{
+		baseRequest: newBaseRequest("crud.replace_many"),
+		space:       space,
+		opts:        ReplaceManyOpts{},
+	}
 }
 
 // Tuples sets the tuples for the ReplaceManyRequest request.
@@ -73,8 +74,9 @@ type ReplaceObjectManyOpts = OperationObjectManyOpts
 // ReplaceObjectManyRequest helps you to create request object to call
 // `crud.replace_object_many` for execution by a Connection.
 type ReplaceObjectManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space   string
 	objects Objects
 	opts    ReplaceObjectManyOpts
 }
@@ -86,13 +88,13 @@ type replaceObjectManyArgs struct {
 	Opts     ReplaceObjectManyOpts
 }
 
-// MakeReplaceObjectManyRequest returns a new empty ReplaceObjectManyRequest.
-func MakeReplaceObjectManyRequest(space string) ReplaceObjectManyRequest {
-	req := ReplaceObjectManyRequest{}
-	req.impl = newCall("crud.replace_object_many")
-	req.space = space
-	req.opts = ReplaceObjectManyOpts{}
-	return req
+// NewReplaceObjectManyRequest returns a new empty ReplaceObjectManyRequest.
+func NewReplaceObjectManyRequest(space string) ReplaceObjectManyRequest {
+	return ReplaceObjectManyRequest{
+		baseRequest: newBaseRequest("crud.replace_object_many"),
+		space:       space,
+		opts:        ReplaceObjectManyOpts{},
+	}
 }
 
 // Objects sets the tuple for the ReplaceObjectManyRequest request.

--- a/crud/request_test.go
+++ b/crud/request_test.go
@@ -97,7 +97,7 @@ func BenchmarkLenRequest(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		req := crud.MakeLenRequest(spaceName).
+		req := crud.NewLenRequest(spaceName).
 			Opts(crud.LenOpts{
 				Timeout: option.SomeFloat64(3.5),
 			})
@@ -116,7 +116,7 @@ func BenchmarkSelectRequest(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		req := crud.MakeSelectRequest(spaceName).
+		req := crud.NewSelectRequest(spaceName).
 			Opts(crud.SelectOpts{
 				Timeout:      option.SomeFloat64(3.5),
 				VshardRouter: option.SomeString("asd"),
@@ -133,30 +133,30 @@ func TestRequestsCodes(t *testing.T) {
 		req   tarantool.Request
 		rtype iproto.Type
 	}{
-		{req: crud.MakeInsertRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeInsertObjectRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeInsertManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeInsertObjectManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeGetRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeUpdateRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeDeleteRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeReplaceRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeReplaceObjectRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeReplaceManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeReplaceObjectManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeUpsertRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeUpsertObjectRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeUpsertManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeUpsertObjectManyRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeMinRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeMaxRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeSelectRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeTruncateRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeLenRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeCountRequest(validSpace), rtype: CrudRequestType},
-		{req: crud.MakeStorageInfoRequest(), rtype: CrudRequestType},
-		{req: crud.MakeStatsRequest(), rtype: CrudRequestType},
-		{req: crud.MakeSchemaRequest(), rtype: CrudRequestType},
+		{req: crud.NewInsertRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewInsertObjectRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewInsertManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewInsertObjectManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewGetRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewUpdateRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewDeleteRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewReplaceRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewReplaceObjectRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewReplaceManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewReplaceObjectManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewUpsertRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewUpsertObjectRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewUpsertManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewUpsertObjectManyRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewMinRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewMaxRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewSelectRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewTruncateRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewLenRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewCountRequest(validSpace), rtype: CrudRequestType},
+		{req: crud.NewStorageInfoRequest(), rtype: CrudRequestType},
+		{req: crud.NewStatsRequest(), rtype: CrudRequestType},
+		{req: crud.NewSchemaRequest(), rtype: CrudRequestType},
 	}
 
 	for _, test := range tests {
@@ -169,30 +169,30 @@ func TestRequestsAsync(t *testing.T) {
 		req   tarantool.Request
 		async bool
 	}{
-		{req: crud.MakeInsertRequest(validSpace), async: false},
-		{req: crud.MakeInsertObjectRequest(validSpace), async: false},
-		{req: crud.MakeInsertManyRequest(validSpace), async: false},
-		{req: crud.MakeInsertObjectManyRequest(validSpace), async: false},
-		{req: crud.MakeGetRequest(validSpace), async: false},
-		{req: crud.MakeUpdateRequest(validSpace), async: false},
-		{req: crud.MakeDeleteRequest(validSpace), async: false},
-		{req: crud.MakeReplaceRequest(validSpace), async: false},
-		{req: crud.MakeReplaceObjectRequest(validSpace), async: false},
-		{req: crud.MakeReplaceManyRequest(validSpace), async: false},
-		{req: crud.MakeReplaceObjectManyRequest(validSpace), async: false},
-		{req: crud.MakeUpsertRequest(validSpace), async: false},
-		{req: crud.MakeUpsertObjectRequest(validSpace), async: false},
-		{req: crud.MakeUpsertManyRequest(validSpace), async: false},
-		{req: crud.MakeUpsertObjectManyRequest(validSpace), async: false},
-		{req: crud.MakeMinRequest(validSpace), async: false},
-		{req: crud.MakeMaxRequest(validSpace), async: false},
-		{req: crud.MakeSelectRequest(validSpace), async: false},
-		{req: crud.MakeTruncateRequest(validSpace), async: false},
-		{req: crud.MakeLenRequest(validSpace), async: false},
-		{req: crud.MakeCountRequest(validSpace), async: false},
-		{req: crud.MakeStorageInfoRequest(), async: false},
-		{req: crud.MakeStatsRequest(), async: false},
-		{req: crud.MakeSchemaRequest(), async: false},
+		{req: crud.NewInsertRequest(validSpace), async: false},
+		{req: crud.NewInsertObjectRequest(validSpace), async: false},
+		{req: crud.NewInsertManyRequest(validSpace), async: false},
+		{req: crud.NewInsertObjectManyRequest(validSpace), async: false},
+		{req: crud.NewGetRequest(validSpace), async: false},
+		{req: crud.NewUpdateRequest(validSpace), async: false},
+		{req: crud.NewDeleteRequest(validSpace), async: false},
+		{req: crud.NewReplaceRequest(validSpace), async: false},
+		{req: crud.NewReplaceObjectRequest(validSpace), async: false},
+		{req: crud.NewReplaceManyRequest(validSpace), async: false},
+		{req: crud.NewReplaceObjectManyRequest(validSpace), async: false},
+		{req: crud.NewUpsertRequest(validSpace), async: false},
+		{req: crud.NewUpsertObjectRequest(validSpace), async: false},
+		{req: crud.NewUpsertManyRequest(validSpace), async: false},
+		{req: crud.NewUpsertObjectManyRequest(validSpace), async: false},
+		{req: crud.NewMinRequest(validSpace), async: false},
+		{req: crud.NewMaxRequest(validSpace), async: false},
+		{req: crud.NewSelectRequest(validSpace), async: false},
+		{req: crud.NewTruncateRequest(validSpace), async: false},
+		{req: crud.NewLenRequest(validSpace), async: false},
+		{req: crud.NewCountRequest(validSpace), async: false},
+		{req: crud.NewStorageInfoRequest(), async: false},
+		{req: crud.NewStatsRequest(), async: false},
+		{req: crud.NewSchemaRequest(), async: false},
 	}
 
 	for _, test := range tests {
@@ -205,30 +205,30 @@ func TestRequestsCtx_default(t *testing.T) {
 		req      tarantool.Request
 		expected context.Context
 	}{
-		{req: crud.MakeInsertRequest(validSpace), expected: nil},
-		{req: crud.MakeInsertObjectRequest(validSpace), expected: nil},
-		{req: crud.MakeInsertManyRequest(validSpace), expected: nil},
-		{req: crud.MakeInsertObjectManyRequest(validSpace), expected: nil},
-		{req: crud.MakeGetRequest(validSpace), expected: nil},
-		{req: crud.MakeUpdateRequest(validSpace), expected: nil},
-		{req: crud.MakeDeleteRequest(validSpace), expected: nil},
-		{req: crud.MakeReplaceRequest(validSpace), expected: nil},
-		{req: crud.MakeReplaceObjectRequest(validSpace), expected: nil},
-		{req: crud.MakeReplaceManyRequest(validSpace), expected: nil},
-		{req: crud.MakeReplaceObjectManyRequest(validSpace), expected: nil},
-		{req: crud.MakeUpsertRequest(validSpace), expected: nil},
-		{req: crud.MakeUpsertObjectRequest(validSpace), expected: nil},
-		{req: crud.MakeUpsertManyRequest(validSpace), expected: nil},
-		{req: crud.MakeUpsertObjectManyRequest(validSpace), expected: nil},
-		{req: crud.MakeMinRequest(validSpace), expected: nil},
-		{req: crud.MakeMaxRequest(validSpace), expected: nil},
-		{req: crud.MakeSelectRequest(validSpace), expected: nil},
-		{req: crud.MakeTruncateRequest(validSpace), expected: nil},
-		{req: crud.MakeLenRequest(validSpace), expected: nil},
-		{req: crud.MakeCountRequest(validSpace), expected: nil},
-		{req: crud.MakeStorageInfoRequest(), expected: nil},
-		{req: crud.MakeStatsRequest(), expected: nil},
-		{req: crud.MakeSchemaRequest(), expected: nil},
+		{req: crud.NewInsertRequest(validSpace), expected: nil},
+		{req: crud.NewInsertObjectRequest(validSpace), expected: nil},
+		{req: crud.NewInsertManyRequest(validSpace), expected: nil},
+		{req: crud.NewInsertObjectManyRequest(validSpace), expected: nil},
+		{req: crud.NewGetRequest(validSpace), expected: nil},
+		{req: crud.NewUpdateRequest(validSpace), expected: nil},
+		{req: crud.NewDeleteRequest(validSpace), expected: nil},
+		{req: crud.NewReplaceRequest(validSpace), expected: nil},
+		{req: crud.NewReplaceObjectRequest(validSpace), expected: nil},
+		{req: crud.NewReplaceManyRequest(validSpace), expected: nil},
+		{req: crud.NewReplaceObjectManyRequest(validSpace), expected: nil},
+		{req: crud.NewUpsertRequest(validSpace), expected: nil},
+		{req: crud.NewUpsertObjectRequest(validSpace), expected: nil},
+		{req: crud.NewUpsertManyRequest(validSpace), expected: nil},
+		{req: crud.NewUpsertObjectManyRequest(validSpace), expected: nil},
+		{req: crud.NewMinRequest(validSpace), expected: nil},
+		{req: crud.NewMaxRequest(validSpace), expected: nil},
+		{req: crud.NewSelectRequest(validSpace), expected: nil},
+		{req: crud.NewTruncateRequest(validSpace), expected: nil},
+		{req: crud.NewLenRequest(validSpace), expected: nil},
+		{req: crud.NewCountRequest(validSpace), expected: nil},
+		{req: crud.NewStorageInfoRequest(), expected: nil},
+		{req: crud.NewStatsRequest(), expected: nil},
+		{req: crud.NewSchemaRequest(), expected: nil},
 	}
 
 	for _, test := range tests {
@@ -242,30 +242,30 @@ func TestRequestsCtx_setter(t *testing.T) {
 		req      tarantool.Request
 		expected context.Context
 	}{
-		{req: crud.MakeInsertRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeInsertObjectRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeInsertManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeInsertObjectManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeGetRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeUpdateRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeDeleteRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeReplaceRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeReplaceObjectRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeReplaceManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeReplaceObjectManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeUpsertRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeUpsertObjectRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeUpsertManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeUpsertObjectManyRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeMinRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeMaxRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeSelectRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeTruncateRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeLenRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeCountRequest(validSpace).Context(ctx), expected: ctx},
-		{req: crud.MakeStorageInfoRequest().Context(ctx), expected: ctx},
-		{req: crud.MakeStatsRequest().Context(ctx), expected: ctx},
-		{req: crud.MakeSchemaRequest().Context(ctx), expected: ctx},
+		{req: crud.NewInsertRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewInsertObjectRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewInsertManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewInsertObjectManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewGetRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewUpdateRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewDeleteRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewReplaceRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewReplaceObjectRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewReplaceManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewReplaceObjectManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewUpsertRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewUpsertObjectRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewUpsertManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewUpsertObjectManyRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewMinRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewMaxRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewSelectRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewTruncateRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewLenRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewCountRequest(validSpace).Context(ctx), expected: ctx},
+		{req: crud.NewStorageInfoRequest().Context(ctx), expected: ctx},
+		{req: crud.NewStatsRequest().Context(ctx), expected: ctx},
+		{req: crud.NewSchemaRequest().Context(ctx), expected: ctx},
 	}
 
 	for _, test := range tests {
@@ -283,148 +283,148 @@ func TestRequestsDefaultValues(t *testing.T) {
 			name: "InsertRequest",
 			ref: tarantool.NewCallRequest("crud.insert").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeInsertRequest(validSpace),
+			target: crud.NewInsertRequest(validSpace),
 		},
 		{
 			name: "InsertObjectRequest",
 			ref: tarantool.NewCallRequest("crud.insert_object").Args(
 				[]any{validSpace, map[string]any{}, map[string]any{}}),
-			target: crud.MakeInsertObjectRequest(validSpace),
+			target: crud.NewInsertObjectRequest(validSpace),
 		},
 		{
 			name: "InsertManyRequest",
 			ref: tarantool.NewCallRequest("crud.insert_many").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeInsertManyRequest(validSpace),
+			target: crud.NewInsertManyRequest(validSpace),
 		},
 		{
 			name: "InsertObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.insert_object_many").Args(
 				[]any{validSpace, []map[string]any{}, map[string]any{}}),
-			target: crud.MakeInsertObjectManyRequest(validSpace),
+			target: crud.NewInsertObjectManyRequest(validSpace),
 		},
 		{
 			name: "GetRequest",
 			ref: tarantool.NewCallRequest("crud.get").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeGetRequest(validSpace),
+			target: crud.NewGetRequest(validSpace),
 		},
 		{
 			name: "UpdateRequest",
 			ref: tarantool.NewCallRequest("crud.update").Args(
 				[]any{validSpace, []any{},
 					[]any{}, map[string]any{}}),
-			target: crud.MakeUpdateRequest(validSpace),
+			target: crud.NewUpdateRequest(validSpace),
 		},
 		{
 			name: "DeleteRequest",
 			ref: tarantool.NewCallRequest("crud.delete").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeDeleteRequest(validSpace),
+			target: crud.NewDeleteRequest(validSpace),
 		},
 		{
 			name: "ReplaceRequest",
 			ref: tarantool.NewCallRequest("crud.replace").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeReplaceRequest(validSpace),
+			target: crud.NewReplaceRequest(validSpace),
 		},
 		{
 			name: "ReplaceObjectRequest",
 			ref: tarantool.NewCallRequest("crud.replace_object").Args([]any{validSpace,
 				map[string]any{}, map[string]any{}}),
-			target: crud.MakeReplaceObjectRequest(validSpace),
+			target: crud.NewReplaceObjectRequest(validSpace),
 		},
 		{
 			name: "ReplaceManyRequest",
 			ref: tarantool.NewCallRequest("crud.replace_many").Args([]any{validSpace,
 				[]any{}, map[string]any{}}),
-			target: crud.MakeReplaceManyRequest(validSpace),
+			target: crud.NewReplaceManyRequest(validSpace),
 		},
 		{
 			name: "ReplaceObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.replace_object_many").Args(
 				[]any{validSpace, []map[string]any{}, map[string]any{}}),
-			target: crud.MakeReplaceObjectManyRequest(validSpace),
+			target: crud.NewReplaceObjectManyRequest(validSpace),
 		},
 		{
 			name: "UpsertRequest",
 			ref: tarantool.NewCallRequest("crud.upsert").Args(
 				[]any{validSpace, []any{}, []any{},
 					map[string]any{}}),
-			target: crud.MakeUpsertRequest(validSpace),
+			target: crud.NewUpsertRequest(validSpace),
 		},
 		{
 			name: "UpsertObjectRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_object").Args(
 				[]any{validSpace, map[string]any{}, []any{},
 					map[string]any{}}),
-			target: crud.MakeUpsertObjectRequest(validSpace),
+			target: crud.NewUpsertObjectRequest(validSpace),
 		},
 		{
 			name: "UpsertManyRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_many").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeUpsertManyRequest(validSpace),
+			target: crud.NewUpsertManyRequest(validSpace),
 		},
 		{
 			name: "UpsertObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_object_many").Args(
 				[]any{validSpace, []any{}, map[string]any{}}),
-			target: crud.MakeUpsertObjectManyRequest(validSpace),
+			target: crud.NewUpsertObjectManyRequest(validSpace),
 		},
 		{
 			name: "SelectRequest",
 			ref: tarantool.NewCallRequest("crud.select").Args(
 				[]any{validSpace, nil, map[string]any{}}),
-			target: crud.MakeSelectRequest(validSpace),
+			target: crud.NewSelectRequest(validSpace),
 		},
 		{
 			name: "MinRequest",
 			ref: tarantool.NewCallRequest("crud.min").Args(
 				[]any{validSpace, nil, map[string]any{}}),
-			target: crud.MakeMinRequest(validSpace),
+			target: crud.NewMinRequest(validSpace),
 		},
 		{
 			name: "MaxRequest",
 			ref: tarantool.NewCallRequest("crud.max").Args(
 				[]any{validSpace, nil, map[string]any{}}),
-			target: crud.MakeMaxRequest(validSpace),
+			target: crud.NewMaxRequest(validSpace),
 		},
 		{
 			name: "TruncateRequest",
 			ref: tarantool.NewCallRequest("crud.truncate").Args(
 				[]any{validSpace, map[string]any{}}),
-			target: crud.MakeTruncateRequest(validSpace),
+			target: crud.NewTruncateRequest(validSpace),
 		},
 		{
 			name: "LenRequest",
 			ref: tarantool.NewCallRequest("crud.len").Args(
 				[]any{validSpace, map[string]any{}}),
-			target: crud.MakeLenRequest(validSpace),
+			target: crud.NewLenRequest(validSpace),
 		},
 		{
 			name: "CountRequest",
 			ref: tarantool.NewCallRequest("crud.count").Args(
 				[]any{validSpace, nil, map[string]any{}}),
-			target: crud.MakeCountRequest(validSpace),
+			target: crud.NewCountRequest(validSpace),
 		},
 		{
 			name: "StorageInfoRequest",
 			ref: tarantool.NewCallRequest("crud.storage_info").Args(
 				[]any{map[string]any{}}),
-			target: crud.MakeStorageInfoRequest(),
+			target: crud.NewStorageInfoRequest(),
 		},
 		{
 			name: "StatsRequest",
 			ref: tarantool.NewCallRequest("crud.stats").Args(
 				[]any{}),
-			target: crud.MakeStatsRequest(),
+			target: crud.NewStatsRequest(),
 		},
 		{
 			name: "SchemaRequest",
 			ref: tarantool.NewCallRequest("crud.schema").Args(
 				[]any{nil, map[string]any{}}),
-			target: crud.MakeSchemaRequest(),
+			target: crud.NewSchemaRequest(),
 		},
 	}
 
@@ -445,162 +445,162 @@ func TestRequestsSetters(t *testing.T) {
 			name: "InsertRequest",
 			ref: tarantool.NewCallRequest("crud.insert").Args(
 				[]any{spaceName, tuple, expectedOpts}),
-			target: crud.MakeInsertRequest(spaceName).Tuple(tuple).Opts(simpleOperationOpts),
+			target: crud.NewInsertRequest(spaceName).Tuple(tuple).Opts(simpleOperationOpts),
 		},
 		{
 			name: "InsertObjectRequest",
 			ref: tarantool.NewCallRequest("crud.insert_object").Args(
 				[]any{spaceName, reqObject, expectedOpts}),
-			target: crud.MakeInsertObjectRequest(spaceName).Object(reqObject).
+			target: crud.NewInsertObjectRequest(spaceName).Object(reqObject).
 				Opts(simpleOperationObjectOpts),
 		},
 		{
 			name: "InsertManyRequest",
 			ref: tarantool.NewCallRequest("crud.insert_many").Args(
 				[]any{spaceName, tuples, expectedOpts}),
-			target: crud.MakeInsertManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts),
+			target: crud.NewInsertManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts),
 		},
 		{
 			name: "InsertObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.insert_object_many").Args(
 				[]any{spaceName, reqObjects, expectedOpts}),
-			target: crud.MakeInsertObjectManyRequest(spaceName).Objects(reqObjects).
+			target: crud.NewInsertObjectManyRequest(spaceName).Objects(reqObjects).
 				Opts(opObjManyOpts),
 		},
 		{
 			name: "GetRequest",
 			ref: tarantool.NewCallRequest("crud.get").Args(
 				[]any{spaceName, key, expectedOpts}),
-			target: crud.MakeGetRequest(spaceName).Key(key).Opts(getOpts),
+			target: crud.NewGetRequest(spaceName).Key(key).Opts(getOpts),
 		},
 		{
 			name: "UpdateRequest",
 			ref: tarantool.NewCallRequest("crud.update").Args(
 				[]any{spaceName, key, operations, expectedOpts}),
-			target: crud.MakeUpdateRequest(spaceName).Key(key).Operations(operations).
+			target: crud.NewUpdateRequest(spaceName).Key(key).Operations(operations).
 				Opts(simpleOperationOpts),
 		},
 		{
 			name: "DeleteRequest",
 			ref: tarantool.NewCallRequest("crud.delete").Args(
 				[]any{spaceName, key, expectedOpts}),
-			target: crud.MakeDeleteRequest(spaceName).Key(key).Opts(simpleOperationOpts),
+			target: crud.NewDeleteRequest(spaceName).Key(key).Opts(simpleOperationOpts),
 		},
 		{
 			name: "ReplaceRequest",
 			ref: tarantool.NewCallRequest("crud.replace").Args(
 				[]any{spaceName, tuple, expectedOpts}),
-			target: crud.MakeReplaceRequest(spaceName).Tuple(tuple).Opts(simpleOperationOpts),
+			target: crud.NewReplaceRequest(spaceName).Tuple(tuple).Opts(simpleOperationOpts),
 		},
 		{
 			name: "ReplaceObjectRequest",
 			ref: tarantool.NewCallRequest("crud.replace_object").Args(
 				[]any{spaceName, reqObject, expectedOpts}),
-			target: crud.MakeReplaceObjectRequest(spaceName).Object(reqObject).
+			target: crud.NewReplaceObjectRequest(spaceName).Object(reqObject).
 				Opts(simpleOperationObjectOpts),
 		},
 		{
 			name: "ReplaceManyRequest",
 			ref: tarantool.NewCallRequest("crud.replace_many").Args(
 				[]any{spaceName, tuples, expectedOpts}),
-			target: crud.MakeReplaceManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts),
+			target: crud.NewReplaceManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts),
 		},
 		{
 			name: "ReplaceObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.replace_object_many").Args(
 				[]any{spaceName, reqObjects, expectedOpts}),
-			target: crud.MakeReplaceObjectManyRequest(spaceName).Objects(reqObjects).
+			target: crud.NewReplaceObjectManyRequest(spaceName).Objects(reqObjects).
 				Opts(opObjManyOpts),
 		},
 		{
 			name: "UpsertRequest",
 			ref: tarantool.NewCallRequest("crud.upsert").Args(
 				[]any{spaceName, tuple, operations, expectedOpts}),
-			target: crud.MakeUpsertRequest(spaceName).Tuple(tuple).Operations(operations).
+			target: crud.NewUpsertRequest(spaceName).Tuple(tuple).Operations(operations).
 				Opts(simpleOperationOpts),
 		},
 		{
 			name: "UpsertObjectRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_object").Args(
 				[]any{spaceName, reqObject, operations, expectedOpts}),
-			target: crud.MakeUpsertObjectRequest(spaceName).Object(reqObject).
+			target: crud.NewUpsertObjectRequest(spaceName).Object(reqObject).
 				Operations(operations).Opts(simpleOperationOpts),
 		},
 		{
 			name: "UpsertManyRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_many").Args(
 				[]any{spaceName, tuplesOperationsData, expectedOpts}),
-			target: crud.MakeUpsertManyRequest(spaceName).
+			target: crud.NewUpsertManyRequest(spaceName).
 				TuplesOperationsData(tuplesOperationsData).Opts(opManyOpts),
 		},
 		{
 			name: "UpsertObjectManyRequest",
 			ref: tarantool.NewCallRequest("crud.upsert_object_many").Args(
 				[]any{spaceName, reqObjectsOperationsData, expectedOpts}),
-			target: crud.MakeUpsertObjectManyRequest(spaceName).
+			target: crud.NewUpsertObjectManyRequest(spaceName).
 				ObjectsOperationsData(reqObjectsOperationsData).Opts(opManyOpts),
 		},
 		{
 			name: "SelectRequest",
 			ref: tarantool.NewCallRequest("crud.select").Args(
 				[]any{spaceName, conditions, expectedOpts}),
-			target: crud.MakeSelectRequest(spaceName).Conditions(conditions).Opts(selectOpts),
+			target: crud.NewSelectRequest(spaceName).Conditions(conditions).Opts(selectOpts),
 		},
 		{
 			name: "MinRequest",
 			ref: tarantool.NewCallRequest("crud.min").Args(
 				[]any{spaceName, indexName, expectedOpts}),
-			target: crud.MakeMinRequest(spaceName).Index(indexName).Opts(minOpts),
+			target: crud.NewMinRequest(spaceName).Index(indexName).Opts(minOpts),
 		},
 		{
 			name: "MaxRequest",
 			ref: tarantool.NewCallRequest("crud.max").Args(
 				[]any{spaceName, indexName, expectedOpts}),
-			target: crud.MakeMaxRequest(spaceName).Index(indexName).Opts(maxOpts),
+			target: crud.NewMaxRequest(spaceName).Index(indexName).Opts(maxOpts),
 		},
 		{
 			name: "TruncateRequest",
 			ref: tarantool.NewCallRequest("crud.truncate").Args(
 				[]any{spaceName, expectedOpts}),
-			target: crud.MakeTruncateRequest(spaceName).Opts(baseOpts),
+			target: crud.NewTruncateRequest(spaceName).Opts(baseOpts),
 		},
 		{
 			name: "LenRequest",
 			ref: tarantool.NewCallRequest("crud.len").Args(
 				[]any{spaceName, expectedOpts}),
-			target: crud.MakeLenRequest(spaceName).Opts(baseOpts),
+			target: crud.NewLenRequest(spaceName).Opts(baseOpts),
 		},
 		{
 			name: "CountRequest",
 			ref: tarantool.NewCallRequest("crud.count").Args(
 				[]any{spaceName, conditions, expectedOpts}),
-			target: crud.MakeCountRequest(spaceName).Conditions(conditions).Opts(countOpts),
+			target: crud.NewCountRequest(spaceName).Conditions(conditions).Opts(countOpts),
 		},
 		{
 			name: "StorageInfoRequest",
 			ref: tarantool.NewCallRequest("crud.storage_info").Args(
 				[]any{expectedOpts}),
-			target: crud.MakeStorageInfoRequest().Opts(baseOpts),
+			target: crud.NewStorageInfoRequest().Opts(baseOpts),
 		},
 		{
 			name: "StatsRequest",
 			ref: tarantool.NewCallRequest("crud.stats").Args(
 				[]any{spaceName}),
-			target: crud.MakeStatsRequest().Space(spaceName),
+			target: crud.NewStatsRequest().Space(spaceName),
 		},
 		{
 			name: "SchemaRequest",
 			ref: tarantool.NewCallRequest("crud.schema").Args(
 				[]any{nil, schemaOpts},
 			),
-			target: crud.MakeSchemaRequest().Opts(schemaOpts),
+			target: crud.NewSchemaRequest().Opts(schemaOpts),
 		},
 		{
 			name: "SchemaRequestWithSpace",
 			ref: tarantool.NewCallRequest("crud.schema").Args(
 				[]any{spaceName, schemaOpts},
 			),
-			target: crud.MakeSchemaRequest().Space(spaceName).Opts(schemaOpts),
+			target: crud.NewSchemaRequest().Space(spaceName).Opts(schemaOpts),
 		},
 	}
 
@@ -624,7 +624,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeInsertRequest(validSpace).Opts(crud.InsertOpts{
+			target: crud.NewInsertRequest(validSpace).Opts(crud.InsertOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -635,7 +635,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeInsertObjectRequest(validSpace).Opts(crud.InsertObjectOpts{
+			target: crud.NewInsertObjectRequest(validSpace).Opts(crud.InsertObjectOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -646,7 +646,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeInsertManyRequest(validSpace).Opts(crud.InsertManyOpts{
+			target: crud.NewInsertManyRequest(validSpace).Opts(crud.InsertManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -657,7 +657,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]map[string]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeInsertObjectManyRequest(validSpace).Opts(crud.InsertObjectManyOpts{
+			target: crud.NewInsertObjectManyRequest(validSpace).Opts(crud.InsertObjectManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -668,7 +668,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeGetRequest(validSpace).Opts(crud.GetOpts{
+			target: crud.NewGetRequest(validSpace).Opts(crud.GetOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -680,7 +680,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeUpdateRequest(validSpace).Opts(crud.UpdateOpts{
+			target: crud.NewUpdateRequest(validSpace).Opts(crud.UpdateOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -691,7 +691,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeDeleteRequest(validSpace).Opts(crud.DeleteOpts{
+			target: crud.NewDeleteRequest(validSpace).Opts(crud.DeleteOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -702,7 +702,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeReplaceRequest(validSpace).Opts(crud.ReplaceOpts{
+			target: crud.NewReplaceRequest(validSpace).Opts(crud.ReplaceOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -713,7 +713,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				map[string]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeReplaceObjectRequest(validSpace).Opts(crud.ReplaceObjectOpts{
+			target: crud.NewReplaceObjectRequest(validSpace).Opts(crud.ReplaceObjectOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -724,7 +724,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeReplaceManyRequest(validSpace).Opts(crud.ReplaceManyOpts{
+			target: crud.NewReplaceManyRequest(validSpace).Opts(crud.ReplaceManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -735,7 +735,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]map[string]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeReplaceObjectManyRequest(validSpace).Opts(crud.ReplaceObjectManyOpts{
+			target: crud.NewReplaceObjectManyRequest(validSpace).Opts(crud.ReplaceObjectManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -747,7 +747,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeUpsertRequest(validSpace).Opts(crud.UpsertOpts{
+			target: crud.NewUpsertRequest(validSpace).Opts(crud.UpsertOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -759,7 +759,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeUpsertObjectRequest(validSpace).Opts(crud.UpsertObjectOpts{
+			target: crud.NewUpsertObjectRequest(validSpace).Opts(crud.UpsertObjectOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -770,7 +770,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeUpsertManyRequest(validSpace).Opts(crud.UpsertManyOpts{
+			target: crud.NewUpsertManyRequest(validSpace).Opts(crud.UpsertManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -781,7 +781,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				[]any{},
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeUpsertObjectManyRequest(validSpace).Opts(crud.UpsertObjectManyOpts{
+			target: crud.NewUpsertObjectManyRequest(validSpace).Opts(crud.UpsertObjectManyOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -792,7 +792,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				nil,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeSelectRequest(validSpace).Opts(crud.SelectOpts{
+			target: crud.NewSelectRequest(validSpace).Opts(crud.SelectOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -803,7 +803,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				nil,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeMinRequest(validSpace).Opts(crud.MinOpts{
+			target: crud.NewMinRequest(validSpace).Opts(crud.MinOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -814,7 +814,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				nil,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeMaxRequest(validSpace).Opts(crud.MaxOpts{
+			target: crud.NewMaxRequest(validSpace).Opts(crud.MaxOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -824,7 +824,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				validSpace,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeTruncateRequest(validSpace).Opts(crud.TruncateOpts{
+			target: crud.NewTruncateRequest(validSpace).Opts(crud.TruncateOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -834,7 +834,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				validSpace,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeLenRequest(validSpace).Opts(crud.LenOpts{
+			target: crud.NewLenRequest(validSpace).Opts(crud.LenOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -845,7 +845,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				nil,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeCountRequest(validSpace).Opts(crud.CountOpts{
+			target: crud.NewCountRequest(validSpace).Opts(crud.CountOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -854,7 +854,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 			ref: tarantool.NewCallRequest("crud.storage_info").Args([]any{
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeStorageInfoRequest().Opts(crud.StorageInfoOpts{
+			target: crud.NewStorageInfoRequest().Opts(crud.StorageInfoOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -864,7 +864,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				nil,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeSchemaRequest().Opts(crud.SchemaOpts{
+			target: crud.NewSchemaRequest().Opts(crud.SchemaOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},
@@ -874,7 +874,7 @@ func TestRequestsVshardRouter(t *testing.T) {
 				validSpace,
 				map[string]any{"vshard_router": "custom_router"},
 			}),
-			target: crud.MakeSchemaRequest().Space(validSpace).Opts(crud.SchemaOpts{
+			target: crud.NewSchemaRequest().Space(validSpace).Opts(crud.SchemaOpts{
 				VshardRouter: option.SomeString("custom_router"),
 			}),
 		},

--- a/crud/result.go
+++ b/crud/result.go
@@ -56,8 +56,8 @@ type Result struct {
 	rowType  reflect.Type
 }
 
-// MakeResult create a Result object with a custom row type for decoding.
-func MakeResult(rowType reflect.Type) Result {
+// NewResult create a Result object with a custom row type for decoding.
+func NewResult(rowType reflect.Type) Result {
 	return Result{
 		rowType: rowType,
 	}

--- a/crud/schema.go
+++ b/crud/schema.go
@@ -51,11 +51,11 @@ type SchemaRequest struct {
 	opts  SchemaOpts
 }
 
-// MakeSchemaRequest returns a new empty SchemaRequest.
-func MakeSchemaRequest() SchemaRequest {
-	req := SchemaRequest{}
-	req.impl = newCall("crud.schema")
-	return req
+// NewSchemaRequest returns a new empty SchemaRequest.
+func NewSchemaRequest() SchemaRequest {
+	return SchemaRequest{
+		baseRequest: newBaseRequest("crud.schema"),
+	}
 }
 
 // Space sets the space name for the SchemaRequest request.

--- a/crud/select.go
+++ b/crud/select.go
@@ -85,8 +85,9 @@ func (opts SelectOpts) EncodeMsgpack(enc *msgpack.Encoder) error {
 // SelectRequest helps you to create request object to call `crud.select`
 // for execution by a Connection.
 type SelectRequest struct {
-	spaceRequest
+	baseRequest
 
+	space      string
 	conditions []Condition
 	opts       SelectOpts
 }
@@ -98,14 +99,13 @@ type selectArgs struct {
 	Opts       SelectOpts
 }
 
-// MakeSelectRequest returns a new empty SelectRequest.
-func MakeSelectRequest(space string) SelectRequest {
-	req := SelectRequest{}
-	req.impl = newCall("crud.select")
-	req.space = space
-	req.conditions = nil
-	req.opts = SelectOpts{}
-	return req
+// NewSelectRequest returns a new empty SelectRequest.
+func NewSelectRequest(space string) SelectRequest {
+	return SelectRequest{
+		baseRequest: newBaseRequest("crud.select"),
+		space:       space,
+		opts:        SelectOpts{},
+	}
 }
 
 // Conditions sets the conditions for the SelectRequest request.

--- a/crud/stats.go
+++ b/crud/stats.go
@@ -17,11 +17,11 @@ type StatsRequest struct {
 	space option.String
 }
 
-// MakeStatsRequest returns a new empty StatsRequest.
-func MakeStatsRequest() StatsRequest {
-	req := StatsRequest{}
-	req.impl = newCall("crud.stats")
-	return req
+// NewStatsRequest returns a new empty StatsRequest.
+func NewStatsRequest() StatsRequest {
+	return StatsRequest{
+		baseRequest: newBaseRequest("crud.stats"),
+	}
 }
 
 // Space sets the space name for the StatsRequest request.

--- a/crud/storage_info.go
+++ b/crud/storage_info.go
@@ -103,12 +103,12 @@ type storageInfoArgs struct {
 	Opts     StorageInfoOpts
 }
 
-// MakeStorageInfoRequest returns a new empty StorageInfoRequest.
-func MakeStorageInfoRequest() StorageInfoRequest {
-	req := StorageInfoRequest{}
-	req.impl = newCall("crud.storage_info")
-	req.opts = StorageInfoOpts{}
-	return req
+// NewStorageInfoRequest returns a new empty StorageInfoRequest.
+func NewStorageInfoRequest() StorageInfoRequest {
+	return StorageInfoRequest{
+		baseRequest: newBaseRequest("crud.storage_info"),
+		opts:        StorageInfoOpts{},
+	}
 }
 
 // Opts sets the options for the torageInfoRequest request.

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -208,21 +208,21 @@ var testProcessDataCases = []struct {
 	{
 		"Select",
 		2,
-		crud.MakeSelectRequest(spaceName).
+		crud.NewSelectRequest(spaceName).
 			Conditions(conditions).
 			Opts(selectOpts),
 	},
 	{
 		"Get",
 		2,
-		crud.MakeGetRequest(spaceName).
+		crud.NewGetRequest(spaceName).
 			Key(key).
 			Opts(getOpts),
 	},
 	{
 		"Update",
 		2,
-		crud.MakeUpdateRequest(spaceName).
+		crud.NewUpdateRequest(spaceName).
 			Key(key).
 			Operations(operations).
 			Opts(simpleOperationOpts),
@@ -230,61 +230,61 @@ var testProcessDataCases = []struct {
 	{
 		"Delete",
 		2,
-		crud.MakeDeleteRequest(spaceName).
+		crud.NewDeleteRequest(spaceName).
 			Key(key).
 			Opts(simpleOperationOpts),
 	},
 	{
 		"Min",
 		2,
-		crud.MakeMinRequest(spaceName).Opts(minOpts),
+		crud.NewMinRequest(spaceName).Opts(minOpts),
 	},
 	{
 		"Min",
 		2,
-		crud.MakeMinRequest(spaceName).Index(indexName).Opts(minOpts),
+		crud.NewMinRequest(spaceName).Index(indexName).Opts(minOpts),
 	},
 	{
 		"Max",
 		2,
-		crud.MakeMaxRequest(spaceName).Opts(maxOpts),
+		crud.NewMaxRequest(spaceName).Opts(maxOpts),
 	},
 	{
 		"Max",
 		2,
-		crud.MakeMaxRequest(spaceName).Index(indexName).Opts(maxOpts),
+		crud.NewMaxRequest(spaceName).Index(indexName).Opts(maxOpts),
 	},
 	{
 		"Truncate",
 		1,
-		crud.MakeTruncateRequest(spaceName).Opts(baseOpts),
+		crud.NewTruncateRequest(spaceName).Opts(baseOpts),
 	},
 	{
 		"Len",
 		1,
-		crud.MakeLenRequest(spaceName).Opts(baseOpts),
+		crud.NewLenRequest(spaceName).Opts(baseOpts),
 	},
 	{
 		"Count",
 		2,
-		crud.MakeCountRequest(spaceName).
+		crud.NewCountRequest(spaceName).
 			Conditions(conditions).
 			Opts(countOpts),
 	},
 	{
 		"Stats",
 		1,
-		crud.MakeStatsRequest().Space(spaceName),
+		crud.NewStatsRequest().Space(spaceName),
 	},
 	{
 		"StorageInfo",
 		1,
-		crud.MakeStorageInfoRequest().Opts(baseOpts),
+		crud.NewStorageInfoRequest().Opts(baseOpts),
 	},
 	{
 		"Schema",
 		1,
-		crud.MakeSchemaRequest().Opts(schemaOpts),
+		crud.NewSchemaRequest().Opts(schemaOpts),
 	},
 }
 
@@ -296,22 +296,22 @@ var testResultWithErrCases = []struct {
 	{
 		"BaseResult",
 		&crud.Result{},
-		crud.MakeSelectRequest(invalidSpaceName).Opts(selectOpts),
+		crud.NewSelectRequest(invalidSpaceName).Opts(selectOpts),
 	},
 	{
 		"ManyResult",
 		&crud.Result{},
-		crud.MakeReplaceManyRequest(invalidSpaceName).Tuples(tuples).Opts(opManyOpts),
+		crud.NewReplaceManyRequest(invalidSpaceName).Tuples(tuples).Opts(opManyOpts),
 	},
 	{
 		"NumberResult",
 		&crud.CountResult{},
-		crud.MakeCountRequest(invalidSpaceName).Opts(countOpts),
+		crud.NewCountRequest(invalidSpaceName).Opts(countOpts),
 	},
 	{
 		"BoolResult",
 		&crud.TruncateResult{},
-		crud.MakeTruncateRequest(invalidSpaceName).Opts(baseOpts),
+		crud.NewTruncateRequest(invalidSpaceName).Opts(baseOpts),
 	},
 }
 
@@ -328,7 +328,7 @@ var testGenerateDataCases = []struct {
 		"Insert",
 		1,
 		1,
-		crud.MakeInsertRequest(spaceName).
+		crud.NewInsertRequest(spaceName).
 			Tuple(tuple).
 			Opts(simpleOperationOpts),
 	},
@@ -336,7 +336,7 @@ var testGenerateDataCases = []struct {
 		"InsertObject",
 		1,
 		1,
-		crud.MakeInsertObjectRequest(spaceName).
+		crud.NewInsertObjectRequest(spaceName).
 			Object(object).
 			Opts(simpleOperationObjectOpts),
 	},
@@ -344,7 +344,7 @@ var testGenerateDataCases = []struct {
 		"InsertMany",
 		1,
 		10,
-		crud.MakeInsertManyRequest(spaceName).
+		crud.NewInsertManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(opManyOpts),
 	},
@@ -352,7 +352,7 @@ var testGenerateDataCases = []struct {
 		"InsertObjectMany",
 		1,
 		10,
-		crud.MakeInsertObjectManyRequest(spaceName).
+		crud.NewInsertObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(opObjManyOpts),
 	},
@@ -360,7 +360,7 @@ var testGenerateDataCases = []struct {
 		"Replace",
 		1,
 		1,
-		crud.MakeReplaceRequest(spaceName).
+		crud.NewReplaceRequest(spaceName).
 			Tuple(tuple).
 			Opts(simpleOperationOpts),
 	},
@@ -368,7 +368,7 @@ var testGenerateDataCases = []struct {
 		"ReplaceObject",
 		1,
 		1,
-		crud.MakeReplaceObjectRequest(spaceName).
+		crud.NewReplaceObjectRequest(spaceName).
 			Object(object).
 			Opts(simpleOperationObjectOpts),
 	},
@@ -376,7 +376,7 @@ var testGenerateDataCases = []struct {
 		"ReplaceMany",
 		1,
 		10,
-		crud.MakeReplaceManyRequest(spaceName).
+		crud.NewReplaceManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(opManyOpts),
 	},
@@ -384,7 +384,7 @@ var testGenerateDataCases = []struct {
 		"ReplaceObjectMany",
 		1,
 		10,
-		crud.MakeReplaceObjectManyRequest(spaceName).
+		crud.NewReplaceObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(opObjManyOpts),
 	},
@@ -392,7 +392,7 @@ var testGenerateDataCases = []struct {
 		"Upsert",
 		1,
 		1,
-		crud.MakeUpsertRequest(spaceName).
+		crud.NewUpsertRequest(spaceName).
 			Tuple(tuple).
 			Operations(operations).
 			Opts(simpleOperationOpts),
@@ -401,7 +401,7 @@ var testGenerateDataCases = []struct {
 		"UpsertObject",
 		1,
 		1,
-		crud.MakeUpsertObjectRequest(spaceName).
+		crud.NewUpsertObjectRequest(spaceName).
 			Object(object).
 			Operations(operations).
 			Opts(simpleOperationOpts),
@@ -410,7 +410,7 @@ var testGenerateDataCases = []struct {
 		"UpsertMany",
 		1,
 		10,
-		crud.MakeUpsertManyRequest(spaceName).
+		crud.NewUpsertManyRequest(spaceName).
 			TuplesOperationsData(tuplesOperationsData).
 			Opts(opManyOpts),
 	},
@@ -418,7 +418,7 @@ var testGenerateDataCases = []struct {
 		"UpsertObjectMany",
 		1,
 		10,
-		crud.MakeUpsertObjectManyRequest(spaceName).
+		crud.NewUpsertObjectManyRequest(spaceName).
 			ObjectsOperationsData(objectsOperationData).
 			Opts(opManyOpts),
 	},
@@ -593,7 +593,7 @@ func TestCrudUpdateSplice(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeUpdateRequest(spaceName).
+	req := crud.NewUpdateRequest(spaceName).
 		Key(key).
 		Operations([]crud.Operation{
 			{
@@ -618,7 +618,7 @@ func TestCrudUpsertSplice(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeUpsertRequest(spaceName).
+	req := crud.NewUpsertRequest(spaceName).
 		Tuple(tuple).
 		Operations([]crud.Operation{
 			{
@@ -643,7 +643,7 @@ func TestCrudUpsertObjectSplice(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeUpsertObjectRequest(spaceName).
+	req := crud.NewUpsertObjectRequest(spaceName).
 		Object(object).
 		Operations([]crud.Operation{
 			{
@@ -700,7 +700,7 @@ func TestUnflattenRows(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	// Do `replace`.
-	req := crud.MakeReplaceRequest(spaceName).
+	req := crud.NewReplaceRequest(spaceName).
 		Tuple(tuple).
 		Opts(simpleOperationOpts)
 	data, err := conn.Do(req).Get()
@@ -756,7 +756,7 @@ func TestBoolResult(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeTruncateRequest(spaceName).Opts(baseOpts)
+	req := crud.NewTruncateRequest(spaceName).Opts(baseOpts)
 	resp := crud.TruncateResult{}
 
 	testCrudRequestPrepareData(t, conn)
@@ -777,7 +777,7 @@ func TestNumberResult(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeCountRequest(spaceName).Opts(countOpts)
+	req := crud.NewCountRequest(spaceName).Opts(countOpts)
 	resp := crud.CountResult{}
 
 	testCrudRequestPrepareData(t, conn)
@@ -816,7 +816,7 @@ func TestBaseResult(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeSelectRequest(spaceName).Opts(selectOpts)
+	req := crud.NewSelectRequest(spaceName).Opts(selectOpts)
 	resp := crud.Result{}
 
 	testCrudRequestPrepareData(t, conn)
@@ -860,7 +860,7 @@ func TestManyResult(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeReplaceManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts)
+	req := crud.NewReplaceManyRequest(spaceName).Tuples(tuples).Opts(opManyOpts)
 	resp := crud.Result{}
 
 	testCrudRequestPrepareData(t, conn)
@@ -886,7 +886,7 @@ func TestStorageInfoResult(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeStorageInfoRequest().Opts(baseOpts)
+	req := crud.NewStorageInfoRequest().Opts(baseOpts)
 	resp := crud.StorageInfoResult{}
 
 	err := conn.Do(req).GetTyped(&resp)
@@ -904,7 +904,7 @@ func TestGetAdditionalOpts(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeGetRequest(spaceName).Key(key).Opts(crud.GetOpts{
+	req := crud.NewGetRequest(spaceName).Key(key).Opts(crud.GetOpts{
 		Timeout:       option.SomeFloat64(1.1),
 		Fields:        option.SomeAny([]any{"name"}),
 		Mode:          option.SomeString("read"),
@@ -925,7 +925,7 @@ var testMetadataCases = []struct {
 }{
 	{
 		"Insert",
-		crud.MakeInsertRequest(spaceName).
+		crud.NewInsertRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.InsertOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -933,7 +933,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"InsertObject",
-		crud.MakeInsertObjectRequest(spaceName).
+		crud.NewInsertObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.InsertObjectOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -941,7 +941,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"InsertMany",
-		crud.MakeInsertManyRequest(spaceName).
+		crud.NewInsertManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.InsertManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -949,7 +949,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"InsertObjectMany",
-		crud.MakeInsertObjectManyRequest(spaceName).
+		crud.NewInsertObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.InsertObjectManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -957,7 +957,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Replace",
-		crud.MakeReplaceRequest(spaceName).
+		crud.NewReplaceRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.ReplaceOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -965,7 +965,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"ReplaceObject",
-		crud.MakeReplaceObjectRequest(spaceName).
+		crud.NewReplaceObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.ReplaceObjectOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -973,7 +973,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"ReplaceMany",
-		crud.MakeReplaceManyRequest(spaceName).
+		crud.NewReplaceManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.ReplaceManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -981,7 +981,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"ReplaceObjectMany",
-		crud.MakeReplaceObjectManyRequest(spaceName).
+		crud.NewReplaceObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.ReplaceObjectManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -989,7 +989,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Upsert",
-		crud.MakeUpsertRequest(spaceName).
+		crud.NewUpsertRequest(spaceName).
 			Tuple(tuple).
 			Operations(operations).
 			Opts(crud.UpsertOpts{
@@ -998,7 +998,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"UpsertObject",
-		crud.MakeUpsertObjectRequest(spaceName).
+		crud.NewUpsertObjectRequest(spaceName).
 			Object(object).
 			Operations(operations).
 			Opts(crud.UpsertObjectOpts{
@@ -1007,7 +1007,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"UpsertMany",
-		crud.MakeUpsertManyRequest(spaceName).
+		crud.NewUpsertManyRequest(spaceName).
 			TuplesOperationsData(tuplesOperationsData).
 			Opts(crud.UpsertManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -1015,7 +1015,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"UpsertObjectMany",
-		crud.MakeUpsertObjectManyRequest(spaceName).
+		crud.NewUpsertObjectManyRequest(spaceName).
 			ObjectsOperationsData(objectsOperationData).
 			Opts(crud.UpsertObjectManyOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -1023,7 +1023,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Select",
-		crud.MakeSelectRequest(spaceName).
+		crud.NewSelectRequest(spaceName).
 			Conditions(conditions).
 			Opts(crud.SelectOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -1031,7 +1031,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Get",
-		crud.MakeGetRequest(spaceName).
+		crud.NewGetRequest(spaceName).
 			Key(key).
 			Opts(crud.GetOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -1039,7 +1039,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Update",
-		crud.MakeUpdateRequest(spaceName).
+		crud.NewUpdateRequest(spaceName).
 			Key(key).
 			Operations(operations).
 			Opts(crud.UpdateOpts{
@@ -1048,7 +1048,7 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Delete",
-		crud.MakeDeleteRequest(spaceName).
+		crud.NewDeleteRequest(spaceName).
 			Key(key).
 			Opts(crud.DeleteOpts{
 				FetchLatestMetadata: option.SomeBool(true),
@@ -1056,14 +1056,14 @@ var testMetadataCases = []struct {
 	},
 	{
 		"Min",
-		crud.MakeMinRequest(spaceName).
+		crud.NewMinRequest(spaceName).
 			Opts(crud.MinOpts{
 				FetchLatestMetadata: option.SomeBool(true),
 			}),
 	},
 	{
 		"Max",
-		crud.MakeMaxRequest(spaceName).
+		crud.NewMaxRequest(spaceName).
 			Opts(crud.MaxOpts{
 				FetchLatestMetadata: option.SomeBool(true),
 			}),
@@ -1105,7 +1105,7 @@ var testNoreturnCases = []struct {
 }{
 	{
 		"Insert",
-		crud.MakeInsertRequest(spaceName).
+		crud.NewInsertRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.InsertOpts{
 				Noreturn: option.SomeBool(true),
@@ -1113,7 +1113,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"InsertObject",
-		crud.MakeInsertObjectRequest(spaceName).
+		crud.NewInsertObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.InsertObjectOpts{
 				Noreturn: option.SomeBool(true),
@@ -1121,7 +1121,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"InsertMany",
-		crud.MakeInsertManyRequest(spaceName).
+		crud.NewInsertManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.InsertManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1129,7 +1129,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"InsertObjectMany",
-		crud.MakeInsertObjectManyRequest(spaceName).
+		crud.NewInsertObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.InsertObjectManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1137,7 +1137,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"Replace",
-		crud.MakeReplaceRequest(spaceName).
+		crud.NewReplaceRequest(spaceName).
 			Tuple(tuple).
 			Opts(crud.ReplaceOpts{
 				Noreturn: option.SomeBool(true),
@@ -1145,7 +1145,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"ReplaceObject",
-		crud.MakeReplaceObjectRequest(spaceName).
+		crud.NewReplaceObjectRequest(spaceName).
 			Object(object).
 			Opts(crud.ReplaceObjectOpts{
 				Noreturn: option.SomeBool(true),
@@ -1153,7 +1153,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"ReplaceMany",
-		crud.MakeReplaceManyRequest(spaceName).
+		crud.NewReplaceManyRequest(spaceName).
 			Tuples(tuples).
 			Opts(crud.ReplaceManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1161,7 +1161,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"ReplaceObjectMany",
-		crud.MakeReplaceObjectManyRequest(spaceName).
+		crud.NewReplaceObjectManyRequest(spaceName).
 			Objects(objects).
 			Opts(crud.ReplaceObjectManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1169,7 +1169,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"Upsert",
-		crud.MakeUpsertRequest(spaceName).
+		crud.NewUpsertRequest(spaceName).
 			Tuple(tuple).
 			Operations(operations).
 			Opts(crud.UpsertOpts{
@@ -1178,7 +1178,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"UpsertObject",
-		crud.MakeUpsertObjectRequest(spaceName).
+		crud.NewUpsertObjectRequest(spaceName).
 			Object(object).
 			Operations(operations).
 			Opts(crud.UpsertObjectOpts{
@@ -1187,7 +1187,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"UpsertMany",
-		crud.MakeUpsertManyRequest(spaceName).
+		crud.NewUpsertManyRequest(spaceName).
 			TuplesOperationsData(tuplesOperationsData).
 			Opts(crud.UpsertManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1195,7 +1195,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"UpsertObjectMany",
-		crud.MakeUpsertObjectManyRequest(spaceName).
+		crud.NewUpsertObjectManyRequest(spaceName).
 			ObjectsOperationsData(objectsOperationData).
 			Opts(crud.UpsertObjectManyOpts{
 				Noreturn: option.SomeBool(true),
@@ -1203,7 +1203,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"Update",
-		crud.MakeUpdateRequest(spaceName).
+		crud.NewUpdateRequest(spaceName).
 			Key(key).
 			Operations(operations).
 			Opts(crud.UpdateOpts{
@@ -1212,7 +1212,7 @@ var testNoreturnCases = []struct {
 	},
 	{
 		"Delete",
-		crud.MakeDeleteRequest(spaceName).
+		crud.NewDeleteRequest(spaceName).
 			Key(key).
 			Opts(crud.DeleteOpts{
 				Noreturn: option.SomeBool(true),
@@ -1361,7 +1361,7 @@ func TestSchemaTyped(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeSchemaRequest()
+	req := crud.NewSchemaRequest()
 	var result crud.SchemaResult
 
 	err := conn.Do(req).GetTyped(&result)
@@ -1373,7 +1373,7 @@ func TestSpaceSchemaTyped(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeSchemaRequest().Space("test")
+	req := crud.NewSchemaRequest().Space("test")
 	var result crud.SpaceSchemaResult
 
 	err := conn.Do(req).GetTyped(&result)
@@ -1385,7 +1385,7 @@ func TestSpaceSchemaTypedError(t *testing.T) {
 	conn := connect(t)
 	defer func() { _ = conn.Close() }()
 
-	req := crud.MakeSchemaRequest().Space("not_exist")
+	req := crud.NewSchemaRequest().Space("not_exist")
 	var result crud.SpaceSchemaResult
 
 	err := conn.Do(req).GetTyped(&result)
@@ -1413,14 +1413,14 @@ var testStorageYieldCases = []struct {
 }{
 	{
 		"Count",
-		crud.MakeCountRequest(spaceName).
+		crud.NewCountRequest(spaceName).
 			Opts(crud.CountOpts{
 				YieldEvery: option.SomeUint(500),
 			}),
 	},
 	{
 		"Select",
-		crud.MakeSelectRequest(spaceName).
+		crud.NewSelectRequest(spaceName).
 			Opts(crud.SelectOpts{
 				YieldEvery: option.SomeUint(500),
 			}),

--- a/crud/truncate.go
+++ b/crud/truncate.go
@@ -17,9 +17,10 @@ type TruncateOpts = BaseOpts
 // TruncateRequest helps you to create request object to call `crud.truncate`
 // for execution by a Connection.
 type TruncateRequest struct {
-	spaceRequest
+	baseRequest
 
-	opts TruncateOpts
+	space string
+	opts  TruncateOpts
 }
 
 type truncateArgs struct {
@@ -28,13 +29,13 @@ type truncateArgs struct {
 	Opts     TruncateOpts
 }
 
-// MakeTruncateRequest returns a new empty TruncateRequest.
-func MakeTruncateRequest(space string) TruncateRequest {
-	req := TruncateRequest{}
-	req.impl = newCall("crud.truncate")
-	req.space = space
-	req.opts = TruncateOpts{}
-	return req
+// NewTruncateRequest returns a new empty TruncateRequest.
+func NewTruncateRequest(space string) TruncateRequest {
+	return TruncateRequest{
+		baseRequest: newBaseRequest("crud.truncate"),
+		space:       space,
+		opts:        TruncateOpts{},
+	}
 }
 
 // Opts sets the options for the TruncateRequest request.

--- a/crud/update.go
+++ b/crud/update.go
@@ -14,8 +14,9 @@ type UpdateOpts = SimpleOperationOpts
 // UpdateRequest helps you to create request object to call `crud.update`
 // for execution by a Connection.
 type UpdateRequest struct {
-	spaceRequest
+	baseRequest
 
+	space      string
 	key        Tuple
 	operations []Operation
 	opts       UpdateOpts
@@ -29,14 +30,14 @@ type updateArgs struct {
 	Opts       UpdateOpts
 }
 
-// MakeUpdateRequest returns a new empty UpdateRequest.
-func MakeUpdateRequest(space string) UpdateRequest {
-	req := UpdateRequest{}
-	req.impl = newCall("crud.update")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpdateOpts{}
-	return req
+// NewUpdateRequest returns a new empty UpdateRequest.
+func NewUpdateRequest(space string) UpdateRequest {
+	return UpdateRequest{
+		baseRequest: newBaseRequest("crud.update"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpdateOpts{},
+	}
 }
 
 // Key sets the key for the UpdateRequest request.

--- a/crud/upsert.go
+++ b/crud/upsert.go
@@ -14,8 +14,9 @@ type UpsertOpts = SimpleOperationOpts
 // UpsertRequest helps you to create request object to call `crud.upsert`
 // for execution by a Connection.
 type UpsertRequest struct {
-	spaceRequest
+	baseRequest
 
+	space      string
 	tuple      Tuple
 	operations []Operation
 	opts       UpsertOpts
@@ -29,14 +30,14 @@ type upsertArgs struct {
 	Opts       UpsertOpts
 }
 
-// MakeUpsertRequest returns a new empty UpsertRequest.
-func MakeUpsertRequest(space string) UpsertRequest {
-	req := UpsertRequest{}
-	req.impl = newCall("crud.upsert")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpsertOpts{}
-	return req
+// NewUpsertRequest returns a new empty UpsertRequest.
+func NewUpsertRequest(space string) UpsertRequest {
+	return UpsertRequest{
+		baseRequest: newBaseRequest("crud.upsert"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpsertOpts{},
+	}
 }
 
 // Tuple sets the tuple for the UpsertRequest request.
@@ -84,8 +85,9 @@ type UpsertObjectOpts = SimpleOperationOpts
 // UpsertObjectRequest helps you to create request object to call
 // `crud.upsert_object` for execution by a Connection.
 type UpsertObjectRequest struct {
-	spaceRequest
+	baseRequest
 
+	space      string
 	object     Object
 	operations []Operation
 	opts       UpsertObjectOpts
@@ -99,14 +101,14 @@ type upsertObjectArgs struct {
 	Opts       UpsertObjectOpts
 }
 
-// MakeUpsertObjectRequest returns a new empty UpsertObjectRequest.
-func MakeUpsertObjectRequest(space string) UpsertObjectRequest {
-	req := UpsertObjectRequest{}
-	req.impl = newCall("crud.upsert_object")
-	req.space = space
-	req.operations = []Operation{}
-	req.opts = UpsertObjectOpts{}
-	return req
+// NewUpsertObjectRequest returns a new empty UpsertObjectRequest.
+func NewUpsertObjectRequest(space string) UpsertObjectRequest {
+	return UpsertObjectRequest{
+		baseRequest: newBaseRequest("crud.upsert_object"),
+		space:       space,
+		operations:  []Operation{},
+		opts:        UpsertObjectOpts{},
+	}
 }
 
 // Object sets the tuple for the UpsertObjectRequest request.

--- a/crud/upsert_many.go
+++ b/crud/upsert_many.go
@@ -21,8 +21,9 @@ type TupleOperationsData struct {
 // UpsertManyRequest helps you to create request object to call
 // `crud.upsert_many` for execution by a Connection.
 type UpsertManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space                string
 	tuplesOperationsData []TupleOperationsData
 	opts                 UpsertManyOpts
 }
@@ -34,14 +35,14 @@ type upsertManyArgs struct {
 	Opts                 UpsertManyOpts
 }
 
-// MakeUpsertManyRequest returns a new empty UpsertManyRequest.
-func MakeUpsertManyRequest(space string) UpsertManyRequest {
-	req := UpsertManyRequest{}
-	req.impl = newCall("crud.upsert_many")
-	req.space = space
-	req.tuplesOperationsData = []TupleOperationsData{}
-	req.opts = UpsertManyOpts{}
-	return req
+// NewUpsertManyRequest returns a new empty UpsertManyRequest.
+func NewUpsertManyRequest(space string) UpsertManyRequest {
+	return UpsertManyRequest{
+		baseRequest:          newBaseRequest("crud.upsert_many"),
+		space:                space,
+		tuplesOperationsData: []TupleOperationsData{},
+		opts:                 UpsertManyOpts{},
+	}
 }
 
 // TuplesOperationsData sets tuples and operations for
@@ -88,8 +89,9 @@ type ObjectOperationsData struct {
 // UpsertObjectManyRequest helps you to create request object to call
 // `crud.upsert_object_many` for execution by a Connection.
 type UpsertObjectManyRequest struct {
-	spaceRequest
+	baseRequest
 
+	space                 string
 	objectsOperationsData []ObjectOperationsData
 	opts                  UpsertObjectManyOpts
 }
@@ -101,14 +103,14 @@ type upsertObjectManyArgs struct {
 	Opts                  UpsertObjectManyOpts
 }
 
-// MakeUpsertObjectManyRequest returns a new empty UpsertObjectManyRequest.
-func MakeUpsertObjectManyRequest(space string) UpsertObjectManyRequest {
-	req := UpsertObjectManyRequest{}
-	req.impl = newCall("crud.upsert_object_many")
-	req.space = space
-	req.objectsOperationsData = []ObjectOperationsData{}
-	req.opts = UpsertObjectManyOpts{}
-	return req
+// NewUpsertObjectManyRequest returns a new empty UpsertObjectManyRequest.
+func NewUpsertObjectManyRequest(space string) UpsertObjectManyRequest {
+	return UpsertObjectManyRequest{
+		baseRequest:           newBaseRequest("crud.upsert_object_many"),
+		space:                 space,
+		objectsOperationsData: []ObjectOperationsData{},
+		opts:                  UpsertObjectManyOpts{},
+	}
 }
 
 // ObjectsOperationsData sets objects and operations

--- a/datetime/datetime.go
+++ b/datetime/datetime.go
@@ -95,15 +95,15 @@ const (
 	offsetMax = 14 * 60 * 60
 )
 
-// MakeDatetime returns a datetime.Datetime object that contains a
+// NewDatetime returns a datetime.Datetime object that contains a
 // specified time.Time. It may return an error if the Time value is out of
 // supported range: [-5879610-06-22T00:00Z .. 5879611-07-11T00:00Z] or
 // an invalid timezone or offset value is out of supported range:
 // [-12 * 60 * 60, 14 * 60 * 60].
 //
 // NOTE: Tarantool's datetime.tz value is picked from t.Location().String().
-// "Local" location is unsupported, see ExampleMakeDatetime_localUnsupported.
-func MakeDatetime(t time.Time) (Datetime, error) {
+// "Local" location is unsupported, see ExampleNewDatetime_localUnsupported.
+func NewDatetime(t time.Time) (Datetime, error) {
 	dt := Datetime{}
 	seconds := t.Unix()
 
@@ -195,7 +195,7 @@ func (d Datetime) MarshalMsgpack() ([]byte, error) {
 	zone := tm.Location().String()
 	_, offset := tm.Zone()
 	if zone != NoTimezone {
-		// The zone value already checked in MakeDatetime() or
+		// The zone value already checked in NewDatetime() or
 		// UnmarshalMsgpack() calls.
 		dt.tzIndex = int16(timezoneToIndex[zone])
 	}
@@ -257,7 +257,7 @@ func (d *Datetime) UnmarshalMsgpack(data []byte) error {
 	}
 	tt = tt.In(loc)
 
-	newDatetime, err := MakeDatetime(tt)
+	newDatetime, err := NewDatetime(tt)
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func (d Datetime) add(ival Interval, positive bool) (Datetime, error) {
 		int(newVal.Day), int(newVal.Hour), int(newVal.Min),
 		int(newVal.Sec), int(newVal.Nsec), d.time.Location())
 
-	return MakeDatetime(tm)
+	return NewDatetime(tm)
 }
 
 // Add creates a new Datetime as addition of the Datetime and Interval. It may

--- a/datetime/datetime_gen_test.go
+++ b/datetime/datetime_gen_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSomeOptionalDatetime(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
 	opt := SomeOptionalDatetime(val)
 
@@ -34,7 +34,7 @@ func TestNoneOptionalDatetime(t *testing.T) {
 }
 
 func TestOptionalDatetime_MustGet(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
 	optSome := SomeOptionalDatetime(val)
 	optNone := NoneOptionalDatetime()
@@ -44,7 +44,7 @@ func TestOptionalDatetime_MustGet(t *testing.T) {
 }
 
 func TestOptionalDatetime_Unwrap(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
 	optSome := SomeOptionalDatetime(val)
 	optNone := NoneOptionalDatetime()
@@ -54,9 +54,9 @@ func TestOptionalDatetime_Unwrap(t *testing.T) {
 }
 
 func TestOptionalDatetime_UnwrapOr(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
-	def, err := MakeDatetime(time.Now().Add(1 * time.Hour).In(time.UTC))
+	def, err := NewDatetime(time.Now().Add(1 * time.Hour).In(time.UTC))
 	require.NoError(t, err)
 	optSome := SomeOptionalDatetime(val)
 	optNone := NoneOptionalDatetime()
@@ -66,9 +66,9 @@ func TestOptionalDatetime_UnwrapOr(t *testing.T) {
 }
 
 func TestOptionalDatetime_UnwrapOrElse(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
-	def, err := MakeDatetime(time.Now().Add(1 * time.Hour).In(time.UTC))
+	def, err := NewDatetime(time.Now().Add(1 * time.Hour).In(time.UTC))
 	require.NoError(t, err)
 	optSome := SomeOptionalDatetime(val)
 	optNone := NoneOptionalDatetime()
@@ -78,7 +78,7 @@ func TestOptionalDatetime_UnwrapOrElse(t *testing.T) {
 }
 
 func TestOptionalDatetime_EncodeDecodeMsgpack_Some(t *testing.T) {
-	val, err := MakeDatetime(time.Now().In(time.UTC))
+	val, err := NewDatetime(time.Now().In(time.UTC))
 	require.NoError(t, err)
 	some := SomeOptionalDatetime(val)
 

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -62,7 +62,7 @@ func skipIfDatetimeUnsupported(t *testing.T) {
 
 func TestDatetimeAdd(t *testing.T) {
 	tm := time.Unix(0, 0).UTC()
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unexpected error")
 
 	newdt, err := dt.Add(Interval{
@@ -225,7 +225,7 @@ func TestDatetimeAddAdjust(t *testing.T) {
 	for _, tc := range cases {
 		tm, err := time.Parse(time.RFC3339, tc.date)
 		require.NoError(t, err, "Unexpected error")
-		dt, err := MakeDatetime(tm)
+		dt, err := NewDatetime(tm)
 		require.NoError(t, err, "Unexpected error")
 		t.Run(fmt.Sprintf("%d_%d_%d_%s", tc.year, tc.month, tc.adjust, tc.date),
 			func(t *testing.T) {
@@ -243,7 +243,7 @@ func TestDatetimeAddAdjust(t *testing.T) {
 
 func TestDatetimeAddSubSymmetric(t *testing.T) {
 	tm := time.Unix(0, 0).UTC()
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unexpected error")
 
 	newdtadd, err := dt.Add(Interval{
@@ -277,7 +277,7 @@ func TestDatetimeAddSubSymmetric(t *testing.T) {
 
 func TestDatetimeAddOutOfRange(t *testing.T) {
 	tm := time.Unix(0, 0).UTC()
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unexpected error")
 
 	_, err = dt.Add(Interval{Year: 1000000000})
@@ -295,9 +295,9 @@ func TestDatetimeInterval(t *testing.T) {
 	tmSecond, err := time.Parse(time.RFC3339, second)
 	require.NoError(t, err, "Error in time.Parse()")
 
-	dtFirst, err := MakeDatetime(tmFirst)
+	dtFirst, err := NewDatetime(tmFirst)
 	require.NoError(t, err, "Unable to create Datetime")
-	dtSecond, err := MakeDatetime(tmSecond)
+	dtSecond, err := NewDatetime(tmSecond)
 	require.NoError(t, err, "Unable to create Datetime")
 
 	ivalFirst := dtFirst.Interval(dtSecond)
@@ -340,8 +340,8 @@ func TestDatetimeTarantoolInterval(t *testing.T) {
 	for _, date := range dates {
 		tm, err := time.Parse(time.RFC3339, date)
 		require.NoError(t, err, "Error in time.Parse()")
-		dt, err := MakeDatetime(tm)
-		require.NoError(t, err, "Error in MakeDatetime()")
+		dt, err := NewDatetime(tm)
+		require.NoError(t, err, "Error in NewDatetime()")
 		datetimes = append(datetimes, dt)
 	}
 
@@ -390,7 +390,7 @@ func TestInvalidTimezone(t *testing.T) {
 	tm, err := time.Parse(time.RFC3339, "2010-08-12T11:39:14Z")
 	require.NoError(t, err, "Time parse failed")
 	tm = tm.In(invalidLoc)
-	_, err = MakeDatetime(tm)
+	_, err = NewDatetime(tm)
 	require.Error(t, err, "Expected error for invalid timezone")
 	require.Equal(t, "unknown timezone AnyInvalid with offset 0", err.Error(), "Unexpected error")
 }
@@ -420,7 +420,7 @@ func TestInvalidOffset(t *testing.T) {
 			tm, err := time.Parse(time.RFC3339, "2010-08-12T11:39:14Z")
 			require.NoError(t, err, "Time parse failed")
 			tm = tm.In(loc)
-			_, err = MakeDatetime(tm)
+			_, err = NewDatetime(tm)
 			if testcase.ok {
 				require.NoError(t, err, "Unexpected error")
 			} else {
@@ -452,7 +452,7 @@ func TestCustomTimezone(t *testing.T) {
 	tm, err := time.Parse(time.RFC3339, "2010-08-12T11:44:14Z")
 	require.NoError(t, err, "Time parse failed")
 	tm = tm.In(customLoc)
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unable to create datetime")
 
 	req := NewReplaceRequest(spaceTuple1).Tuple([]any{dt, "payload"})
@@ -476,7 +476,7 @@ func TestCustomTimezone(t *testing.T) {
 func tupleInsertSelectDelete(t *testing.T, conn *Connection, tm time.Time) {
 	t.Helper()
 
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm)
 
 	// Insert tuple with datetime.
@@ -610,7 +610,7 @@ func TestDatetimeOutOfRange(t *testing.T) {
 
 	for _, tm := range greaterBoundaryTimes {
 		t.Run(tm.String(), func(t *testing.T) {
-			_, err := MakeDatetime(tm)
+			_, err := NewDatetime(tm)
 			assert.Error(t, err, "Time %s should be unsupported!", tm)
 		})
 	}
@@ -625,7 +625,7 @@ func TestDatetimeReplace(t *testing.T) {
 	tm, err := time.Parse(time.RFC3339, "2007-01-02T15:04:05Z")
 	require.NoError(t, err, "Time parse failed")
 
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm)
 
 	rep := NewReplaceRequest(spaceTuple1).Tuple([]any{dt, "payload"})
@@ -778,9 +778,9 @@ func TestCustomEncodeDecodeTuple1(t *testing.T) {
 
 	tm1, _ := time.Parse(time.RFC3339, "2010-05-24T17:51:56.000000009Z")
 	tm2, _ := time.Parse(time.RFC3339, "2022-05-24T17:51:56.000000009Z")
-	dt1, err := MakeDatetime(tm1)
+	dt1, err := NewDatetime(tm1)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm1)
-	dt2, err := MakeDatetime(tm2)
+	dt2, err := NewDatetime(tm2)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm2)
 	const cid = 13
 	const orig = "orig"
@@ -862,7 +862,7 @@ func TestCustomEncodeDecodeTuple5(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	tm := time.Unix(500, 1000).In(time.FixedZone(NoTimezone, 0))
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm)
 
 	ins := NewInsertRequest(spaceTuple1).Tuple([]any{dt})
@@ -900,7 +900,7 @@ func TestMPEncode(t *testing.T) {
 				tm = tm.In(loc)
 			}
 			require.NoError(t, err, "Time (%s) parse failed", testcase.dt)
-			dt, err := MakeDatetime(tm)
+			dt, err := NewDatetime(tm)
 			require.NoError(t, err, "Unable to create Datetime")
 			buf, err := msgpack.Marshal(dt)
 			require.NoError(t, err, "Marshalling failed")
@@ -992,7 +992,7 @@ func runTestMain(m *testing.M) int {
 
 func TestDatetimeString(t *testing.T) {
 	tm, _ := time.Parse(time.RFC3339Nano, "2010-05-24T17:51:56.000000009Z")
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	require.NoError(t, err, "Unable to create Datetime from %s", tm)
 
 	expected := "2010-05-24T17:51:56.000000009Z"

--- a/datetime/example_test.go
+++ b/datetime/example_test.go
@@ -40,7 +40,7 @@ func Example() {
 		fmt.Printf("Error in time.Parse() is %v", err)
 		return
 	}
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -93,13 +93,13 @@ func Example() {
 	fmt.Printf("Data: %v\n", respDt.ToTime())
 }
 
-// ExampleMakeDatetime_localUnsupported demonstrates that "Local" location is
+// ExampleNewDatetime_localUnsupported demonstrates that "Local" location is
 // unsupported.
-func ExampleMakeDatetime_localUnsupported() {
+func ExampleNewDatetime_localUnsupported() {
 	tm := time.Now().Local()
 	loc := tm.Location()
 	fmt.Println("Location:", loc)
-	if _, err := MakeDatetime(tm); err != nil {
+	if _, err := NewDatetime(tm); err != nil {
 		fmt.Printf("Could not create a Datetime with %s location.\n", loc)
 	} else {
 		fmt.Printf("A Datetime with %s location created.\n", loc)
@@ -111,7 +111,7 @@ func ExampleMakeDatetime_localUnsupported() {
 
 // Example demonstrates how to create a datetime for Tarantool without UTC
 // timezone in datetime.
-func ExampleMakeDatetime_noTimezone() {
+func ExampleNewDatetime_noTimezone() {
 	var datetime = "2013-10-28T17:51:56.000000009Z"
 	tm, err := time.Parse(time.RFC3339, datetime)
 	if err != nil {
@@ -121,7 +121,7 @@ func ExampleMakeDatetime_noTimezone() {
 
 	tm = tm.In(time.FixedZone(NoTimezone, 0))
 
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -147,12 +147,12 @@ func ExampleDatetime_Interval() {
 		return
 	}
 
-	dtFirst, err := MakeDatetime(tmFirst)
+	dtFirst, err := NewDatetime(tmFirst)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tmFirst, err)
 		return
 	}
-	dtSecond, err := MakeDatetime(tmSecond)
+	dtSecond, err := NewDatetime(tmSecond)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tmSecond, err)
 		return
@@ -172,7 +172,7 @@ func ExampleDatetime_Add() {
 		fmt.Printf("Error in time.Parse() is %s", err)
 		return
 	}
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return
@@ -203,7 +203,7 @@ func ExampleDatetime_Add_dst() {
 		return
 	}
 	tm := time.Date(2008, 1, 1, 1, 1, 1, 1, loc)
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime: %s", err)
 		return
@@ -239,7 +239,7 @@ func ExampleDatetime_Sub() {
 		fmt.Printf("Error in time.Parse() is %s", err)
 		return
 	}
-	dt, err := MakeDatetime(tm)
+	dt, err := NewDatetime(tm)
 	if err != nil {
 		fmt.Printf("Unable to create Datetime from %s: %s", tm, err)
 		return

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -58,19 +58,19 @@ type Decimal struct {
 	decimal.Decimal
 }
 
-// MakeDecimal creates a new Decimal from a decimal.Decimal.
-func MakeDecimal(decimal decimal.Decimal) Decimal {
+// NewDecimal creates a new Decimal from a decimal.Decimal.
+func NewDecimal(decimal decimal.Decimal) Decimal {
 	return Decimal{Decimal: decimal}
 }
 
-// MakeDecimalFromString creates a new Decimal from a string.
-func MakeDecimalFromString(src string) (Decimal, error) {
+// NewDecimalFromString creates a new Decimal from a string.
+func NewDecimalFromString(src string) (Decimal, error) {
 	result := Decimal{}
 	dec, err := decimal.NewFromString(src)
 	if err != nil {
 		return result, err
 	}
-	result = MakeDecimal(dec)
+	result = NewDecimal(dec)
 	return result, nil
 }
 
@@ -122,7 +122,7 @@ func (d *Decimal) UnmarshalMsgpack(data []byte) error {
 		dec = dec.Shift(int32(exp))
 	}
 
-	*d = MakeDecimal(dec)
+	*d = NewDecimal(dec)
 	return nil
 }
 
@@ -374,10 +374,10 @@ func (d Decimal) handleMinInt64(scale int) string {
 	return string(buf[:pos])
 }
 
-func MustMakeDecimal(src string) Decimal {
-	dec, err := MakeDecimalFromString(src)
+func MustNewDecimal(src string) Decimal {
+	dec, err := NewDecimalFromString(src)
 	if err != nil {
-		panic(fmt.Sprintf("MustMakeDecimalFromString: %v", err))
+		panic(fmt.Sprintf("MustNewDecimalFromString: %v", err))
 	}
 	return dec
 }

--- a/decimal/decimal_bench_test.go
+++ b/decimal/decimal_bench_test.go
@@ -10,7 +10,7 @@ import (
 
 // Minimal benchmark without dependencies.
 func BenchmarkMinimal(b *testing.B) {
-	dec := MustMakeDecimal("123.45")
+	dec := MustNewDecimal("123.45")
 
 	b.Run("String", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -42,7 +42,7 @@ func BenchmarkDecimalString_SmallNumbers(b *testing.B) {
 
 	decimals := make([]Decimal, len(smallNumbers))
 	for i, str := range smallNumbers {
-		decimals[i] = MustMakeDecimal(str)
+		decimals[i] = MustNewDecimal(str)
 	}
 
 	b.ResetTimer()
@@ -74,7 +74,7 @@ func BenchmarkDecimalString_Int64Boundaries(b *testing.B) {
 
 	decimals := make([]Decimal, len(boundaryNumbers))
 	for i, str := range boundaryNumbers {
-		decimals[i] = MustMakeDecimal(str)
+		decimals[i] = MustNewDecimal(str)
 	}
 
 	b.ResetTimer()
@@ -106,7 +106,7 @@ func BenchmarkDecimalString_LargeNumbers(b *testing.B) {
 
 	decimals := make([]Decimal, len(largeNumbers))
 	for i, str := range largeNumbers {
-		decimals[i] = MustMakeDecimal(str)
+		decimals[i] = MustNewDecimal(str)
 	}
 
 	b.ResetTimer()
@@ -143,7 +143,7 @@ func BenchmarkDecimalString_Mixed(b *testing.B) {
 
 	decimals := make([]Decimal, len(mixedNumbers))
 	for i, str := range mixedNumbers {
-		decimals[i] = MustMakeDecimal(str)
+		decimals[i] = MustNewDecimal(str)
 	}
 
 	b.ResetTimer()
@@ -178,7 +178,7 @@ func BenchmarkDecimalString_DifferentPrecision(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-			dec := MustMakeDecimal(tc.value)
+			dec := MustNewDecimal(tc.value)
 
 			b.Run("String", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
@@ -209,7 +209,7 @@ func BenchmarkDecimalString_Random(b *testing.B) {
 			scale := rng.Intn(10)
 
 			if scale == 0 {
-				return MustMakeDecimal(strconv.FormatInt(value, 10))
+				return MustNewDecimal(strconv.FormatInt(value, 10))
 			}
 
 			// For numbers with fractional part
@@ -225,14 +225,14 @@ func BenchmarkDecimalString_Random(b *testing.B) {
 				if value < 0 {
 					result = "-" + result
 				}
-				return MustMakeDecimal(result)
+				return MustNewDecimal(result)
 			} else {
 				zeros := scale - len(str)
 				result := "0." + strings.Repeat("0", zeros) + str
 				if value < 0 {
 					result = "-" + result
 				}
-				return MustMakeDecimal(result)
+				return MustNewDecimal(result)
 			}
 		} else {
 			// Large numbers (fallback) - generate correct strings
@@ -253,7 +253,7 @@ func BenchmarkDecimalString_Random(b *testing.B) {
 				if rng.Float64() < 0.5 {
 					bigNum = "-" + bigNum
 				}
-				return MustMakeDecimal(bigNum)
+				return MustNewDecimal(bigNum)
 			}
 
 			if scale < len(bigNum) {
@@ -263,14 +263,14 @@ func BenchmarkDecimalString_Random(b *testing.B) {
 				if rng.Float64() < 0.5 {
 					result = "-" + result
 				}
-				return MustMakeDecimal(result)
+				return MustNewDecimal(result)
 			} else {
 				zeros := scale - len(bigNum)
 				result := "0." + strings.Repeat("0", zeros) + bigNum
 				if rng.Float64() < 0.5 {
 					result = "-" + result
 				}
-				return MustMakeDecimal(result)
+				return MustNewDecimal(result)
 			}
 		}
 	}
@@ -308,7 +308,7 @@ func BenchmarkDecimalString_MemoryAllocations(b *testing.B) {
 
 	decimals := make([]Decimal, len(testNumbers))
 	for i, str := range testNumbers {
-		decimals[i] = MustMakeDecimal(str)
+		decimals[i] = MustNewDecimal(str)
 	}
 
 	b.ResetTimer()

--- a/decimal/decimal_gen_test.go
+++ b/decimal/decimal_gen_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSomeOptionalDecimal(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
 	opt := SomeOptionalDecimal(val)
 
 	assert.True(t, opt.IsSome())
@@ -33,7 +33,7 @@ func TestNoneOptionalDecimal(t *testing.T) {
 }
 
 func TestOptionalDecimal_MustGet(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
 	optSome := SomeOptionalDecimal(val)
 	optNone := NoneOptionalDecimal()
 
@@ -42,7 +42,7 @@ func TestOptionalDecimal_MustGet(t *testing.T) {
 }
 
 func TestOptionalDecimal_Unwrap(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
 	optSome := SomeOptionalDecimal(val)
 	optNone := NoneOptionalDecimal()
 
@@ -51,8 +51,8 @@ func TestOptionalDecimal_Unwrap(t *testing.T) {
 }
 
 func TestOptionalDecimal_UnwrapOr(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
-	def := MakeDecimal(decimal.NewFromFloat(4.56))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
+	def := NewDecimal(decimal.NewFromFloat(4.56))
 	optSome := SomeOptionalDecimal(val)
 	optNone := NoneOptionalDecimal()
 
@@ -61,8 +61,8 @@ func TestOptionalDecimal_UnwrapOr(t *testing.T) {
 }
 
 func TestOptionalDecimal_UnwrapOrElse(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
-	def := MakeDecimal(decimal.NewFromFloat(4.56))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
+	def := NewDecimal(decimal.NewFromFloat(4.56))
 	optSome := SomeOptionalDecimal(val)
 	optNone := NoneOptionalDecimal()
 
@@ -71,7 +71,7 @@ func TestOptionalDecimal_UnwrapOrElse(t *testing.T) {
 }
 
 func TestOptionalDecimal_EncodeDecodeMsgpack_Some(t *testing.T) {
-	val := MakeDecimal(decimal.NewFromFloat(1.23))
+	val := NewDecimal(decimal.NewFromFloat(1.23))
 	some := SomeOptionalDecimal(val)
 
 	var buf bytes.Buffer

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -166,7 +166,7 @@ var decimalSamples = []struct {
 func TestMPEncodeDecode(t *testing.T) {
 	for _, testcase := range benchmarkSamples {
 		t.Run(testcase.numString, func(t *testing.T) {
-			decNum, err := MakeDecimalFromString(testcase.numString)
+			decNum, err := NewDecimalFromString(testcase.numString)
 			require.NoError(t, err)
 			var buf []byte
 			tuple := TupleDecimal{number: decNum}
@@ -243,7 +243,7 @@ func TestEncodeMaxNumber(t *testing.T) {
 	referenceErrMsg := "msgpack: decimal number is bigger than maximum " +
 		"supported number (10^38 - 1)"
 	decNum := decimal.New(1, DecimalPrecision) // // 10^DecimalPrecision
-	tuple := TupleDecimal{number: MakeDecimal(decNum)}
+	tuple := TupleDecimal{number: NewDecimal(decNum)}
 	_, err := msgpack.Marshal(&tuple)
 	require.Error(t, err,
 		"It is possible to msgpack.Encoder a number unsupported by Tarantool")
@@ -256,7 +256,7 @@ func TestEncodeMinNumber(t *testing.T) {
 		"supported number (-10^38 - 1)"
 	two := decimal.NewFromInt(2)
 	decNum := decimal.New(1, DecimalPrecision).Neg().Sub(two) // -10^DecimalPrecision - 2
-	tuple := TupleDecimal{number: MakeDecimal(decNum)}
+	tuple := TupleDecimal{number: NewDecimal(decNum)}
 	_, err := msgpack.Marshal(&tuple)
 	require.Error(t, err,
 		"It is possible to msgpack.Encoder a number unsupported by Tarantool")
@@ -273,7 +273,7 @@ func benchmarkMPEncodeDecode(b *testing.B, src decimal.Decimal) {
 	var buf []byte
 	var err error
 	for i := 0; i < b.N; i++ {
-		tuple := TupleDecimal{number: MakeDecimal(src)}
+		tuple := TupleDecimal{number: NewDecimal(src)}
 		if buf, err = msgpack.Marshal(&tuple); err != nil {
 			b.Fatal(err)
 		}
@@ -298,7 +298,7 @@ func BenchmarkMPEncodeDecodeDecimal(b *testing.B) {
 func BenchmarkMPEncodeDecimal(b *testing.B) {
 	for _, testcase := range benchmarkSamples {
 		b.Run(testcase.numString, func(b *testing.B) {
-			decNum, err := MakeDecimalFromString(testcase.numString)
+			decNum, err := NewDecimalFromString(testcase.numString)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -315,7 +315,7 @@ func BenchmarkMPEncodeDecimal(b *testing.B) {
 func BenchmarkMPDecodeDecimal(b *testing.B) {
 	for _, testcase := range benchmarkSamples {
 		b.Run(testcase.numString, func(b *testing.B) {
-			decNum, err := MakeDecimalFromString(testcase.numString)
+			decNum, err := NewDecimalFromString(testcase.numString)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -402,8 +402,8 @@ func TestMPEncode(t *testing.T) {
 	samples = append(samples, benchmarkSamples...)
 	for _, testcase := range samples {
 		t.Run(testcase.numString, func(t *testing.T) {
-			dec, err := MakeDecimalFromString(testcase.numString)
-			require.NoError(t, err, "MakeDecimalFromString() failed")
+			dec, err := NewDecimalFromString(testcase.numString)
+			require.NoError(t, err, "NewDecimalFromString() failed")
 			buf, err := msgpack.Marshal(dec)
 			require.NoError(t, err, "Marshalling failed")
 			refBuf, _ := hex.DecodeString(testcase.mpBuf)
@@ -469,7 +469,7 @@ func TestSelect(t *testing.T) {
 	number, err := decimal.NewFromString("-12.34")
 	require.NoError(t, err, "Failed to prepare test decimal")
 
-	ins := NewInsertRequest(space).Tuple([]any{MakeDecimal(number)})
+	ins := NewInsertRequest(space).Tuple([]any{NewDecimal(number)})
 	data, err := conn.Do(ins).Get()
 	require.NoError(t, err, "Decimal insert failed")
 	tupleValueIsDecimal(t, data, number)
@@ -481,12 +481,12 @@ func TestSelect(t *testing.T) {
 		Offset(offset).
 		Limit(limit).
 		Iterator(IterEq).
-		Key([]any{MakeDecimal(number)})
+		Key([]any{NewDecimal(number)})
 	data, err = conn.Do(sel).Get()
 	require.NoError(t, err, "Decimal select failed")
 	tupleValueIsDecimal(t, data, number)
 
-	del := NewDeleteRequest(space).Index(index).Key([]any{MakeDecimal(number)})
+	del := NewDeleteRequest(space).Index(index).Key([]any{NewDecimal(number)})
 	data, err = conn.Do(del).Get()
 	require.NoError(t, err, "Decimal delete failed")
 	tupleValueIsDecimal(t, data, number)
@@ -522,12 +522,12 @@ func assertInsert(t *testing.T, conn *Connection, numString string) {
 	number, err := decimal.NewFromString(numString)
 	require.NoError(t, err, "Failed to prepare test decimal")
 
-	ins := NewInsertRequest(space).Tuple([]any{MakeDecimal(number)})
+	ins := NewInsertRequest(space).Tuple([]any{NewDecimal(number)})
 	data, err := conn.Do(ins).Get()
 	require.NoError(t, err, "Decimal insert failed")
 	tupleValueIsDecimal(t, data, number)
 
-	del := NewDeleteRequest(space).Index(index).Key([]any{MakeDecimal(number)})
+	del := NewDeleteRequest(space).Index(index).Key([]any{NewDecimal(number)})
 	data, err = conn.Do(del).Get()
 	require.NoError(t, err, "Decimal delete failed")
 	tupleValueIsDecimal(t, data, number)
@@ -557,7 +557,7 @@ func TestReplace(t *testing.T) {
 	number, err := decimal.NewFromString("-12.34")
 	require.NoError(t, err, "Failed to prepare test decimal")
 
-	rep := NewReplaceRequest(space).Tuple([]any{MakeDecimal(number)})
+	rep := NewReplaceRequest(space).Tuple([]any{NewDecimal(number)})
 	dataRep, errRep := conn.Do(rep).Get()
 	require.NoError(t, errRep, "Decimal replace failed")
 	tupleValueIsDecimal(t, dataRep, number)
@@ -566,7 +566,7 @@ func TestReplace(t *testing.T) {
 		Index(index).
 		Limit(1).
 		Iterator(IterEq).
-		Key([]any{MakeDecimal(number)})
+		Key([]any{NewDecimal(number)})
 	dataSel, errSel := conn.Do(sel).Get()
 	require.NoError(t, errSel, "Decimal select failed")
 	tupleValueIsDecimal(t, dataSel, number)
@@ -677,7 +677,7 @@ func TestDecimalString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dec, err := MakeDecimalFromString(tt.input)
+			dec, err := NewDecimalFromString(tt.input)
 			require.NoError(t, err)
 
 			result := dec.String()
@@ -700,7 +700,7 @@ func TestTarantoolBCDCompatibility(t *testing.T) {
 
 	for _, input := range testCases {
 		t.Run(input, func(t *testing.T) {
-			dec, err := MakeDecimalFromString(input)
+			dec, err := NewDecimalFromString(input)
 			require.NoError(t, err)
 
 			msgpackData, err := dec.MarshalMsgpack()
@@ -728,16 +728,16 @@ func TestRealTarantoolUsage(t *testing.T) {
 			name: "insert operation",
 			data: map[string]any{
 				"id":      1,
-				"amount":  MustMakeDecimal("123.45"),
-				"balance": MustMakeDecimal("-500.00"),
+				"amount":  MustNewDecimal("123.45"),
+				"balance": MustNewDecimal("-500.00"),
 			},
 		},
 		{
 			name: "update operation",
 			data: map[string]any{
 				"id":       2,
-				"price":    MustMakeDecimal("99.99"),
-				"quantity": MustMakeDecimal("1000.000"),
+				"price":    MustNewDecimal("99.99"),
+				"quantity": MustNewDecimal("1000.000"),
 			},
 		},
 	}
@@ -774,7 +774,7 @@ func TestRealTarantoolUsage(t *testing.T) {
 }
 
 func Test100_00(t *testing.T) {
-	dec := MustMakeDecimal("100.00")
+	dec := MustNewDecimal("100.00")
 
 	coefficient := dec.Decimal.Coefficient()
 	if !coefficient.IsInt64() {
@@ -797,7 +797,7 @@ func Test100_00(t *testing.T) {
 
 func TestLargeNumberString(t *testing.T) {
 	largeNumber := "123456789012345678901234567890.123456789"
-	dec, err := MakeDecimalFromString(largeNumber)
+	dec, err := NewDecimalFromString(largeNumber)
 	if err != nil {
 		t.Fatalf("Failed to create decimal: %v", err)
 	}
@@ -835,7 +835,7 @@ func TestDecimalTrailingZeros(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			dec := MustMakeDecimal(tt.input)
+			dec := MustNewDecimal(tt.input)
 			result := dec.String()
 			if result != tt.expected {
 				t.Errorf("For %s: expected %s, got %s", tt.input, tt.expected, result)
@@ -858,7 +858,7 @@ func TestDecimalStringPositiveExponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			dec := MustMakeDecimal(tt.input)
+			dec := MustNewDecimal(tt.input)
 			result := dec.String()
 			if result != tt.expected {
 				t.Errorf("For %s: expected %s, got %s", tt.input, tt.expected, result)
@@ -888,7 +888,7 @@ func TestDecimalStringMinInt64WithScale(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dec := MustMakeDecimal(tt.input)
+			dec := MustNewDecimal(tt.input)
 			result := dec.String()
 			if result != tt.expected {
 				t.Errorf("For %s: expected %s, got %s", tt.input, tt.expected, result)
@@ -916,7 +916,7 @@ func TestDecimalStringNegativeTrailingZeros(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			dec := MustMakeDecimal(tt.input)
+			dec := MustNewDecimal(tt.input)
 			result := dec.String()
 			if result != tt.expected {
 				t.Errorf("For %s: expected %s, got %s", tt.input, tt.expected, result)

--- a/decimal/example_test.go
+++ b/decimal/example_test.go
@@ -39,7 +39,7 @@ func Example() {
 
 	spaceNo := uint32(524)
 
-	number, err := MakeDecimalFromString("-22.804")
+	number, err := NewDecimalFromString("-22.804")
 	if err != nil {
 		log.Fatalf("Failed to prepare test decimal: %s", err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -247,8 +247,7 @@ func ExampleSelectRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewSelectRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewSelectRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {
@@ -361,8 +360,7 @@ func ExampleDeleteRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewDeleteRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewDeleteRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {
@@ -475,8 +473,7 @@ func ExampleUpdateRequest_spaceAndIndexNames() {
 	conn := exampleConnect(dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := tarantool.NewUpdateRequest(spaceName)
-	req.Index(indexName)
+	req := tarantool.NewUpdateRequest(spaceName).Index(indexName)
 	data, err := conn.Do(req).Get()
 
 	if err != nil {

--- a/prepared.go
+++ b/prepared.go
@@ -54,15 +54,15 @@ type PrepareRequest struct {
 }
 
 // NewPrepareRequest returns a new empty PrepareRequest.
-func NewPrepareRequest(expr string) *PrepareRequest {
-	req := new(PrepareRequest)
-	req.rtype = iproto.IPROTO_PREPARE
-	req.expr = expr
-	return req
+func NewPrepareRequest(expr string) PrepareRequest {
+	return PrepareRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PREPARE},
+		expr:        expr,
+	}
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -80,13 +80,13 @@ func (req *PrepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *PrepareRequest) Context(ctx context.Context) *PrepareRequest {
+func (req PrepareRequest) Context(ctx context.Context) PrepareRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the PrepareRequest.
-func (req *PrepareRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req PrepareRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -106,20 +106,20 @@ type UnprepareRequest struct {
 }
 
 // NewUnprepareRequest returns a new empty UnprepareRequest.
-func NewUnprepareRequest(stmt *Prepared) *UnprepareRequest {
-	req := new(UnprepareRequest)
-	req.rtype = iproto.IPROTO_PREPARE
-	req.stmt = stmt
-	return req
+func NewUnprepareRequest(stmt *Prepared) UnprepareRequest {
+	return UnprepareRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PREPARE},
+		stmt:        stmt,
+	}
 }
 
 // Conn returns the Connection object the request belongs to.
-func (req *UnprepareRequest) Conn() *Connection {
+func (req UnprepareRequest) Conn() *Connection {
 	return req.stmt.Conn
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (req *UnprepareRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UnprepareRequest) Context(ctx context.Context) *UnprepareRequest {
+func (req UnprepareRequest) Context(ctx context.Context) UnprepareRequest {
 	req.ctx = ctx
 	return req
 }
@@ -153,28 +153,28 @@ type ExecutePreparedRequest struct {
 }
 
 // NewExecutePreparedRequest returns a new empty preparedExecuteRequest.
-func NewExecutePreparedRequest(stmt *Prepared) *ExecutePreparedRequest {
-	req := new(ExecutePreparedRequest)
-	req.rtype = iproto.IPROTO_EXECUTE
-	req.stmt = stmt
-	req.args = []any{}
-	return req
+func NewExecutePreparedRequest(stmt *Prepared) ExecutePreparedRequest {
+	return ExecutePreparedRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EXECUTE},
+		stmt:        stmt,
+		args:        []any{},
+	}
 }
 
 // Conn returns the Connection object the request belongs to.
-func (req *ExecutePreparedRequest) Conn() *Connection {
+func (req ExecutePreparedRequest) Conn() *Connection {
 	return req.stmt.Conn
 }
 
 // Args sets the args for execute the prepared request.
 // Note: default value is empty.
-func (req *ExecutePreparedRequest) Args(args any) *ExecutePreparedRequest {
+func (req ExecutePreparedRequest) Args(args any) ExecutePreparedRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -200,13 +200,13 @@ func (req *ExecutePreparedRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ExecutePreparedRequest) Context(ctx context.Context) *ExecutePreparedRequest {
+func (req ExecutePreparedRequest) Context(ctx context.Context) ExecutePreparedRequest {
 	req.ctx = ctx
 	return req
 }
 
 // Response creates a response for the ExecutePreparedRequest.
-func (req *ExecutePreparedRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req ExecutePreparedRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err

--- a/protocol.go
+++ b/protocol.go
@@ -72,15 +72,15 @@ type IdRequest struct {
 }
 
 // NewIdRequest returns a new IdRequest.
-func NewIdRequest(protocolInfo ProtocolInfo) *IdRequest {
-	req := new(IdRequest)
-	req.rtype = iproto.IPROTO_ID
-	req.protocolInfo = protocolInfo.Clone()
-	return req
+func NewIdRequest(protocolInfo ProtocolInfo) IdRequest {
+	return IdRequest{
+		baseRequest:  baseRequest{rtype: iproto.IPROTO_ID},
+		protocolInfo: protocolInfo.Clone(),
+	}
 }
 
 // Body fills an msgpack.Encoder with the id request body.
-func (req *IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (req *IdRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *IdRequest) Context(ctx context.Context) *IdRequest {
+func (req IdRequest) Context(ctx context.Context) IdRequest {
 	req.ctx = ctx
 	return req
 }

--- a/request.go
+++ b/request.go
@@ -274,33 +274,23 @@ type baseRequest struct {
 }
 
 // Type returns a IPROTO type for the request.
-func (req *baseRequest) Type() iproto.Type {
+func (req baseRequest) Type() iproto.Type {
 	return req.rtype
 }
 
 // Async returns true if the request does not require a response.
-func (req *baseRequest) Async() bool {
+func (req baseRequest) Async() bool {
 	return req.async
 }
 
 // Ctx returns a context of the request.
-func (req *baseRequest) Ctx() context.Context {
+func (req baseRequest) Ctx() context.Context {
 	return req.ctx
 }
 
 // Response creates a response for the baseRequest.
-func (req *baseRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req baseRequest) Response(header Header, body io.Reader) (Response, error) {
 	return DecodeBaseResponse(header, body)
-}
-
-type spaceRequest struct {
-	baseRequest
-
-	space any
-}
-
-func (req *spaceRequest) setSpace(space any) {
-	req.space = space
 }
 
 func EncodeSpace(res SchemaResolver, enc *msgpack.Encoder, space any) error {
@@ -312,16 +302,6 @@ func EncodeSpace(res SchemaResolver, enc *msgpack.Encoder, space any) error {
 		return err
 	}
 	return nil
-}
-
-type spaceIndexRequest struct {
-	spaceRequest
-
-	index any
-}
-
-func (req *spaceIndexRequest) setIndex(index any) {
-	req.index = index
 }
 
 // authRequest implements IPROTO_AUTH request.
@@ -415,14 +395,14 @@ type PingRequest struct {
 }
 
 // NewPingRequest returns a new PingRequest.
-func NewPingRequest() *PingRequest {
-	req := new(PingRequest)
-	req.rtype = iproto.IPROTO_PING
-	return req
+func NewPingRequest() PingRequest {
+	return PingRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_PING},
+	}
 }
 
 // Body fills an msgpack.Encoder with the ping request body.
-func (req *PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
@@ -432,17 +412,17 @@ func (req *PingRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *PingRequest) Context(ctx context.Context) *PingRequest {
+func (req PingRequest) Context(ctx context.Context) PingRequest {
 	req.ctx = ctx
 	return req
 }
 
 // SelectRequest allows you to create a select request object for execution
 // by a Connection.
-
 type SelectRequest struct {
-	spaceIndexRequest
+	baseRequest
 
+	space, index            any
 	isIteratorSet, fetchPos bool
 	offset, limit           uint32
 	iterator                Iter
@@ -450,43 +430,40 @@ type SelectRequest struct {
 }
 
 // NewSelectRequest returns a new empty SelectRequest.
-func NewSelectRequest(space any) *SelectRequest {
-	req := new(SelectRequest)
-	req.rtype = iproto.IPROTO_SELECT
-	req.setSpace(space)
-	req.isIteratorSet = false
-	req.fetchPos = false
-	req.iterator = IterAll
-	req.key = []any{}
-	req.after = nil
-	req.limit = 0xFFFFFFFF
-	return req
+func NewSelectRequest(space any) SelectRequest {
+	return SelectRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_SELECT},
+		space:       space,
+		iterator:    IterAll,
+		key:         []any{},
+		limit:       0xFFFFFFFF,
+	}
 }
 
 // Index sets the index for the select request.
 // Note: default value is 0.
-func (req *SelectRequest) Index(index any) *SelectRequest {
-	req.setIndex(index)
+func (req SelectRequest) Index(index any) SelectRequest {
+	req.index = index
 	return req
 }
 
 // Offset sets the offset for the select request.
 // Note: default value is 0.
-func (req *SelectRequest) Offset(offset uint32) *SelectRequest {
+func (req SelectRequest) Offset(offset uint32) SelectRequest {
 	req.offset = offset
 	return req
 }
 
 // Limit sets the limit for the select request.
 // Note: default value is 0xFFFFFFFF.
-func (req *SelectRequest) Limit(limit uint32) *SelectRequest {
+func (req SelectRequest) Limit(limit uint32) SelectRequest {
 	req.limit = limit
 	return req
 }
 
 // Iterator set the iterator for the select request.
 // Note: default value is IterAll if key is not set or IterEq otherwise.
-func (req *SelectRequest) Iterator(iterator Iter) *SelectRequest {
+func (req SelectRequest) Iterator(iterator Iter) SelectRequest {
 	req.iterator = iterator
 	req.isIteratorSet = true
 	return req
@@ -494,7 +471,7 @@ func (req *SelectRequest) Iterator(iterator Iter) *SelectRequest {
 
 // Key set the key for the select request.
 // Note: default value is empty.
-func (req *SelectRequest) Key(key any) *SelectRequest {
+func (req SelectRequest) Key(key any) SelectRequest {
 	req.key = key
 	if !req.isIteratorSet {
 		req.iterator = IterEq
@@ -510,7 +487,7 @@ func (req *SelectRequest) Key(key any) *SelectRequest {
 // Requires Tarantool >= 2.11.
 //
 // Since 1.11.0.
-func (req *SelectRequest) FetchPos(fetch bool) *SelectRequest {
+func (req SelectRequest) FetchPos(fetch bool) SelectRequest {
 	req.fetchPos = fetch
 	return req
 }
@@ -523,13 +500,13 @@ func (req *SelectRequest) FetchPos(fetch bool) *SelectRequest {
 // Requires Tarantool >= 2.11.
 //
 // Since 1.11.0.
-func (req *SelectRequest) After(after any) *SelectRequest {
+func (req SelectRequest) After(after any) SelectRequest {
 	req.after = after
 	return req
 }
 
 // Body fills an encoder with the select request body.
-func (req *SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -619,7 +596,7 @@ func (req *SelectRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *SelectRequest) Context(ctx context.Context) *SelectRequest {
+func (req SelectRequest) Context(ctx context.Context) SelectRequest {
 	req.ctx = ctx
 	return req
 }
@@ -631,7 +608,7 @@ var selectsPool *sync.Pool = &sync.Pool{
 }
 
 // Response creates a response for the SelectRequest.
-func (req *SelectRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req SelectRequest) Response(header Header, body io.Reader) (Response, error) {
 	base, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -644,33 +621,32 @@ func (req *SelectRequest) Response(header Header, body io.Reader) (Response, err
 }
 
 // InsertRequest helps you to create an insert request object for execution
-
 // by a Connection.
-
 type InsertRequest struct {
-	spaceRequest
+	baseRequest
 
+	space any
 	tuple any
 }
 
 // NewInsertRequest returns a new empty InsertRequest.
-func NewInsertRequest(space any) *InsertRequest {
-	req := new(InsertRequest)
-	req.rtype = iproto.IPROTO_INSERT
-	req.setSpace(space)
-	req.tuple = []any{}
-	return req
+func NewInsertRequest(space any) InsertRequest {
+	return InsertRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_INSERT},
+		space:       space,
+		tuple:       []any{},
+	}
 }
 
 // Tuple sets the tuple for insertion the insert request.
 // Note: default value is nil.
-func (req *InsertRequest) Tuple(tuple any) *InsertRequest {
+func (req InsertRequest) Tuple(tuple any) InsertRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Body fills an msgpack.Encoder with the insert request body.
-func (req *InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -697,7 +673,7 @@ func (req *InsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *InsertRequest) Context(ctx context.Context) *InsertRequest {
+func (req InsertRequest) Context(ctx context.Context) InsertRequest {
 	req.ctx = ctx
 	return req
 }
@@ -705,29 +681,30 @@ func (req *InsertRequest) Context(ctx context.Context) *InsertRequest {
 // ReplaceRequest helps you to create a replace request object for execution
 // by a Connection.
 type ReplaceRequest struct {
-	spaceRequest
+	baseRequest
 
+	space any
 	tuple any
 }
 
 // NewReplaceRequest returns a new empty ReplaceRequest.
-func NewReplaceRequest(space any) *ReplaceRequest {
-	req := new(ReplaceRequest)
-	req.rtype = iproto.IPROTO_REPLACE
-	req.setSpace(space)
-	req.tuple = []any{}
-	return req
+func NewReplaceRequest(space any) ReplaceRequest {
+	return ReplaceRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_REPLACE},
+		space:       space,
+		tuple:       []any{},
+	}
 }
 
 // Tuple sets the tuple for replace by the replace request.
 // Note: default value is nil.
-func (req *ReplaceRequest) Tuple(tuple any) *ReplaceRequest {
+func (req ReplaceRequest) Tuple(tuple any) ReplaceRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Body fills an msgpack.Encoder with the replace request body.
-func (req *ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -754,7 +731,7 @@ func (req *ReplaceRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error 
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ReplaceRequest) Context(ctx context.Context) *ReplaceRequest {
+func (req ReplaceRequest) Context(ctx context.Context) ReplaceRequest {
 	req.ctx = ctx
 	return req
 }
@@ -762,36 +739,37 @@ func (req *ReplaceRequest) Context(ctx context.Context) *ReplaceRequest {
 // DeleteRequest helps you to create a delete request object for execution
 // by a Connection.
 type DeleteRequest struct {
-	spaceIndexRequest
+	baseRequest
 
-	key any
+	space, index any
+	key          any
 }
 
 // NewDeleteRequest returns a new empty DeleteRequest.
-func NewDeleteRequest(space any) *DeleteRequest {
-	req := new(DeleteRequest)
-	req.rtype = iproto.IPROTO_DELETE
-	req.setSpace(space)
-	req.key = []any{}
-	return req
+func NewDeleteRequest(space any) DeleteRequest {
+	return DeleteRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_DELETE},
+		space:       space,
+		key:         []any{},
+	}
 }
 
 // Index sets the index for the delete request.
 // Note: default value is 0.
-func (req *DeleteRequest) Index(index any) *DeleteRequest {
-	req.setIndex(index)
+func (req DeleteRequest) Index(index any) DeleteRequest {
+	req.index = index
 	return req
 }
 
 // Key sets the key of tuple for the delete request.
 // Note: default value is empty.
-func (req *DeleteRequest) Key(key any) *DeleteRequest {
+func (req DeleteRequest) Key(key any) DeleteRequest {
 	req.key = key
 	return req
 }
 
 // Body fills an msgpack.Encoder with the delete request body.
-func (req *DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -815,7 +793,7 @@ func (req *DeleteRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *DeleteRequest) Context(ctx context.Context) *DeleteRequest {
+func (req DeleteRequest) Context(ctx context.Context) DeleteRequest {
 	req.ctx = ctx
 	return req
 }
@@ -823,44 +801,45 @@ func (req *DeleteRequest) Context(ctx context.Context) *DeleteRequest {
 // UpdateRequest helps you to create an update request object for execution
 // by a Connection.
 type UpdateRequest struct {
-	spaceIndexRequest
+	baseRequest
 
-	key any
-	ops *Operations
+	space, index any
+	key          any
+	ops          *Operations
 }
 
 // NewUpdateRequest returns a new empty UpdateRequest.
-func NewUpdateRequest(space any) *UpdateRequest {
-	req := new(UpdateRequest)
-	req.rtype = iproto.IPROTO_UPDATE
-	req.setSpace(space)
-	req.key = []any{}
-	return req
+func NewUpdateRequest(space any) UpdateRequest {
+	return UpdateRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_UPDATE},
+		space:       space,
+		key:         []any{},
+	}
 }
 
 // Index sets the index for the update request.
 // Note: default value is 0.
-func (req *UpdateRequest) Index(index any) *UpdateRequest {
-	req.setIndex(index)
+func (req UpdateRequest) Index(index any) UpdateRequest {
+	req.index = index
 	return req
 }
 
 // Key sets the key of tuple for the update request.
 // Note: default value is empty.
-func (req *UpdateRequest) Key(key any) *UpdateRequest {
+func (req UpdateRequest) Key(key any) UpdateRequest {
 	req.key = key
 	return req
 }
 
 // Operations sets operations to be performed on update.
 // Note: default value is empty.
-func (req *UpdateRequest) Operations(ops *Operations) *UpdateRequest {
+func (req UpdateRequest) Operations(ops *Operations) UpdateRequest {
 	req.ops = ops
 	return req
 }
 
 // Body fills an msgpack.Encoder with the update request body.
-func (req *UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -896,7 +875,7 @@ func (req *UpdateRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UpdateRequest) Context(ctx context.Context) *UpdateRequest {
+func (req UpdateRequest) Context(ctx context.Context) UpdateRequest {
 	req.ctx = ctx
 	return req
 }
@@ -904,37 +883,38 @@ func (req *UpdateRequest) Context(ctx context.Context) *UpdateRequest {
 // UpsertRequest helps you to create an upsert request object for execution
 // by a Connection.
 type UpsertRequest struct {
-	spaceRequest
+	baseRequest
 
+	space any
 	tuple any
 	ops   *Operations
 }
 
 // NewUpsertRequest returns a new empty UpsertRequest.
-func NewUpsertRequest(space any) *UpsertRequest {
-	req := new(UpsertRequest)
-	req.rtype = iproto.IPROTO_UPSERT
-	req.setSpace(space)
-	req.tuple = []any{}
-	return req
+func NewUpsertRequest(space any) UpsertRequest {
+	return UpsertRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_UPSERT},
+		space:       space,
+		tuple:       []any{},
+	}
 }
 
 // Tuple sets the tuple for insertion or update by the upsert request.
 // Note: default value is empty.
-func (req *UpsertRequest) Tuple(tuple any) *UpsertRequest {
+func (req UpsertRequest) Tuple(tuple any) UpsertRequest {
 	req.tuple = tuple
 	return req
 }
 
 // Operations sets operations to be performed on update case by the upsert request.
 // Note: default value is empty.
-func (req *UpsertRequest) Operations(ops *Operations) *UpsertRequest {
+func (req UpsertRequest) Operations(ops *Operations) UpsertRequest {
 	req.ops = ops
 	return req
 }
 
 // Body fills an msgpack.Encoder with the upsert request body.
-func (req *UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	spaceEnc, err := newSpaceEncoder(res, req.space)
 	if err != nil {
 		return err
@@ -973,7 +953,7 @@ func (req *UpsertRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *UpsertRequest) Context(ctx context.Context) *UpsertRequest {
+func (req UpsertRequest) Context(ctx context.Context) UpsertRequest {
 	req.ctx = ctx
 	return req
 }
@@ -989,22 +969,22 @@ type CallRequest struct {
 
 // NewCallRequest returns a new empty CallRequest. It uses request code for
 // Tarantool >= 1.7.
-func NewCallRequest(function string) *CallRequest {
-	req := new(CallRequest)
-	req.rtype = iproto.IPROTO_CALL
-	req.function = function
-	return req
+func NewCallRequest(function string) CallRequest {
+	return CallRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_CALL},
+		function:    function,
+	}
 }
 
 // Args sets the args for the call request.
 // Note: default value is empty.
-func (req *CallRequest) Args(args any) *CallRequest {
+func (req CallRequest) Args(args any) CallRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an encoder with the call request body.
-func (req *CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1034,7 +1014,7 @@ func (req *CallRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *CallRequest) Context(ctx context.Context) *CallRequest {
+func (req CallRequest) Context(ctx context.Context) CallRequest {
 	req.ctx = ctx
 	return req
 }
@@ -1049,23 +1029,23 @@ type EvalRequest struct {
 }
 
 // NewEvalRequest returns a new empty EvalRequest.
-func NewEvalRequest(expr string) *EvalRequest {
-	req := new(EvalRequest)
-	req.rtype = iproto.IPROTO_EVAL
-	req.expr = expr
-	req.args = []any{}
-	return req
+func NewEvalRequest(expr string) EvalRequest {
+	return EvalRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EVAL},
+		expr:        expr,
+		args:        []any{},
+	}
 }
 
 // Args sets the args for the eval request.
 // Note: default value is empty.
-func (req *EvalRequest) Args(args any) *EvalRequest {
+func (req EvalRequest) Args(args any) EvalRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the eval request body.
-func (req *EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1095,7 +1075,7 @@ func (req *EvalRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *EvalRequest) Context(ctx context.Context) *EvalRequest {
+func (req EvalRequest) Context(ctx context.Context) EvalRequest {
 	req.ctx = ctx
 	return req
 }
@@ -1110,23 +1090,23 @@ type ExecuteRequest struct {
 }
 
 // NewExecuteRequest returns a new empty ExecuteRequest.
-func NewExecuteRequest(expr string) *ExecuteRequest {
-	req := new(ExecuteRequest)
-	req.rtype = iproto.IPROTO_EXECUTE
-	req.expr = expr
-	req.args = []any{}
-	return req
+func NewExecuteRequest(expr string) ExecuteRequest {
+	return ExecuteRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_EXECUTE},
+		expr:        expr,
+		args:        []any{},
+	}
 }
 
 // Args sets the args for the execute request.
 // Note: default value is empty.
-func (req *ExecuteRequest) Args(args any) *ExecuteRequest {
+func (req ExecuteRequest) Args(args any) ExecuteRequest {
 	req.args = args
 	return req
 }
 
 // Body fills an msgpack.Encoder with the execute request body.
-func (req *ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(2); err != nil {
 		return err
 	}
@@ -1152,7 +1132,7 @@ func (req *ExecuteRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *ExecuteRequest) Context(ctx context.Context) *ExecuteRequest {
+func (req ExecuteRequest) Context(ctx context.Context) ExecuteRequest {
 	req.ctx = ctx
 	return req
 }
@@ -1164,7 +1144,7 @@ var executesPool = sync.Pool{
 }
 
 // Response creates a response for the ExecuteRequest.
-func (req *ExecuteRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req ExecuteRequest) Response(header Header, body io.Reader) (Response, error) {
 	baseResp, err := createBaseResponse(header, body)
 	if err != nil {
 		return nil, err
@@ -1185,15 +1165,15 @@ type WatchOnceRequest struct {
 }
 
 // NewWatchOnceRequest returns a new watchOnceRequest.
-func NewWatchOnceRequest(key string) *WatchOnceRequest {
-	req := new(WatchOnceRequest)
-	req.rtype = iproto.IPROTO_WATCH_ONCE
-	req.key = key
-	return req
+func NewWatchOnceRequest(key string) WatchOnceRequest {
+	return WatchOnceRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_WATCH_ONCE},
+		key:         key,
+	}
 }
 
 // Body fills an msgpack.Encoder with the watchOnce request body.
-func (req *WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	if err := enc.EncodeMapLen(1); err != nil {
 		return err
 	}
@@ -1206,7 +1186,7 @@ func (req *WatchOnceRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error 
 }
 
 // Context sets a passed context to the request.
-func (req *WatchOnceRequest) Context(ctx context.Context) *WatchOnceRequest {
+func (req WatchOnceRequest) Context(ctx context.Context) WatchOnceRequest {
 	req.ctx = ctx
 	return req
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -118,8 +118,7 @@ func TestGetSchema_index_select_error(t *testing.T) {
 func TestResolverCalledWithoutNameSupport(t *testing.T) {
 	resolver := ValidSchemeResolver{nameUseSupported: false}
 
-	req := tarantool.NewSelectRequest("valid")
-	req.Index("valid")
+	req := tarantool.NewSelectRequest("valid").Index("valid")
 
 	var reqBuf bytes.Buffer
 	reqEnc := msgpack.NewEncoder(&reqBuf)
@@ -138,8 +137,7 @@ func TestResolverCalledWithoutNameSupport(t *testing.T) {
 func TestResolverNotCalledWithNameSupport(t *testing.T) {
 	resolver := ValidSchemeResolver{nameUseSupported: true}
 
-	req := tarantool.NewSelectRequest("valid")
-	req.Index("valid")
+	req := tarantool.NewSelectRequest("valid").Index("valid")
 
 	var reqBuf bytes.Buffer
 	reqEnc := msgpack.NewEncoder(&reqBuf)

--- a/settings/request.go
+++ b/settings/request.go
@@ -70,11 +70,11 @@ import (
 
 // SetRequest helps to set session settings.
 type SetRequest struct {
-	impl *tarantool.UpdateRequest
+	impl tarantool.UpdateRequest
 }
 
-func newSetRequest(setting string, value any) *SetRequest {
-	return &SetRequest{
+func newSetRequest(setting string, value any) SetRequest {
+	return SetRequest{
 		impl: tarantool.NewUpdateRequest(sessionSettingsSpace).
 			Key(tarantool.StringKey{S: setting}).
 			Operations(tarantool.NewOperations().Assign(sessionSettingValueField, value)),
@@ -82,45 +82,45 @@ func newSetRequest(setting string, value any) *SetRequest {
 }
 
 // Context sets a passed context to set session settings request.
-func (req *SetRequest) Context(ctx context.Context) *SetRequest {
+func (req SetRequest) Context(ctx context.Context) SetRequest {
 	req.impl = req.impl.Context(ctx)
 
 	return req
 }
 
 // Type returns IPROTO type for set session settings request.
-func (req *SetRequest) Type() iproto.Type {
+func (req SetRequest) Type() iproto.Type {
 	return req.impl.Type()
 }
 
 // Body fills an encoder with set session settings request body.
-func (req *SetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (req SetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	return req.impl.Body(res, enc)
 }
 
 // Ctx returns a context of set session settings request.
-func (req *SetRequest) Ctx() context.Context {
+func (req SetRequest) Ctx() context.Context {
 	return req.impl.Ctx()
 }
 
 // Async returns is set session settings request expects a response.
-func (req *SetRequest) Async() bool {
+func (req SetRequest) Async() bool {
 	return req.impl.Async()
 }
 
 // Response creates a response for the SetRequest.
-func (req *SetRequest) Response(header tarantool.Header,
+func (req SetRequest) Response(header tarantool.Header,
 	body io.Reader) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
 }
 
 // GetRequest helps to get session settings.
 type GetRequest struct {
-	impl *tarantool.SelectRequest
+	impl tarantool.SelectRequest
 }
 
-func newGetRequest(setting string) *GetRequest {
-	return &GetRequest{
+func newGetRequest(setting string) GetRequest {
+	return GetRequest{
 		impl: tarantool.NewSelectRequest(sessionSettingsSpace).
 			Key(tarantool.StringKey{S: setting}).
 			Limit(1),
@@ -128,162 +128,162 @@ func newGetRequest(setting string) *GetRequest {
 }
 
 // Context sets a passed context to get session settings request.
-func (req *GetRequest) Context(ctx context.Context) *GetRequest {
+func (req GetRequest) Context(ctx context.Context) GetRequest {
 	req.impl = req.impl.Context(ctx)
 
 	return req
 }
 
 // Type returns IPROTO type for get session settings request.
-func (req *GetRequest) Type() iproto.Type {
+func (req GetRequest) Type() iproto.Type {
 	return req.impl.Type()
 }
 
 // Body fills an encoder with get session settings request body.
-func (req *GetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
+func (req GetRequest) Body(res tarantool.SchemaResolver, enc *msgpack.Encoder) error {
 	return req.impl.Body(res, enc)
 }
 
 // Ctx returns a context of get session settings request.
-func (req *GetRequest) Ctx() context.Context {
+func (req GetRequest) Ctx() context.Context {
 	return req.impl.Ctx()
 }
 
 // Async returns is get session settings request expects a response.
-func (req *GetRequest) Async() bool {
+func (req GetRequest) Async() bool {
 	return req.impl.Async()
 }
 
 // Response creates a response for the GetRequest.
-func (req *GetRequest) Response(header tarantool.Header,
+func (req GetRequest) Response(header tarantool.Header,
 	body io.Reader) (tarantool.Response, error) {
 	return req.impl.Response(header, body)
 }
 
 // NewErrorMarshalingEnabledSetRequest creates a request to
 // update current session ErrorMarshalingEnabled setting.
-func NewErrorMarshalingEnabledSetRequest(value bool) *SetRequest {
+func NewErrorMarshalingEnabledSetRequest(value bool) SetRequest {
 	return newSetRequest(errorMarshalingEnabled, value)
 }
 
 // NewErrorMarshalingEnabledGetRequest creates a request to get
 // current session ErrorMarshalingEnabled setting in tuple format.
-func NewErrorMarshalingEnabledGetRequest() *GetRequest {
+func NewErrorMarshalingEnabledGetRequest() GetRequest {
 	return newGetRequest(errorMarshalingEnabled)
 }
 
 // NewSQLDefaultEngineSetRequest creates a request to
 // update current session SQLDefaultEngine setting.
-func NewSQLDefaultEngineSetRequest(value string) *SetRequest {
+func NewSQLDefaultEngineSetRequest(value string) SetRequest {
 	return newSetRequest(sqlDefaultEngine, value)
 }
 
 // NewSQLDefaultEngineGetRequest creates a request to get
 // current session SQLDefaultEngine setting in tuple format.
-func NewSQLDefaultEngineGetRequest() *GetRequest {
+func NewSQLDefaultEngineGetRequest() GetRequest {
 	return newGetRequest(sqlDefaultEngine)
 }
 
 // NewSQLDeferForeignKeysSetRequest creates a request to
 // update current session SQLDeferForeignKeys setting.
-func NewSQLDeferForeignKeysSetRequest(value bool) *SetRequest {
+func NewSQLDeferForeignKeysSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlDeferForeignKeys, value)
 }
 
 // NewSQLDeferForeignKeysGetRequest creates a request to get
 // current session SQLDeferForeignKeys setting in tuple format.
-func NewSQLDeferForeignKeysGetRequest() *GetRequest {
+func NewSQLDeferForeignKeysGetRequest() GetRequest {
 	return newGetRequest(sqlDeferForeignKeys)
 }
 
 // NewSQLFullColumnNamesSetRequest creates a request to
 // update current session SQLFullColumnNames setting.
-func NewSQLFullColumnNamesSetRequest(value bool) *SetRequest {
+func NewSQLFullColumnNamesSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlFullColumnNames, value)
 }
 
 // NewSQLFullColumnNamesGetRequest creates a request to get
 // current session SQLFullColumnNames setting in tuple format.
-func NewSQLFullColumnNamesGetRequest() *GetRequest {
+func NewSQLFullColumnNamesGetRequest() GetRequest {
 	return newGetRequest(sqlFullColumnNames)
 }
 
 // NewSQLFullMetadataSetRequest creates a request to
 // update current session SQLFullMetadata setting.
-func NewSQLFullMetadataSetRequest(value bool) *SetRequest {
+func NewSQLFullMetadataSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlFullMetadata, value)
 }
 
 // NewSQLFullMetadataGetRequest creates a request to get
 // current session SQLFullMetadata setting in tuple format.
-func NewSQLFullMetadataGetRequest() *GetRequest {
+func NewSQLFullMetadataGetRequest() GetRequest {
 	return newGetRequest(sqlFullMetadata)
 }
 
 // NewSQLParserDebugSetRequest creates a request to
 // update current session SQLParserDebug setting.
-func NewSQLParserDebugSetRequest(value bool) *SetRequest {
+func NewSQLParserDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlParserDebug, value)
 }
 
 // NewSQLParserDebugGetRequest creates a request to get
 // current session SQLParserDebug setting in tuple format.
-func NewSQLParserDebugGetRequest() *GetRequest {
+func NewSQLParserDebugGetRequest() GetRequest {
 	return newGetRequest(sqlParserDebug)
 }
 
 // NewSQLRecursiveTriggersSetRequest creates a request to
 // update current session SQLRecursiveTriggers setting.
-func NewSQLRecursiveTriggersSetRequest(value bool) *SetRequest {
+func NewSQLRecursiveTriggersSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlRecursiveTriggers, value)
 }
 
 // NewSQLRecursiveTriggersGetRequest creates a request to get
 // current session SQLRecursiveTriggers setting in tuple format.
-func NewSQLRecursiveTriggersGetRequest() *GetRequest {
+func NewSQLRecursiveTriggersGetRequest() GetRequest {
 	return newGetRequest(sqlRecursiveTriggers)
 }
 
 // NewSQLReverseUnorderedSelectsSetRequest creates a request to
 // update current session SQLReverseUnorderedSelects setting.
-func NewSQLReverseUnorderedSelectsSetRequest(value bool) *SetRequest {
+func NewSQLReverseUnorderedSelectsSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlReverseUnorderedSelects, value)
 }
 
 // NewSQLReverseUnorderedSelectsGetRequest creates a request to get
 // current session SQLReverseUnorderedSelects setting in tuple format.
-func NewSQLReverseUnorderedSelectsGetRequest() *GetRequest {
+func NewSQLReverseUnorderedSelectsGetRequest() GetRequest {
 	return newGetRequest(sqlReverseUnorderedSelects)
 }
 
 // NewSQLSelectDebugSetRequest creates a request to
 // update current session SQLSelectDebug setting.
-func NewSQLSelectDebugSetRequest(value bool) *SetRequest {
+func NewSQLSelectDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlSelectDebug, value)
 }
 
 // NewSQLSelectDebugGetRequest creates a request to get
 // current session SQLSelectDebug setting in tuple format.
-func NewSQLSelectDebugGetRequest() *GetRequest {
+func NewSQLSelectDebugGetRequest() GetRequest {
 	return newGetRequest(sqlSelectDebug)
 }
 
 // NewSQLVDBEDebugSetRequest creates a request to
 // update current session SQLVDBEDebug setting.
-func NewSQLVDBEDebugSetRequest(value bool) *SetRequest {
+func NewSQLVDBEDebugSetRequest(value bool) SetRequest {
 	return newSetRequest(sqlVDBEDebug, value)
 }
 
 // NewSQLVDBEDebugGetRequest creates a request to get
 // current session SQLVDBEDebug setting in tuple format.
-func NewSQLVDBEDebugGetRequest() *GetRequest {
+func NewSQLVDBEDebugGetRequest() GetRequest {
 	return newGetRequest(sqlVDBEDebug)
 }
 
 // NewSessionSettingsGetRequest creates a request to get all
 // current session settings in tuple format.
-func NewSessionSettingsGetRequest() *GetRequest {
-	return &GetRequest{
+func NewSessionSettingsGetRequest() GetRequest {
+	return GetRequest{
 		impl: tarantool.NewSelectRequest(sessionSettingsSpace).
 			Limit(selectAllLimit),
 	}

--- a/settings/request_test.go
+++ b/settings/request_test.go
@@ -75,7 +75,7 @@ func TestRequestsAPI(t *testing.T) {
 func TestRequestsCtx(t *testing.T) {
 	// tarantool.Request interface doesn't have Context()
 	getTests := []struct {
-		req *GetRequest
+		req GetRequest
 	}{
 		{req: NewErrorMarshalingEnabledGetRequest()},
 		{req: NewSQLDefaultEngineGetRequest()},
@@ -96,7 +96,7 @@ func TestRequestsCtx(t *testing.T) {
 	}
 
 	setTests := []struct {
-		req *SetRequest
+		req SetRequest
 	}{
 		{req: NewErrorMarshalingEnabledSetRequest(false)},
 		{req: NewSQLDefaultEngineSetRequest("memtx")},

--- a/stream.go
+++ b/stream.go
@@ -48,35 +48,35 @@ type BeginRequest struct {
 }
 
 // NewBeginRequest returns a new BeginRequest.
-func NewBeginRequest() *BeginRequest {
-	req := new(BeginRequest)
-	req.rtype = iproto.IPROTO_BEGIN
-	req.txnIsolation = DefaultIsolationLevel
-	return req
+func NewBeginRequest() BeginRequest {
+	return BeginRequest{
+		baseRequest:  baseRequest{rtype: iproto.IPROTO_BEGIN},
+		txnIsolation: DefaultIsolationLevel,
+	}
 }
 
 // TxnIsolation sets the transaction isolation level for transaction manager.
 // By default, the isolation level of Tarantool is serializable.
-func (req *BeginRequest) TxnIsolation(txnIsolation TxnIsolationLevel) *BeginRequest {
+func (req BeginRequest) TxnIsolation(txnIsolation TxnIsolationLevel) BeginRequest {
 	req.txnIsolation = txnIsolation
 	return req
 }
 
 // Timeout allows to set up a timeout for call BeginRequest.
-func (req *BeginRequest) Timeout(timeout time.Duration) *BeginRequest {
+func (req BeginRequest) Timeout(timeout time.Duration) BeginRequest {
 	req.timeout = timeout
 	return req
 }
 
 // IsSync allows to set up a IsSync flag for call BeginRequest.
-func (req *BeginRequest) IsSync(isSync bool) *BeginRequest {
+func (req BeginRequest) IsSync(isSync bool) BeginRequest {
 	req.isSync = isSync
 	req.isSyncSet = true
 	return req
 }
 
 // Body fills an msgpack.Encoder with the begin request body.
-func (req *BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	var (
 		mapLen            = 0
 		hasTimeout        = req.timeout > 0
@@ -138,7 +138,7 @@ func (req *BeginRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *BeginRequest) Context(ctx context.Context) *BeginRequest {
+func (req BeginRequest) Context(ctx context.Context) BeginRequest {
 	req.ctx = ctx
 	return req
 }
@@ -154,21 +154,21 @@ type CommitRequest struct {
 }
 
 // NewCommitRequest returns a new CommitRequest.
-func NewCommitRequest() *CommitRequest {
-	req := new(CommitRequest)
-	req.rtype = iproto.IPROTO_COMMIT
-	return req
+func NewCommitRequest() CommitRequest {
+	return CommitRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_COMMIT},
+	}
 }
 
 // IsSync allows to set up a IsSync flag for call BeginRequest.
-func (req *CommitRequest) IsSync(isSync bool) *CommitRequest {
+func (req CommitRequest) IsSync(isSync bool) CommitRequest {
 	req.isSync = isSync
 	req.isSyncSet = true
 	return req
 }
 
 // Body fills an msgpack.Encoder with the commit request body.
-func (req *CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	var (
 		mapLen = 0
 	)
@@ -200,7 +200,7 @@ func (req *CommitRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *CommitRequest) Context(ctx context.Context) *CommitRequest {
+func (req CommitRequest) Context(ctx context.Context) CommitRequest {
 	req.ctx = ctx
 	return req
 }
@@ -213,14 +213,14 @@ type RollbackRequest struct {
 }
 
 // NewRollbackRequest returns a new RollbackRequest.
-func NewRollbackRequest() *RollbackRequest {
-	req := new(RollbackRequest)
-	req.rtype = iproto.IPROTO_ROLLBACK
-	return req
+func NewRollbackRequest() RollbackRequest {
+	return RollbackRequest{
+		baseRequest: baseRequest{rtype: iproto.IPROTO_ROLLBACK},
+	}
 }
 
 // Body fills an msgpack.Encoder with the rollback request body.
-func (req *RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
+func (req RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 	return enc.EncodeMapLen(0)
 }
 
@@ -230,7 +230,7 @@ func (req *RollbackRequest) Body(_ SchemaResolver, enc *msgpack.Encoder) error {
 // the timeout option for Connection does not affect the lifetime
 // of the request. For those purposes use context.WithTimeout() as
 // the root context.
-func (req *RollbackRequest) Context(ctx context.Context) *RollbackRequest {
+func (req RollbackRequest) Context(ctx context.Context) RollbackRequest {
 	req.ctx = ctx
 	return req
 }

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -1363,8 +1363,7 @@ func TestConnection_SetSchema_Changes(t *testing.T) {
 	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
 	defer func() { _ = conn.Close() }()
 
-	req := NewInsertRequest(spaceName)
-	req.Tuple([]any{uint(1010), "Tarantool"})
+	req := NewInsertRequest(spaceName).Tuple([]any{uint(1010), "Tarantool"})
 	_, err := conn.Do(req).Get()
 	require.NoError(t, err, "Failed to Insert")
 
@@ -1376,8 +1375,7 @@ func TestConnection_SetSchema_Changes(t *testing.T) {
 	// connection schema.
 	s.Spaces[spaceName] = Space{}
 
-	reqS := NewSelectRequest(spaceName)
-	reqS.Key([]any{uint(1010)})
+	reqS := NewSelectRequest(spaceName).Key([]any{uint(1010)})
 	data, err := conn.Do(reqS).Get()
 	require.NoError(t, err, "failed to Select")
 	assert.Equal(t, "Tarantool", data[0].([]any)[1], "wrong Select body")

--- a/watch.go
+++ b/watch.go
@@ -11,53 +11,53 @@ import (
 // BroadcastRequest helps to send broadcast messages. See:
 // https://www.tarantool.io/en/doc/latest/reference/reference_lua/box_events/broadcast/
 type BroadcastRequest struct {
-	call *CallRequest
+	call CallRequest
 	key  string
 }
 
 // NewBroadcastRequest returns a new broadcast request for a specified key.
-func NewBroadcastRequest(key string) *BroadcastRequest {
-	req := new(BroadcastRequest)
-	req.key = key
-	req.call = NewCallRequest("box.broadcast").Args([]any{key})
-	return req
+func NewBroadcastRequest(key string) BroadcastRequest {
+	return BroadcastRequest{
+		call: NewCallRequest("box.broadcast").Args([]any{key}),
+		key:  key,
+	}
 }
 
 // Value sets the value for the broadcast request.
 // Note: default value is nil.
-func (req *BroadcastRequest) Value(value any) *BroadcastRequest {
+func (req BroadcastRequest) Value(value any) BroadcastRequest {
 	req.call = req.call.Args([]any{req.key, value})
 	return req
 }
 
 // Context sets a passed context to the broadcast request.
-func (req *BroadcastRequest) Context(ctx context.Context) *BroadcastRequest {
+func (req BroadcastRequest) Context(ctx context.Context) BroadcastRequest {
 	req.call = req.call.Context(ctx)
 	return req
 }
 
 // Type returns IPROTO code for the broadcast request.
-func (req *BroadcastRequest) Type() iproto.Type {
+func (req BroadcastRequest) Type() iproto.Type {
 	return req.call.Type()
 }
 
 // Body fills an msgpack.Encoder with the broadcast request body.
-func (req *BroadcastRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
+func (req BroadcastRequest) Body(res SchemaResolver, enc *msgpack.Encoder) error {
 	return req.call.Body(res, enc)
 }
 
 // Ctx returns a context of the broadcast request.
-func (req *BroadcastRequest) Ctx() context.Context {
+func (req BroadcastRequest) Ctx() context.Context {
 	return req.call.Ctx()
 }
 
 // Async returns is the broadcast request expects a response.
-func (req *BroadcastRequest) Async() bool {
+func (req BroadcastRequest) Async() bool {
 	return req.call.Async()
 }
 
 // Response creates a response for a BroadcastRequest.
-func (req *BroadcastRequest) Response(header Header, body io.Reader) (Response, error) {
+func (req BroadcastRequest) Response(header Header, body io.Reader) (Response, error) {
 	return DecodeBaseResponse(header, body)
 }
 


### PR DESCRIPTION
- Rename `Make*Requests()` to `New*Requests()`, same for the type constructors.
- All `New*Request()` constructors now return values instead of pointers; all methods use value receivers and return values, enabling immutable builder-style chaining.
- Removed intermediate `spaceRequest`/`spaceIndexRequest` types from the `tarantool` package and `spaceRequest` from `crud` — `space` and `index` fields are inlined directly into each request struct. Constructors converted to composite literal style.
- Same pattern applied to `arrow/` and `settings/`. In `box/`, request types no longer embed `tarantool.CallRequest` — they store it via `baseCallRequest` and implement their own `Context()` returning the wrapper type.
- See `MIGRATION.md` and `CHANGELOG.md` for the full migration guide and breaking-change note (calling a builder method without using the return value silently discards the change).

Replaces #553, which was rebased onto current master and renamed to `bigbes/gh-238-request-value-receivers`.

Part of #238
