### PR TITLE
tests: prevent leaked tarantool and panic on bad start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 * Fixed the fluctuating behavior of the TestConnectionHandlerOpenUpdateClose
   test by increasing the waiting time (#502).
+* On Linux, tarantool processes started by `test_helpers.StartTarantool`
+  are now terminated when the parent test process dies, preventing leaked
+  instances after a panic (#147).
+* Reordered tests to defer `test_helpers.StopTarantoolWithCleanup` only
+  after asserting `StartTarantool` did not return an error, so a failed
+  start no longer panics with a nil-pointer dereference in the deferred
+  cleanup (#147).
 
 ## [v2.4.1] - 2025-10-16
 

--- a/arrow/tarantool_test.go
+++ b/arrow/tarantool_test.go
@@ -108,12 +108,11 @@ func runTestMain(m *testing.M) int {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(instance)
-
 	if err != nil {
 		log.Printf("Failed to prepare test Tarantool: %s", err)
 		return 1
 	}
+	defer test_helpers.StopTarantoolWithCleanup(instance)
 
 	return m.Run()
 }

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -1446,12 +1446,11 @@ func TestYieldEveryOption(t *testing.T) {
 // https://stackoverflow.com/questions/27629380/how-to-exit-a-go-program-honoring-deferred-calls
 func runTestMain(m *testing.M) int {
 	inst, err := test_helpers.StartTarantool(startOpts)
-	defer test_helpers.StopTarantoolWithCleanup(inst)
-
 	if err != nil {
 		log.Printf("Failed to prepare test tarantool: %s", err)
 		return 1
 	}
+	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	return m.Run()
 }

--- a/datetime/datetime_test.go
+++ b/datetime/datetime_test.go
@@ -981,12 +981,11 @@ func runTestMain(m *testing.M) int {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(instance)
-
 	if err != nil {
 		log.Printf("Failed to prepare test Tarantool: %s", err)
 		return 1
 	}
+	defer test_helpers.StopTarantoolWithCleanup(instance)
 
 	return m.Run()
 }

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -599,12 +599,11 @@ func runTestMain(m *testing.M) int {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(instance)
-
 	if err != nil {
 		log.Printf("Failed to prepare test Tarantool: %s", err)
 		return 1
 	}
+	defer test_helpers.StopTarantoolWithCleanup(instance)
 
 	return m.Run()
 }

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -2762,8 +2762,8 @@ func newWatcherReconnectionPrepareTestConnection(t *testing.T) (*Connection, con
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	t.Cleanup(func() { test_helpers.StopTarantoolWithCleanup(inst) })
 	require.NoErrorf(t, err, "Unable to start Tarantool")
+	t.Cleanup(func() { test_helpers.StopTarantoolWithCleanup(inst) })
 
 	ctx, cancel := test_helpers.GetConnectContext()
 
@@ -2843,8 +2843,8 @@ func TestConnection_NewWatcher_reconnect(t *testing.T) {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(inst)
 	require.NoErrorf(t, err, "Unable to start Tarantool")
+	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	reconnectOpts := opts
 	reconnectOpts.Reconnect = 100 * time.Millisecond
@@ -3097,8 +3097,8 @@ func TestConnection_named_index_after_reconnect(t *testing.T) {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(inst)
 	require.NoErrorf(t, err, "Unable to start Tarantool")
+	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	reconnectOpts := opts
 	reconnectOpts.Reconnect = 100 * time.Millisecond
@@ -3205,8 +3205,8 @@ func TestConnectIsBlocked(t *testing.T) {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(inst)
 	require.NoErrorf(t, err, "Unable to start Tarantool")
+	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	var counter int
 	mockDialer := mockSlowDialer{original: testDialer, counter: &counter}

--- a/test_helpers/cmd_linux.go
+++ b/test_helpers/cmd_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package test_helpers
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// commandKillOnExit returns an *exec.Cmd that will be terminated by the
+// kernel when the parent process dies, see
+// https://github.com/golang/go/issues/37206. Without this, a panic in a
+// test leaves the spawned tarantool process running and blocking the TCP
+// port for subsequent runs (issue #147).
+func commandKillOnExit(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGTERM,
+	}
+	return cmd
+}

--- a/test_helpers/cmd_other.go
+++ b/test_helpers/cmd_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package test_helpers
+
+import (
+	"os/exec"
+)
+
+// commandKillOnExit is a fallback for platforms without a Pdeathsig
+// equivalent. It just delegates to exec.Command, so a parent panic may
+// leave the tarantool child alive (issue #147).
+func commandKillOnExit(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}

--- a/test_helpers/main.go
+++ b/test_helpers/main.go
@@ -430,7 +430,7 @@ func StartTarantool(startOpts StartOpts) (*TarantoolInstance, error) {
 		args = append(args, "--config", startOpts.ConfigFile)
 		args = append(args, "--name", startOpts.InstanceName)
 	}
-	inst.Cmd = exec.Command(getTarantoolExec(), args...)
+	inst.Cmd = commandKillOnExit(getTarantoolExec(), args...)
 	inst.Cmd.Dir = startOpts.WorkDir
 
 	inst.Cmd.Env = append(

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -149,12 +149,11 @@ func runTestMain(m *testing.M) int {
 		ConnectRetry: 10,
 		RetryTimeout: 500 * time.Millisecond,
 	})
-	defer test_helpers.StopTarantoolWithCleanup(inst)
-
 	if err != nil {
 		log.Printf("Failed to prepare test tarantool: %s", err)
 		return 1
 	}
+	defer test_helpers.StopTarantoolWithCleanup(inst)
 
 	return m.Run()
 }


### PR DESCRIPTION
Two related issues from #147 made test failures painful to diagnose:

1. When a test panicked, the spawned tarantool process was left running and kept its TCP port bound, so the next run failed with `address already in use` instead of the original test failure.
2. The common `defer test_helpers.StopTarantoolWithCleanup(inst)` placed before the `require.NoError(t, err)` panicked with a nil-pointer dereference when `StartTarantool` returned a nil instance on error, hiding the real "Unable to start Tarantool" failure.

Changes were made:

- New `test_helpers.commandKillOnExit` helper: sets `Pdeathsig=SIGTERM` on Linux so the tarantool child dies with the test process. Darwin gets a no-op fallback (no `Pdeathsig` equivalent — see `cmd_other.go`).
- Reordered every offending test site to assert `StartTarantool` succeeded before deferring cleanup. Standard Go idiom, and avoids growing a nil-guard inside the helper that would mask further `StartTarantool` bugs.

Part of #147.