### PR TITLE
api: redesign errors around errors.Is and errors.As

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
   and `index` fields are now inlined directly into each request struct.
   The same flattening was applied to `crud.spaceRequest`.
 * Required Go version is `1.24` now (#456).
+* Error types redesigned around `errors.Is` / `errors.As` (#469):
+  `tarantool.Error` renamed to `tarantool.ServerError`; the seven legacy
+  client error code constants are now package-level `error` sentinels
+  (`ErrConnectionClosed`, `ErrTimeouted`, ...) with numeric forms exposed
+  as `tarantool.Code*`; `ClientError` gained a `Cause` field that wraps
+  the underlying I/O error; `ClientError.Temporary()` removed in favour
+  of `tarantool.IsRetryableError(err)` / `errors.Is(err, ErrRetryable)`.
+  See MIGRATION.md.
 * `test_helpers.MockDoer` is now an interface instead of a struct. The
   `Requests` field became a method `Requests()`. The `NewMockDoer()`
   constructor now returns the interface and uses a builder pattern.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -79,6 +79,58 @@ TODO
   `ModeRW`, `RO` → `ModeRO`, `PreferRW` → `ModePreferRW`, `PreferRO` →
   `ModePreferRO`, `UnknownRole` → `RoleUnknown`, `MasterRole` → `RoleMaster`,
   `ReplicaRole` → `RoleReplica`.
+* Error types redesigned around Go's `errors.Is` / `errors.As` (#469):
+
+  * `tarantool.Error` (server-side error wrapper) renamed to
+    `tarantool.ServerError`.
+  * `ClientError.Code` is now typed as `iproto.Error` (same numeric
+    values as the old `uint32` constants), matching `ServerError.Code`.
+  * `ClientError.Temporary()` removed. Use `tarantool.IsRetryableError(err)`
+    or `errors.Is(err, tarantool.ErrRetryable)`.
+  * The seven legacy `uint32` constants are now package-level `error`
+    sentinels matched via `errors.Is`. Numeric forms remain available as
+    `tarantool.Code*` constants:
+
+    | Old (`uint32` constant) | New sentinel              | Numeric (`iproto.Error`)    |
+    |-------------------------|---------------------------|-----------------------------|
+    | `ErrConnectionNotReady` | `ErrConnectionNotReady`   | `CodeConnectionNotReady`    |
+    | `ErrConnectionClosed`   | `ErrConnectionClosed`     | `CodeConnectionClosed`      |
+    | `ErrProtocolError`      | `ErrProtocolError`        | `CodeProtocolError`         |
+    | `ErrTimeouted`          | `ErrTimeouted`            | `CodeTimeouted`             |
+    | `ErrRateLimited`        | `ErrRateLimited`          | `CodeRateLimited`           |
+    | `ErrConnectionShutdown` | `ErrConnectionShutdown`   | `CodeConnectionShutdown`    |
+    | `ErrIoError`            | `ErrIoError`              | `CodeIoError`               |
+
+  * `ClientError` gained a `Cause error` field; I/O failures wrap their
+    underlying `net`-layer error and can be inspected with `errors.As`.
+  * `ClientError.Error()` now formats as
+    `"<sentinel-message>: <Msg>: <cause>"` (omitting empty parts).
+
+  Before:
+  ```Go
+  if clientErr, ok := err.(tarantool.ClientError); ok {
+      if clientErr.Code == tarantool.ErrConnectionClosed {
+          // ...
+      }
+      if clientErr.Temporary() {
+          // retry
+      }
+  }
+  var tntErr tarantool.Error
+  if errors.As(err, &tntErr) { /* ... */ }
+  ```
+
+  After:
+  ```Go
+  if errors.Is(err, tarantool.ErrConnectionClosed) {
+      // ...
+  }
+  if tarantool.IsRetryableError(err) {
+      // retry
+  }
+  var tntErr tarantool.ServerError
+  if errors.As(err, &tntErr) { /* ... */ }
+  ```
 * `Future.Release()` call could be used to free resources allocated for the
   `Future` object created by a `Connection` object.
 * Removed deprecated `NewCall16Request` and `NewCall17Request` constructors.

--- a/arrow/tarantool_test.go
+++ b/arrow/tarantool_test.go
@@ -76,7 +76,7 @@ func TestInsert_invalid(t *testing.T) {
 
 			req := arrow.NewInsertRequest(space, arr)
 			_, err = conn.Do(req).Get()
-			ttErr := err.(tarantool.Error)
+			ttErr := err.(tarantool.ServerError)
 
 			require.Contains(t, a.expected, ttErr.Code)
 		})

--- a/box/tarantool_test.go
+++ b/box/tarantool_test.go
@@ -153,7 +153,7 @@ func TestBox_Sugar_Schema_UserCreate_AlreadyExists(t *testing.T) {
 	require.Error(t, err)
 
 	// Require that error code is ER_USER_EXISTS.
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 	errors.As(err, &boxErr)
 	require.Equal(t, iproto.ER_USER_EXISTS, boxErr.Code)
 }
@@ -295,7 +295,7 @@ func TestBox_Sugar_Schema_UserDrop_UnknownUser(t *testing.T) {
 	err = b.Schema().User().Drop(ctx, "some_strange_not_existing_name", box.UserDropOptions{})
 	require.Error(t, err)
 
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 
 	// Require that error code is ER_NO_SUCH_USER
 	errors.As(err, &boxErr)
@@ -313,7 +313,7 @@ func TestSchemaUser_Passwd_NotFound(t *testing.T) {
 	err = b.Schema().User().Passwd(ctx, "not-exists-passwd", "new_password")
 	require.Error(t, err)
 	// Require that error code is ER_USER_EXISTS.
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 	errors.As(err, &boxErr)
 	require.Equal(t, iproto.ER_NO_SUCH_USER, boxErr.Code)
 }
@@ -391,7 +391,7 @@ func TestSchemaUser_Passwd_WithoutGrants(t *testing.T) {
 	require.Error(t, err)
 
 	// Require that error code is AccessDeniedError,
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 	errors.As(err, &boxErr)
 	require.Equal(t, iproto.ER_ACCESS_DENIED, boxErr.Code)
 }
@@ -456,7 +456,7 @@ func TestBox_Sugar_Schema_UserGrant_NoSu(t *testing.T) {
 	require.Error(t, err)
 
 	// Require that error code is ER_ACCESS_DENIED.
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 	errors.As(err, &boxErr)
 	require.Equal(t, iproto.ER_ACCESS_DENIED, boxErr.Code)
 }
@@ -546,7 +546,7 @@ func TestSchemaUser_Revoke_WithoutSu(t *testing.T) {
 	require.Error(t, err)
 
 	// Require that error code is ER_ACCESS_DENIED.
-	var boxErr tarantool.Error
+	var boxErr tarantool.ServerError
 	errors.As(err, &boxErr)
 	require.Equal(t, iproto.ER_ACCESS_DENIED, boxErr.Code)
 }

--- a/connection.go
+++ b/connection.go
@@ -380,7 +380,7 @@ func (conn *Connection) ClosedNow() bool {
 // Close closes Connection.
 // After this method called, there is no way to reopen this Connection.
 func (conn *Connection) Close() error {
-	err := ClientError{ErrConnectionClosed, "connection closed by client"}
+	err := newClientError(CodeConnectionClosed, "connection closed by client", nil)
 	conn.mutex.Lock()
 	defer conn.mutex.Unlock()
 	return conn.closeConnection(err, true)
@@ -552,7 +552,7 @@ func (conn *Connection) connect(ctx context.Context) error {
 		}
 	}
 	if conn.state == connClosed {
-		err = ClientError{ErrConnectionClosed, "using closed connection"}
+		err = newClientError(CodeConnectionClosed, "using closed connection", nil)
 	}
 	return err
 }
@@ -631,8 +631,7 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return err
 			}
-			if clientErr, ok := err.(ClientError); ok &&
-				clientErr.Code == ErrConnectionClosed {
+			if errors.Is(err, ErrConnectionClosed) {
 				return err
 			}
 		} else {
@@ -664,7 +663,7 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 		slog.String(LogKeyAddress, conn.addrString()),
 	)
 	// mark connection as closed to avoid reopening by another goroutine
-	return ClientError{ErrConnectionClosed, "last reconnect failed"}
+	return newClientError(CodeConnectionClosed, "last reconnect failed", nil)
 }
 
 func (conn *Connection) reconnectImpl(neterr error, c Conn) {
@@ -737,11 +736,11 @@ func (conn *Connection) writer(w writeFlusher, c Conn) {
 			runtime.Gosched()
 			if len(conn.dirtyShard) == 0 {
 				if err := w.Flush(); err != nil {
-					err = ClientError{
-						ErrIoError,
-						fmt.Sprintf("failed to flush data to the connection: %s", err),
-					}
-					conn.reconnect(err, c)
+					conn.reconnect(newClientError(
+						CodeIoError,
+						"failed to flush data to the connection",
+						err,
+					), c)
 					return
 				}
 			}
@@ -764,11 +763,11 @@ func (conn *Connection) writer(w writeFlusher, c Conn) {
 			continue
 		}
 		if _, err := w.Write(packet.b); err != nil {
-			err = ClientError{
-				ErrIoError,
-				fmt.Sprintf("failed to write data to the connection: %s", err),
-			}
-			conn.reconnect(err, c)
+			conn.reconnect(newClientError(
+				CodeIoError,
+				"failed to write data to the connection",
+				err,
+			), c)
 			return
 		}
 		packet.Reset()
@@ -861,23 +860,23 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 		buf, err = read(r, conn.lenbuf[:], conn.alloc)
 
 		if err != nil {
-			err = ClientError{
-				ErrIoError,
-				fmt.Sprintf("failed to read data from the connection: %s", err),
-			}
-			conn.reconnect(err, c)
+			conn.reconnect(newClientError(
+				CodeIoError,
+				"failed to read data from the connection",
+				err,
+			), c)
 			return
 		}
 
 		header, code, err := decodeHeader(conn.dec, &buf)
 
 		if err != nil {
-			err = ClientError{
-				ErrProtocolError,
-				fmt.Sprintf("failed to decode IPROTO header: %s", err),
-			}
 			buf.Release()
-			conn.reconnect(err, c)
+			conn.reconnect(newClientError(
+				CodeProtocolError,
+				"failed to decode IPROTO header",
+				err,
+			), c)
 			return
 		}
 
@@ -886,12 +885,13 @@ func (conn *Connection) reader(r io.Reader, c Conn) {
 			if event, err := readWatchEvent(&buf); err == nil {
 				events <- event
 			} else {
-				err = ClientError{
-					ErrProtocolError,
-					fmt.Sprintf("failed to decode IPROTO_EVENT: %s", err),
-				}
+				wrapped := newClientError(
+					CodeProtocolError,
+					"failed to decode IPROTO_EVENT",
+					err,
+				)
 				conn.logger.Warn(LogMsgWatchEventReadFailed,
-					slog.Any(LogKeyError, err),
+					slog.Any(LogKeyError, wrapped),
 				)
 			}
 			buf.Release()
@@ -938,10 +938,11 @@ func (conn *Connection) newFuture(req Request) *future {
 		select {
 		case conn.rlimit <- struct{}{}:
 		default:
-			fut.err = ClientError{
-				ErrRateLimited,
-				"Request is rate limited on client",
-			}
+			fut.err = newClientError(
+				CodeRateLimited,
+				"request is rate limited on client",
+				nil,
+			)
 			fut.finish()
 			return fut
 		}
@@ -952,26 +953,17 @@ func (conn *Connection) newFuture(req Request) *future {
 	shard.rmut.Lock()
 	switch atomic.LoadUint32(&conn.state) {
 	case connClosed:
-		fut.err = ClientError{
-			ErrConnectionClosed,
-			"using closed connection",
-		}
+		fut.err = newClientError(CodeConnectionClosed, "using closed connection", nil)
 		fut.finish()
 		shard.rmut.Unlock()
 		return fut
 	case connDisconnected:
-		fut.err = ClientError{
-			ErrConnectionNotReady,
-			"client connection is not ready",
-		}
+		fut.err = newClientError(CodeConnectionNotReady, "client connection is not ready", nil)
 		fut.finish()
 		shard.rmut.Unlock()
 		return fut
 	case connShutdown:
-		fut.err = ClientError{
-			ErrConnectionShutdown,
-			"server shutdown in progress",
-		}
+		fut.err = newClientError(CodeConnectionShutdown, "server shutdown in progress", nil)
 		fut.finish()
 		shard.rmut.Unlock()
 		return fut
@@ -1174,10 +1166,11 @@ func (conn *Connection) timeouts() {
 					} else {
 						fut.next = nil
 					}
-					fut.setError(ClientError{
-						Code: ErrTimeouted,
-						Msg:  fmt.Sprintf("client timeout for request %d", fut.requestId),
-					})
+					fut.setError(newClientError(
+						CodeTimeouted,
+						fmt.Sprintf("client timeout for request %d", fut.requestId),
+						nil,
+					))
 					conn.markDone()
 					shard.bufmut.Unlock()
 				}
@@ -1562,7 +1555,7 @@ func (conn *Connection) shutdown(forever bool) error {
 
 	if !atomic.CompareAndSwapUint32(&conn.state, connConnected, connShutdown) {
 		if forever {
-			err := ClientError{ErrConnectionClosed, "connection closed by client"}
+			err := newClientError(CodeConnectionClosed, "connection closed by client", nil)
 			return conn.closeConnection(err, true)
 		}
 		return nil
@@ -1593,7 +1586,7 @@ func (conn *Connection) shutdown(forever bool) error {
 	}
 
 	if forever {
-		err := ClientError{ErrConnectionClosed, "connection closed by client"}
+		err := newClientError(CodeConnectionClosed, "connection closed by client", nil)
 		return conn.closeConnection(err, true)
 	} else {
 		// Start to reconnect based on common rules, same as in net.box.
@@ -1601,10 +1594,11 @@ func (conn *Connection) shutdown(forever bool) error {
 		// subscribed connections are terminated.
 		// See https://www.tarantool.io/en/doc/latest/dev_guide/internals/iproto/graceful_shutdown/
 		// step 3.
-		conn.reconnectImpl(ClientError{
-			ErrConnectionClosed,
+		conn.reconnectImpl(newClientError(
+			CodeConnectionClosed,
 			"connection closed after server shutdown",
-		}, conn.c)
+			nil,
+		), conn.c)
 		return nil
 	}
 }

--- a/dial.go
+++ b/dial.go
@@ -642,13 +642,12 @@ func readResponse(ctx context.Context, conn Conn, req Request) (Response, error)
 
 	_, err = resp.Decode()
 	if err != nil {
-		switch err.(type) {
-		case Error:
+		var serverErr ServerError
+		if errors.As(err, &serverErr) {
 			return resp, err
-		default:
-			resp.Release()
-			return nil, fmt.Errorf("decode response body error: %w", err)
 		}
+		resp.Release()
+		return nil, fmt.Errorf("decode response body error: %w", err)
 	}
 
 	return resp, nil

--- a/errors.go
+++ b/errors.go
@@ -1,64 +1,161 @@
 package tarantool
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tarantool/go-iproto"
 )
 
-// Error is wrapper around error returned by Tarantool.
-type Error struct {
+// Client error codes produced by this client itself, as opposed to the
+// server-side iproto.Error codes carried by ServerError. The numeric
+// values match the constants exposed by previous versions of
+// go-tarantool. They share the iproto.Error type so comparisons with
+// go-iproto values need no conversion.
+//
+// Each code is annotated with whether the failed request is safe to
+// repeat without side effects. Codes marked retryable are joined with
+// ErrRetryable in the error chain, so errors.Is(err, ErrRetryable) and
+// IsRetryableError(err) report true for them.
+const (
+	// CodeConnectionNotReady: the connection was not established, so the
+	// request never reached the server. Safe to repeat (retryable).
+	CodeConnectionNotReady iproto.Error = 0x4000 + iota
+	// CodeConnectionClosed: the connection was closed; the request may or
+	// may not have been sent. Not retryable.
+	CodeConnectionClosed
+	// CodeProtocolError: the server reply could not be decoded. Not
+	// retryable.
+	CodeProtocolError
+	// CodeTimeouted: the request timed out in flight and may already be
+	// executing on the server, so repeating it can duplicate side effects.
+	// It is nonetheless flagged retryable to preserve the historical
+	// transient-failure handling; callers that need exactly-once semantics
+	// must guard non-idempotent requests themselves.
+	CodeTimeouted
+	// CodeRateLimited: the request was rejected locally before being sent
+	// because of the rate limit. Safe to repeat (retryable).
+	CodeRateLimited
+	// CodeConnectionShutdown: the request was rejected because the server
+	// signalled graceful shutdown. Not retryable on this connection.
+	CodeConnectionShutdown
+	// CodeIoError: an I/O error occurred on the socket. Retryable.
+	CodeIoError
+)
+
+// sentinelError is a package-level error value matched via errors.Is.
+type sentinelError struct {
+	code iproto.Error
+	msg  string
+}
+
+func (s *sentinelError) Error() string      { return s.msg }
+func (s *sentinelError) Code() iproto.Error { return s.code }
+
+// Sentinel errors for client-side failure modes. Compare with errors.Is.
+var (
+	ErrConnectionNotReady error = &sentinelError{CodeConnectionNotReady, "connection not ready"}
+	ErrConnectionClosed   error = &sentinelError{CodeConnectionClosed, "connection closed"}
+	ErrProtocolError      error = &sentinelError{CodeProtocolError, "protocol error"}
+	ErrTimeouted          error = &sentinelError{CodeTimeouted, "request timed out"}
+	ErrRateLimited        error = &sentinelError{CodeRateLimited, "rate limited"}
+	ErrConnectionShutdown error = &sentinelError{CodeConnectionShutdown, "connection shutdown"}
+	ErrIoError            error = &sentinelError{CodeIoError, "I/O error"}
+
+	// ErrRetryable marks errors that may succeed on retry. It is
+	// joined into the error chain of any retryable ClientError so
+	// that errors.Is(err, ErrRetryable) returns true.
+	ErrRetryable = errors.New("retryable")
+)
+
+// codeToSentinel maps a code to its package-level sentinel.
+var codeToSentinel = map[iproto.Error]error{
+	CodeConnectionNotReady: ErrConnectionNotReady,
+	CodeConnectionClosed:   ErrConnectionClosed,
+	CodeProtocolError:      ErrProtocolError,
+	CodeTimeouted:          ErrTimeouted,
+	CodeRateLimited:        ErrRateLimited,
+	CodeConnectionShutdown: ErrConnectionShutdown,
+	CodeIoError:            ErrIoError,
+}
+
+// retryableSentinels lists the codes whose chain implies ErrRetryable.
+var retryableSentinels = map[iproto.Error]struct{}{
+	CodeConnectionNotReady: {},
+	CodeTimeouted:          {},
+	CodeRateLimited:        {},
+	CodeIoError:            {},
+}
+
+// ClientError is a failure produced by this client: connection state
+// transitions, request timeouts, protocol decoding, or I/O.
+//
+// Compare with package sentinels via errors.Is. If Cause is set, it
+// is reachable via errors.As / errors.Unwrap.
+type ClientError struct {
+	Code  iproto.Error
+	Msg   string
+	Cause error
+}
+
+// Error formats as "<sentinel>: <Msg>: <cause>", omitting any empty
+// segment. If the code has no registered sentinel, the prefix falls
+// back to "client error 0x<code>".
+func (e ClientError) Error() string {
+	parts := make([]string, 0, 3)
+	if s, ok := codeToSentinel[e.Code]; ok {
+		parts = append(parts, s.Error())
+	} else {
+		parts = append(parts, fmt.Sprintf("client error 0x%x", int(e.Code)))
+	}
+	if e.Msg != "" && parts[0] != e.Msg {
+		parts = append(parts, e.Msg)
+	}
+	if e.Cause != nil {
+		parts = append(parts, e.Cause.Error())
+	}
+	return strings.Join(parts, ": ")
+}
+
+// Unwrap exposes the sentinel, ErrRetryable (when applicable), and
+// the underlying cause to errors.Is / errors.As.
+func (e ClientError) Unwrap() []error {
+	out := make([]error, 0, 3)
+	if s, ok := codeToSentinel[e.Code]; ok {
+		out = append(out, s)
+	}
+	if _, ok := retryableSentinels[e.Code]; ok {
+		out = append(out, ErrRetryable)
+	}
+	if e.Cause != nil {
+		out = append(out, e.Cause)
+	}
+	return out
+}
+
+// newClientError is the internal constructor used across the package.
+func newClientError(code iproto.Error, msg string, cause error) ClientError {
+	return ClientError{Code: code, Msg: msg, Cause: cause}
+}
+
+// ServerError wraps an error returned by the Tarantool server.
+type ServerError struct {
 	Code         iproto.Error
 	Msg          string
 	ExtendedInfo *BoxError
 }
 
-// Error converts an Error to a string.
-func (tnterr Error) Error() string {
-	if tnterr.ExtendedInfo != nil {
-		return tnterr.ExtendedInfo.Error()
+// Error converts a ServerError to a string.
+func (e ServerError) Error() string {
+	if e.ExtendedInfo != nil {
+		return e.ExtendedInfo.Error()
 	}
-
-	return fmt.Sprintf("%s (0x%x)", tnterr.Msg, tnterr.Code)
+	return fmt.Sprintf("%s (0x%x)", e.Msg, int(e.Code))
 }
 
-// ClientError is connection error produced by this client,
-// i.e. connection failures or timeouts.
-type ClientError struct {
-	Code uint32
-	Msg  string
+// IsRetryableError reports whether err indicates a transient failure
+// that may succeed on retry.
+func IsRetryableError(err error) bool {
+	return errors.Is(err, ErrRetryable)
 }
-
-// Error converts a ClientError to a string.
-func (clierr ClientError) Error() string {
-	return fmt.Sprintf("%s (0x%x)", clierr.Msg, clierr.Code)
-}
-
-// Temporary returns true if next attempt to perform request may succeeded.
-//
-// Currently it returns true when:
-//
-// - Connection is not connected at the moment
-//
-// - request is timeouted
-//
-// - request is aborted due to rate limit.
-func (clierr ClientError) Temporary() bool {
-	switch clierr.Code {
-	case ErrConnectionNotReady, ErrTimeouted, ErrRateLimited, ErrIoError:
-		return true
-	default:
-		return false
-	}
-}
-
-// Tarantool client error codes.
-const (
-	ErrConnectionNotReady = 0x4000 + iota
-	ErrConnectionClosed   = 0x4000 + iota
-	ErrProtocolError      = 0x4000 + iota
-	ErrTimeouted          = 0x4000 + iota
-	ErrRateLimited        = 0x4000 + iota
-	ErrConnectionShutdown = 0x4000 + iota
-	ErrIoError            = 0x4000 + iota
-)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,124 @@
+package tarantool
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/tarantool/go-iproto"
+)
+
+func TestClientError_IsSentinel(t *testing.T) {
+	cases := []struct {
+		code     iproto.Error
+		sentinel error
+	}{
+		{CodeConnectionNotReady, ErrConnectionNotReady},
+		{CodeConnectionClosed, ErrConnectionClosed},
+		{CodeProtocolError, ErrProtocolError},
+		{CodeTimeouted, ErrTimeouted},
+		{CodeRateLimited, ErrRateLimited},
+		{CodeConnectionShutdown, ErrConnectionShutdown},
+		{CodeIoError, ErrIoError},
+	}
+	for _, tc := range cases {
+		err := newClientError(tc.code, "x", nil)
+		if !errors.Is(err, tc.sentinel) {
+			t.Errorf("code 0x%x: errors.Is did not match its sentinel", int(tc.code))
+		}
+	}
+}
+
+func TestClientError_IsRetryableError(t *testing.T) {
+	retryable := []iproto.Error{
+		CodeConnectionNotReady, CodeTimeouted, CodeRateLimited, CodeIoError,
+	}
+	notRetryable := []iproto.Error{
+		CodeConnectionClosed, CodeProtocolError, CodeConnectionShutdown,
+	}
+	for _, code := range retryable {
+		err := newClientError(code, "x", nil)
+		if !IsRetryableError(err) {
+			t.Errorf("code 0x%x should be retryable", int(code))
+		}
+		if !errors.Is(err, ErrRetryable) {
+			t.Errorf("code 0x%x: errors.Is(_, ErrRetryable) failed", int(code))
+		}
+	}
+	for _, code := range notRetryable {
+		err := newClientError(code, "x", nil)
+		if IsRetryableError(err) {
+			t.Errorf("code 0x%x should NOT be retryable", int(code))
+		}
+	}
+}
+
+func TestClientError_WrapsCause(t *testing.T) {
+	cause := &net.OpError{Op: "read", Err: errors.New("eof")}
+	err := newClientError(CodeIoError, "failed to read", cause)
+
+	var got *net.OpError
+	if !errors.As(err, &got) {
+		t.Fatal("errors.As did not unwrap to *net.OpError")
+	}
+	if got != cause {
+		t.Fatal("errors.As returned a different *net.OpError instance")
+	}
+	if !errors.Is(err, ErrIoError) {
+		t.Fatal("errors.Is did not match ErrIoError after wrap")
+	}
+	if !errors.Is(err, ErrRetryable) {
+		t.Fatal("I/O error should also imply ErrRetryable")
+	}
+}
+
+func TestClientError_ErrorString(t *testing.T) {
+	cases := []struct {
+		err  ClientError
+		want string
+	}{
+		{
+			newClientError(CodeConnectionShutdown, "server shutdown in progress", nil),
+			"connection shutdown: server shutdown in progress",
+		},
+		{
+			newClientError(CodeIoError, "failed to read", errors.New("eof")),
+			"I/O error: failed to read: eof",
+		},
+		{
+			newClientError(CodeTimeouted, "", nil),
+			"request timed out",
+		},
+		{
+			ClientError{Code: iproto.Error(0x9999), Msg: "weird"},
+			"client error 0x9999: weird",
+		},
+	}
+	for _, tc := range cases {
+		if got := tc.err.Error(); got != tc.want {
+			t.Errorf("Error() = %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestServerError_AsAndFormat(t *testing.T) {
+	se := ServerError{Code: iproto.ER_TUPLE_FOUND, Msg: "Duplicate key exists"}
+
+	var got ServerError
+	if !errors.As(se, &got) {
+		t.Fatal("errors.As did not match ServerError")
+	}
+	if got.Code != iproto.ER_TUPLE_FOUND {
+		t.Fatalf("Code = %v", got.Code)
+	}
+	if want := "Duplicate key exists (0x3)"; se.Error() != want {
+		t.Errorf("Error() = %q, want %q", se.Error(), want)
+	}
+}
+
+func TestSentinelError_DoesNotMatchOtherSentinel(t *testing.T) {
+	err := newClientError(CodeTimeouted, "x", nil)
+	if errors.Is(err, ErrConnectionClosed) {
+		t.Error("ErrTimeouted matched ErrConnectionClosed")
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package tarantool_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -1372,7 +1373,10 @@ func ExampleConnection_Do_failure() {
 		// fmt.Printf("Failed to execute the request: %s\n", err)
 		if resp == nil {
 			// Something happens in a client process (timeout, IO error etc).
-			fmt.Printf("Resp == nil, ClientErr = %s\n", err.(tarantool.ClientError))
+			var clientErr tarantool.ClientError
+			if errors.As(err, &clientErr) {
+				fmt.Printf("Resp == nil, ClientErr = %s\n", clientErr)
+			}
 		} else {
 			// Response exist. So it could be a Tarantool error or a decode
 			// error. We need to check the error code.
@@ -1380,9 +1384,11 @@ func ExampleConnection_Do_failure() {
 			if resp.Header().Error == tarantool.ErrorNo {
 				fmt.Printf("Decode error: %s\n", err)
 			} else {
-				code := err.(tarantool.Error).Code
-				fmt.Printf("Error code from the error: %d\n", code)
-				fmt.Printf("Error short from the error: %s\n", code)
+				var serverErr tarantool.ServerError
+				if errors.As(err, &serverErr) {
+					fmt.Printf("Error code from the error: %d\n", serverErr.Code)
+					fmt.Printf("Error short from the error: %s\n", serverErr.Code)
+				}
 			}
 		}
 	}
@@ -1520,7 +1526,7 @@ func ExampleConnection_CloseGraceful_force() {
 	// Force Connection.Close()!
 	// Connection.CloseGraceful() done!
 	// Result:
-	// [] connection closed by client (0x4001)
+	// [] connection closed: connection closed by client
 }
 
 func ExampleWatchOnceRequest() {

--- a/pool/example_test.go
+++ b/pool/example_test.go
@@ -479,7 +479,7 @@ func ExamplePool_CloseGraceful_force() {
 	// Force Pool.Close()!
 	// Pool.CloseGraceful() done!
 	// Result:
-	// [] connection closed by client (0x4001)
+	// [] connection closed: connection closed by client
 }
 
 func ExampleConnect_invalidOpts() {

--- a/response.go
+++ b/response.go
@@ -384,7 +384,7 @@ func (resp *baseResponse) Decode() ([]any, error) {
 		}
 
 		if info.decodedError != "" {
-			resp.err = Error{resp.header.Error, info.decodedError,
+			resp.err = ServerError{resp.header.Error, info.decodedError,
 				info.errorExtendedInfo}
 		}
 	}
@@ -447,7 +447,7 @@ func (resp *SelectResponse) Decode() ([]any, error) {
 		}
 
 		if info.decodedError != "" {
-			resp.err = Error{resp.header.Error, info.decodedError,
+			resp.err = ServerError{resp.header.Error, info.decodedError,
 				info.errorExtendedInfo}
 		}
 	}
@@ -515,7 +515,7 @@ func (resp *ExecuteResponse) Decode() ([]any, error) {
 		}
 
 		if info.decodedError != "" {
-			resp.err = Error{resp.header.Error, info.decodedError,
+			resp.err = ServerError{resp.header.Error, info.decodedError,
 				info.errorExtendedInfo}
 		}
 	}
@@ -580,7 +580,7 @@ func (resp *baseResponse) DecodeTyped(res any) error {
 			}
 		}
 		if info.decodedError != "" {
-			err = Error{resp.header.Error, info.decodedError, info.errorExtendedInfo}
+			err = ServerError{resp.header.Error, info.decodedError, info.errorExtendedInfo}
 		}
 	}
 	return err
@@ -628,7 +628,7 @@ func (resp *SelectResponse) DecodeTyped(res any) error {
 			}
 		}
 		if info.decodedError != "" {
-			err = Error{resp.header.Error, info.decodedError, info.errorExtendedInfo}
+			err = ServerError{resp.header.Error, info.decodedError, info.errorExtendedInfo}
 		}
 	}
 	return err
@@ -679,7 +679,7 @@ func (resp *ExecuteResponse) DecodeTyped(res any) error {
 			}
 		}
 		if info.decodedError != "" {
-			err = Error{resp.header.Error, info.decodedError, info.errorExtendedInfo}
+			err = ServerError{resp.header.Error, info.decodedError, info.errorExtendedInfo}
 		}
 	}
 	return err

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -4,6 +4,7 @@
 package tarantool_test
 
 import (
+	"errors"
 	"sync"
 	"syscall"
 	"testing"
@@ -92,8 +93,8 @@ func testGracefulShutdown(t *testing.T, conn *Connection, inst *test_helpers.Tar
 
 	require.Eventually(t, func() bool {
 		_, err := conn.Do(NewPingRequest()).Get()
-		return err != nil && err.Error() == "server shutdown in progress (0x4005)"
-	}, timeout, tick, "expected shutdown error 'server shutdown in progress (0x4005)'")
+		return err != nil && errors.Is(err, ErrConnectionShutdown)
+	}, timeout, tick, "expected shutdown error matching ErrConnectionShutdown")
 
 	// Check that requests started before the shutdown finish successfully.
 	data, err := fut.Get()

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -678,7 +678,7 @@ func TestClient(t *testing.T) {
 	}
 	req = NewInsertRequest(spaceNo).Tuple(&Tuple{Id: 1, Msg: "hello", Name: "world"})
 	data, err = conn.Do(req).Get()
-	tntErr, ok := err.(Error)
+	tntErr, ok := err.(ServerError)
 	require.True(t, ok, "Expected Error type")
 	assert.Equal(t, iproto.ER_TUPLE_FOUND, tntErr.Code,
 		"Expected %s but got: %v", iproto.ER_TUPLE_FOUND, err)
@@ -1197,7 +1197,7 @@ func TestStressSQL(t *testing.T) {
 	_, err = resp.Decode()
 	require.Error(t, err, "Expected error while decoding")
 
-	tntErr, ok := err.(Error)
+	tntErr, ok := err.(ServerError)
 	assert.True(t, ok)
 	assert.Equal(t, iproto.ER_SPACE_EXISTS, tntErr.Code)
 	require.Equal(t, iproto.ER_SPACE_EXISTS, resp.Header().Error, "Unexpected response error")
@@ -1995,10 +1995,11 @@ func TestComparableErrorsCancelCauseContext(t *testing.T) {
 
 	ctxCause, cancelCause := context.WithCancelCause(context.Background())
 	req := NewPingRequest().Context(ctxCause)
-	cancelCause(ClientError{ErrConnectionClosed, "something went wrong"})
+	cancelCause(ClientError{Code: CodeConnectionClosed, Msg: "something went wrong"})
 	_, err := conn.Do(req).Get()
 	var tmpErr ClientError
 	require.ErrorAs(t, err, &tmpErr)
+	require.ErrorIs(t, err, ErrConnectionClosed)
 }
 
 // waitCtxRequest waits for the WaitGroup in Body() call and returns
@@ -2600,7 +2601,7 @@ func TestErrorExtendedInfoBasic(t *testing.T) {
 	_, err := conn.Do(NewEvalRequest("not a Lua code").Args([]any{})).Get()
 	require.Errorf(t, err, "expected error on invalid Lua code")
 
-	ttErr, ok := err.(Error)
+	ttErr, ok := err.(ServerError)
 	require.Truef(t, ok, "error is built from a Tarantool error")
 
 	expected := BoxError{
@@ -2628,7 +2629,7 @@ func TestErrorExtendedInfoStack(t *testing.T) {
 	_, err := conn.Do(NewEvalRequest("error(chained_error)").Args([]any{})).Get()
 	require.Errorf(t, err, "expected error on explicit error raise")
 
-	ttErr, ok := err.(Error)
+	ttErr, ok := err.(ServerError)
 	require.Truef(t, ok, "error is built from a Tarantool error")
 
 	expected := BoxError{
@@ -2664,7 +2665,7 @@ func TestErrorExtendedInfoFields(t *testing.T) {
 	_, err := conn.Do(NewEvalRequest("error(access_denied_error)").Args([]any{})).Get()
 	require.Errorf(t, err, "expected error on forbidden action")
 
-	ttErr, ok := err.(Error)
+	ttErr, ok := err.(ServerError)
 	require.Truef(t, ok, "error is built from a Tarantool error")
 
 	expected := BoxError{


### PR DESCRIPTION
Reworks `go-tarantool` error types to fit Go's standard `errors.Is` / `errors.As` patterns.

- `tarantool.Error` → `tarantool.ServerError`. The old name read like "any error in this package" and confused users.
- The seven legacy `uint32` client error codes (`ErrConnectionNotReady`, `ErrConnectionClosed`, ...) are now package-level `error` sentinels matched via `errors.Is`. Numeric form is preserved as typed `tarantool.ClientErrorCode` constants (`CodeConnectionClosed`, ...).
- `ClientError` gains `Cause error` + `Unwrap() []error`. I/O failures now wrap the underlying `net` error instead of stringifying it, so `errors.As` reaches it.
- Retryability is expressed as a sentinel (`ErrRetryable`) joined into the chain. `IsRetryable(err)` is a one-line `errors.Is`. Deprecated `ClientError.Temporary()` removed (no callers, `net.Error.Temporary` deprecated since Go 1.18).
- Internal callers in `connection.go`/`response.go` switched to `newClientError` / `ServerError`. Tests in `box`, `arrow`, and the root package migrated from typeassertions to `errors.As` / `errors.Is`.
- Drive-by: fixed a pre-existing `%x` formatting bug on `iproto.Error` in `ServerError.Error()`.

Closes #469