### PR TITLE
connection: fix race on future release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 * A data race that could cause "unlock of unlocked mutex" panics when
   a request's context was cancelled concurrently with response arrival and
   future release.
+* A data race when `Future.Release()` was called right after
+  `Future.WaitChan()` closed, which could cause "unlock of unlocked mutex"
+  panics.
 
 ## [v3.0.0] - 2026-06-08
 

--- a/future.go
+++ b/future.go
@@ -44,19 +44,6 @@ func (fut *future) wait() {
 	}
 }
 
-func (fut *future) finish() {
-	fut.mutex.Lock()
-	defer fut.mutex.Unlock()
-
-	fut.finished = true
-
-	if fut.done != nil {
-		close(fut.done)
-	}
-
-	fut.cond.Broadcast()
-}
-
 // NewFutureWithErr returns Future with given error.
 func NewFutureWithErr(req Request, err error) Future {
 	fut := newFuture(req)
@@ -90,28 +77,47 @@ func (fut *future) isFinished() bool {
 	return fut.finished
 }
 
+// finalize is a common code across finish methods.
+func (fut *future) finalize() {
+	fut.finished = true
+
+	done := fut.done
+
+	fut.cond.Broadcast()
+
+	fut.mutex.Unlock()
+
+	if done != nil {
+		close(done)
+	}
+}
+
+func (fut *future) finish() {
+	fut.mutex.Lock()
+
+	fut.finalize()
+}
+
 // setResponse sets a response for the future and finishes the future.
 func (fut *future) setResponse(header Header, body io.Reader) error {
 	fut.mutex.Lock()
-	defer fut.mutex.Unlock()
 
 	if fut.finished {
+		fut.mutex.Unlock()
+
 		return nil
 	}
 
 	resp, err := fut.req.Response(header, body)
 	if err != nil {
+		fut.mutex.Unlock()
+
 		return err
 	}
+
 	fut.resp = resp
 
-	fut.finished = true
-
-	if fut.done != nil {
-		close(fut.done)
-	}
-
-	fut.cond.Broadcast()
+	fut.finalize()
 
 	return nil
 }
@@ -119,20 +125,16 @@ func (fut *future) setResponse(header Header, body io.Reader) error {
 // setError sets an error for the future and finishes the future.
 func (fut *future) setError(err error) {
 	fut.mutex.Lock()
-	defer fut.mutex.Unlock()
 
 	if fut.finished {
+		fut.mutex.Unlock()
+
 		return
 	}
+
 	fut.err = err
 
-	fut.finished = true
-
-	if fut.done != nil {
-		close(fut.done)
-	}
-
-	fut.cond.Broadcast()
+	fut.finalize()
 }
 
 // GetResponse waits for Future to be filled and returns Response and error.

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -3646,6 +3646,25 @@ func TestDoContextCancelConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
+func TestDoWaitChanReleaseConcurrency(t *testing.T) {
+	conn := test_helpers.ConnectWithValidation(t, dialer, opts)
+	defer func() { _ = conn.Close() }()
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 200 {
+				fut := conn.Do(NewPingRequest())
+				<-fut.WaitChan()
+				fut.Release()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func runTestMain(m *testing.M) int {
 	// Tarantool supports streams and interactive transactions since version 2.10.0
 	isStreamUnsupported, err := test_helpers.IsTarantoolVersionLess(2, 10, 0)


### PR DESCRIPTION
The wait channel was closed while the future's mutex was still held, so a caller woken by WaitChan() could call Release() and zero the future before the internal goroutine finished unlocking the mutex. This caused "unlock of unlocked mutex" panics under concurrent load.

Follows #595

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Follows #595 