### PR TITLE
connection: fix data race in context watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* A data race that could cause "unlock of unlocked mutex" panics when
+  a request's context was cancelled concurrently with response arrival and
+  future release.
+
 ## [v3.0.0] - 2026-06-08
 
 v3 redesigns the connector for a simpler, more idiomatic Go experience.

--- a/connection.go
+++ b/connection.go
@@ -1003,20 +1003,27 @@ func (conn *Connection) newFuture(req Request) *future {
 	return fut
 }
 
-// This method removes a future from the internal queue if the context
-// is "done" before the response is come.
-func (conn *Connection) contextWatchdog(fut *future, ctx context.Context) {
-	select {
-	case <-fut.WaitChan():
-	case <-ctx.Done():
-	}
+func (conn *Connection) startContextWatchdog(ctx context.Context, fut *future) {
+	// We need to save it before start a gorouitine to avoid use released
+	// future object.
+	waitChan := fut.WaitChan()
+	reqId := fut.requestId
 
+	go conn.contextWatchdog(ctx, waitChan, reqId)
+}
+
+// contextWatchdog removes a future from the internal queue if the context
+// is "done" before the response is come.
+func (conn *Connection) contextWatchdog(ctx context.Context, ch <-chan struct{}, reqId uint32) {
 	select {
-	case <-fut.WaitChan():
+	case <-ch:
 		return
-	default:
-		conn.cancelFuture(fut, fmt.Errorf("context is done (request ID %d): %w",
-			fut.requestId, context.Cause(ctx)))
+	case <-ctx.Done():
+		if fut := conn.fetchFuture(reqId); fut != nil {
+			err := fmt.Errorf("context is done (request ID %d): %w", reqId, context.Cause(ctx))
+			fut.setError(err)
+			conn.markDone()
+		}
 	}
 }
 
@@ -1047,7 +1054,7 @@ func (conn *Connection) send(req Request, streamId uint64) *future {
 			return fut
 		default:
 		}
-		go conn.contextWatchdog(fut, req.Ctx())
+		conn.startContextWatchdog(req.Ctx(), fut)
 	}
 	conn.putFuture(fut, req, streamId)
 

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -3609,6 +3609,43 @@ func TestConnectionNilAllocatorNeverCallsPut(t *testing.T) {
 	assert.Zero(t, mockAlloc.putCallCount())
 }
 
+// TestDoContextCancelConcurrency verifies that there is no data race
+// when a request's context is cancelled concurrently with response
+// arrival and future release.
+func TestDoContextCancelConcurrency(t *testing.T) {
+	var err error
+
+	topts := opts
+	topts.Allocator, err = tarantool.NewPoolAllocator([]int{5, 8, 10})
+	require.NoError(t, err)
+
+	conn := test_helpers.ConnectWithValidation(t, dialer, topts)
+	defer func() { _ = conn.Close() }()
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const iterations = 200
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				ctx, cancel := context.WithCancel(context.Background())
+				fut := conn.Do(NewPingRequest().Context(ctx))
+				cancel()
+
+				_, err := fut.Get()
+				if err != nil {
+					assert.ErrorIs(t, err, context.Canceled)
+				}
+				fut.Release()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func runTestMain(m *testing.M) int {
 	// Tarantool supports streams and interactive transactions since version 2.10.0
 	isStreamUnsupported, err := test_helpers.IsTarantoolVersionLess(2, 10, 0)


### PR DESCRIPTION
The context watchdog accessed the future object directly, which could be released concurrently when the response arrived. This caused a data race that manifested as "unlock of unlocked mutex" panics under concurrent context cancellation.

The watchdog now captures the wait channel and request ID before starting the goroutine, and uses fetchFuture to safely access the future only if it still exists in the connection's internal queue.

Follows #595

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)