### PR TITLE
internal: enable tparallel, predeclared, nilnil

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
     - maintidx
     - mnd
     - nestif
-    - nilnil
     - nlreturn
     - noctx
     - noinlineerr
@@ -59,11 +58,9 @@ linters:
     - paralleltest
     - perfsprint
     - prealloc
-    - predeclared
     - recvcheck
     - revive
     - staticcheck
-    - tparallel
     - testableexamples
     - testpackage
     - unqueryvet

--- a/box/schema_user_test.go
+++ b/box/schema_user_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestUserExistsResponse_DecodeMsgpack(t *testing.T) {
+	t.Parallel()
+
 	tCases := map[bool]func() *bytes.Buffer{
 		true: func() *bytes.Buffer {
 			buf := bytes.NewBuffer(nil)
@@ -47,6 +49,8 @@ func TestUserExistsResponse_DecodeMsgpack(t *testing.T) {
 }
 
 func TestUserPasswordResponse_DecodeMsgpack(t *testing.T) {
+	t.Parallel()
+
 	tCases := []string{
 		"test",
 		"$tr0ng_pass",

--- a/client_tools.go
+++ b/client_tools.go
@@ -144,8 +144,8 @@ func (ops *Operations) append(op string, field int, arg any) *Operations {
 	return ops
 }
 
-func (ops *Operations) appendSplice(op string, field, pos, len int, replace string) *Operations {
-	ops.ops = append(ops.ops, operation{Op: op, Field: field, Pos: pos, Len: len, Replace: replace})
+func (ops *Operations) appendSplice(op string, field, pos, length int, replace string) *Operations {
+	ops.ops = append(ops.ops, operation{Op: op, Field: field, Pos: pos, Len: length, Replace: replace})
 	return ops
 }
 
@@ -175,8 +175,8 @@ func (ops *Operations) BitwiseXor(field int, arg any) *Operations {
 }
 
 // Splice adds a splice operation to the collection of update operations.
-func (ops *Operations) Splice(field, pos, len int, replace string) *Operations {
-	return ops.appendSplice(spliceOperator, field, pos, len, replace)
+func (ops *Operations) Splice(field, pos, length int, replace string) *Operations {
+	return ops.appendSplice(spliceOperator, field, pos, length, replace)
 }
 
 // Insert adds an insert operation to the collection of update operations.

--- a/crud/tarantool_test.go
+++ b/crud/tarantool_test.go
@@ -471,30 +471,30 @@ func generateObjectsOperationsData(objs []crud.Object,
 	return objectsOperationsData
 }
 
-func getCrudError(req tarantool.Request, crudError any) (any, error) {
+func getCrudError(req tarantool.Request, crudError any) error {
 	var err []any
 	var ok bool
 
 	rtype := req.Type()
 	if crudError != nil {
 		if rtype == iproto.IPROTO_CALL {
-			return crudError, nil
+			return fmt.Errorf("CRUD error: %v", crudError)
 		}
 
 		if err, ok = crudError.([]any); !ok {
-			return nil, fmt.Errorf("Incorrect CRUD error format")
+			return fmt.Errorf("incorrect CRUD error format")
 		}
 
 		if len(err) < 1 {
-			return nil, fmt.Errorf("Incorrect CRUD error format")
+			return fmt.Errorf("incorrect CRUD error format")
 		}
 
 		if err[0] != nil {
-			return err[0], nil
+			return fmt.Errorf("CRUD error: %v", err[0])
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func testCrudRequestPrepareData(t *testing.T, conn tarantool.Connector) {
@@ -532,9 +532,8 @@ func testCrudRequestCheck(t *testing.T, req tarantool.Request,
 	// resp.Data[0] - CRUD res.
 	// resp.Data[1] - CRUD err.
 	if expectedLen >= 2 && data[1] != nil {
-		crudErr, getErr := getCrudError(req, data[1])
-		require.NoError(t, getErr, "Failed to get CRUD error")
-		require.Nil(t, crudErr, "Failed to perform CRUD request on CRUD side")
+		crudErr := getCrudError(req, data[1])
+		require.NoError(t, crudErr, "Failed to perform CRUD request on CRUD side")
 	}
 }
 

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -9,6 +9,7 @@
 package queue
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 
 	"github.com/tarantool/go-tarantool/v3"
 )
+
+var ErrEmptyStatistic = errors.New("empty statistic response")
 
 // Queue is a handle to Tarantool queue's tube.
 type Queue interface {
@@ -439,7 +442,7 @@ func (q *queue) Statistic() (any, error) {
 		return data[0], nil
 	}
 
-	return nil, nil
+	return nil, ErrEmptyStatistic
 }
 
 func makeCmd(q *queue) {


### PR DESCRIPTION
The codebase had patterns flagged by disabled linters: tests missing `t.Parallel()` at the top level, a parameter shadowing the predeclared identifier `len`, and functions returning both a nil value and a nil error.

Enable these linters and fix the reported issues to prevent regressions and improve code quality.