### PR TITLE
connection: fix future release race on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 ### Fixed
 
+* Lost or stuck requests, and occasional panics, after a connection drop
+  (server restart, network blip) while requests were in-flight and the
+  documented `Do` → `Get` → `Release` lifecycle was used (#600).
+
 ## [v3.0.1] - 2026-08-19
 
 This patch release fixes two data races in the connection's `Future` handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Versioning](http://semver.org/spec/v2.0.0.html) except to the first release.
 
 * Lost or stuck requests, and occasional panics, after a connection drop
   (server restart, network blip) while requests were in-flight and the
-  documented `Do` → `Get` → `Release` lifecycle was used (#600).
+  documented `Do` → `Get` → `Release` lifecycle was used (#601).
+* A data race on `Connection.Addr()` that could be triggered when the
+  connection was reconnecting in the background (e.g. after a server
+  restart or a transient network failure) while the user code was
+  concurrently calling `Addr()` to log or inspect the endpoint (#602).
 
 ## [v3.0.1] - 2026-08-19
 

--- a/connection.go
+++ b/connection.go
@@ -196,9 +196,11 @@ func (list *futureList) clear(err error, conn *Connection) {
 	list.first = nil
 	list.last = &list.first
 	for fut != nil {
+		next := fut.next
+		fut.next = nil
 		fut.setError(err)
 		conn.markDone()
-		fut, fut.next = fut.next, nil
+		fut = next
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -397,14 +397,22 @@ func (conn *Connection) CloseGraceful() error {
 
 // Addr returns a configured address of Tarantool socket.
 func (conn *Connection) Addr() net.Addr {
+	conn.mutex.Lock()
+	defer conn.mutex.Unlock()
 	return conn.addr
 }
 
-func (conn *Connection) addrString() string {
-	if a := conn.Addr(); a != nil {
+func (conn *Connection) addrStringLocked() string {
+	if a := conn.addr; a != nil {
 		return a.String()
 	}
 	return ""
+}
+
+func (conn *Connection) addrString() string {
+	conn.mutex.Lock()
+	defer conn.mutex.Unlock()
+	return conn.addrStringLocked()
 }
 
 // Handle returns a user-specified handle from Opts.
@@ -644,7 +652,7 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 			slog.Uint64(LogKeyAttempt, uint64(reconnects)),
 			slog.Uint64(LogKeyMaxAttempts, uint64(conn.opts.MaxReconnects)),
 			slog.Any(LogKeyError, err),
-			slog.String(LogKeyAddress, conn.addrString()),
+			slog.String(LogKeyAddress, conn.addrStringLocked()),
 		)
 		conn.notify(ReconnectFailed)
 		reconnects++
@@ -662,7 +670,7 @@ func (conn *Connection) runReconnects(ctx context.Context) error {
 
 	conn.logger.Warn(LogMsgLastReconnectFailed,
 		slog.Any(LogKeyError, err),
-		slog.String(LogKeyAddress, conn.addrString()),
+		slog.String(LogKeyAddress, conn.addrStringLocked()),
 	)
 	// mark connection as closed to avoid reopening by another goroutine
 	return newClientError(CodeConnectionClosed, "last reconnect failed", nil)

--- a/dial_test.go
+++ b/dial_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -234,6 +235,67 @@ func TestConn_Addr(t *testing.T) {
 
 	assert.Equal(t, addr, conn.Addr().String())
 	assert.Equal(t, 1, dialer.conn.addrCnt)
+}
+
+// TestConn_Addr_race_on_reconnect verifies that Connection.Addr() is safe to
+// call concurrently with background reconnects. Before the fix, Addr()
+// read conn.addr without synchronization while dial() wrote it during
+// reconnects, causing a data race detectable only with the -race flag.
+func TestConn_Addr_race_on_reconnect(t *testing.T) {
+	var dialCount atomic.Uint32
+	dialer := mockIoDialer{
+		init: func(conn *mockIoConn) {
+			n := dialCount.Add(1)
+			addr := "addr1"
+			if n%2 == 0 {
+				addr = "addr2"
+			}
+			conn.addr = stubAddr{str: addr}
+			// Skip waitgroup blocking so Read() returns io.EOF immediately,
+			// triggering a reconnect on every new connection.
+			conn.readWgDelay = 100000
+			conn.writeWgDelay = 100000
+			conn.wgDoneOnClose = false
+		},
+	}
+
+	conn, err := tarantool.Connect(t.Context(), &dialer, tarantool.Opts{
+		Timeout:       1000 * time.Second,
+		Reconnect:     1 * time.Millisecond,
+		MaxReconnects: 0, // Infinite.
+		SkipSchema:    true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer func() { _ = conn.Close() }()
+
+	// Concurrently call Addr() while reconnects write conn.addr in the
+	// background.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = conn.Addr()
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	close(stop)
+	wg.Wait()
+	_ = conn.Close()
+
+	assert.Greater(t, dialCount.Load(), uint32(1),
+		"expected at least one reconnect to trigger dial()")
+	s := conn.Addr().String()
+	assert.Contains(t, []string{"addr1", "addr2"}, s)
 }
 
 func TestConn_Greeting(t *testing.T) {

--- a/tarantool_test.go
+++ b/tarantool_test.go
@@ -3665,6 +3665,75 @@ func TestDoWaitChanReleaseConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
+// TestFutureReleaseRaceOnReconnect verifies that there is no data race
+// between Future.Release() and future clean when the server is
+// restarted while requests are in-flight and the caller uses the
+// documented Future lifecycle: Do -> Get -> Release.
+func TestFutureReleaseRaceOnReconnect(t *testing.T) {
+	const server = "127.0.0.1:3016"
+
+	testDialer := dialer
+	testDialer.Address = server
+
+	inst, err := test_helpers.StartTarantool(test_helpers.StartOpts{
+		Dialer:       testDialer,
+		InitScript:   "config.lua",
+		Listen:       server,
+		WaitStart:    100 * time.Millisecond,
+		ConnectRetry: 10,
+		RetryTimeout: 50 * time.Millisecond,
+	})
+	require.NoErrorf(t, err, "Unable to start Tarantool")
+	defer test_helpers.StopTarantoolWithCleanup(inst)
+
+	reconnectOpts := opts
+	reconnectOpts.Reconnect = 50 * time.Millisecond
+	reconnectOpts.MaxReconnects = 0
+
+	conn := test_helpers.ConnectWithValidation(t, testDialer, reconnectOpts)
+	defer func() { _ = conn.Close() }()
+
+	const workers = 64
+	slowEval := "local fiber = require('fiber'); fiber.sleep(0.02); return 1"
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				fut := conn.Do(NewEvalRequest(slowEval))
+				_, _ = fut.Get()
+				fut.Release()
+			}
+		}()
+	}
+
+	// Restart the server several times while requests are in-flight so
+	// that the client's reader goroutine runs futures clear over
+	// pending futures concurrently with Future.Release().
+	const restarts = 5
+	for range restarts {
+		time.Sleep(100 * time.Millisecond)
+		test_helpers.StopTarantool(inst)
+		require.NoErrorf(t, test_helpers.RestartTarantool(inst),
+			"Unable to restart Tarantool")
+		require.True(t,
+			test_helpers.WaitUntilReconnected(conn, 100, 50*time.Millisecond),
+			"Reconnect failed")
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	close(stop)
+	wg.Wait()
+}
+
 func runTestMain(m *testing.M) int {
 	// Tarantool supports streams and interactive transactions since version 2.10.0
 	isStreamUnsupported, err := test_helpers.IsTarantoolVersionLess(2, 10, 0)


### PR DESCRIPTION
Reconnecting while requests were in-flight could leave callers blocked forever or cause panics in the documented Do -> Get -> Release lifecycle. The internal cleanup of pending futures on reconnect wrote a future's list link after setError() had already unblocked the caller, racing with Release() zeroing the same object and returning it to the pool for reuse by a new Do(). The late write could drop the new request from the connection's tracking list, so its response was never matched back.

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Tests (see [documentation](https://pkg.go.dev/testing) for a testing package)
- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:

Closes #600
