### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Setup Tarantool
       uses: tarantool/setup-tarantool@v4
@@ -38,9 +38,9 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -54,7 +54,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install codespell
         run: pip3 install codespell

--- a/.github/workflows/reusable-run.yml
+++ b/.github/workflows/reusable-run.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup tt
         run: |
@@ -52,7 +52,7 @@ jobs:
       - name: Cache Tarantool master
         if: inputs.tarantool-version == 'master'
         id: cache-latest
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ github.workspace }}/bin
@@ -69,7 +69,7 @@ jobs:
         run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
       - name: Setup golang for the connector and tests
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
 

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Clone the go-tarantool connector
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository_owner }}/go-tarantool
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
 
@@ -34,7 +34,7 @@ jobs:
           echo "TNT_VERSION=$TNT_VERSION" >> $GITHUB_ENV
 
       - name: Setup golang for connector and tests
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Clone the connector
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ${{ env.SRCDIR }}
 
@@ -105,7 +105,7 @@ jobs:
         run: brew install tarantool
 
       - name: Setup golang for the connector and tests
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.golang }}
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -95,7 +95,7 @@ var connOpts = tarantool.Opts{
 	Timeout: 5 * time.Second,
 }
 
-const defaultCountRetry = 5
+const defaultCountRetry = 20
 
 const tick = 500 * time.Millisecond
 const timeout = defaultCountRetry * tick


### PR DESCRIPTION
Update third-party actions used in workflows to the current major releases so we benefit from upstream bug fixes, Node.js runtime updates, and security patches.

- actions/checkout v5 -> v6
- actions/setup-go v5 -> v6
- actions/cache v4 -> v5
- actions/download-artifact v5 -> v8