### PR TITLE
ci: pin golangci-lint version and unlimit issue output

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  GOLANGCI_LINT_VERSION: v2.11.4
+
 jobs:
   luacheck:
     runs-on: ubuntu-24.04
@@ -45,6 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --config=.golangci.yml
 
   codespell:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,10 @@
 version: "2"
 
+issues:
+  # Disable limits on the number of printed issues.
+  max-issues-per-linter: 0 # 0 = no limit.
+  max-same-issues: 0 # 0 = no limit.
+
 formatters:
   enable:
     - goimports

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ format:
 
 .PHONY: golangci-lint
 golangci-lint:
-	golangci-lint run --max-same-issues 0 --max-issues-per-linter 100
+	golangci-lint run ./...
 
 .PHONY: test
 test:


### PR DESCRIPTION
Pin golangci-lint to v2.11.4 via a top-level GOLANGCI_LINT_VERSION env var so the version is bumped in one place. Disable per-linter and same-issue printing limits in .golangci.yml so all findings are visible.